### PR TITLE
[error]: add error kind for account service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6411,6 +6411,7 @@ dependencies = [
  "starcoin-logger",
  "starcoin-types",
  "stest",
+ "thiserror",
 ]
 
 [[package]]

--- a/rpc/server/src/module/account_rpc.rs
+++ b/rpc/server/src/module/account_rpc.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::module::map_err;
+use crate::module::map_rpc_err;
 use futures::future::TryFutureExt;
 use starcoin_rpc_api::{account::AccountApi, FutureResult};
 use starcoin_types::account_address::AccountAddress;
@@ -33,22 +33,34 @@ where
             .service
             .clone()
             .create_account(password)
-            .map_err(map_err);
+            .map_err(|e| map_rpc_err(e.into()));
         Box::new(fut.compat())
     }
 
     fn list(&self) -> FutureResult<Vec<WalletAccount>> {
-        let fut = self.service.clone().get_accounts().map_err(map_err);
+        let fut = self
+            .service
+            .clone()
+            .get_accounts()
+            .map_err(|e| map_rpc_err(e.into()));
         Box::new(fut.compat())
     }
 
     fn get(&self, address: AccountAddress) -> FutureResult<Option<WalletAccount>> {
-        let fut = self.service.clone().get_account(address).map_err(map_err);
+        let fut = self
+            .service
+            .clone()
+            .get_account(address)
+            .map_err(|e| map_rpc_err(e.into()));
         Box::new(fut.compat())
     }
 
     fn sign_txn(&self, raw_txn: RawUserTransaction) -> FutureResult<SignedUserTransaction> {
-        let fut = self.service.clone().sign_txn(raw_txn).map_err(map_err);
+        let fut = self
+            .service
+            .clone()
+            .sign_txn(raw_txn)
+            .map_err(|e| map_rpc_err(e.into()));
         Box::new(fut.compat())
     }
 
@@ -62,7 +74,7 @@ where
             .service
             .clone()
             .unlock_account(address, password, duration)
-            .map_err(map_err);
+            .map_err(|e| map_rpc_err(e.into()));
         Box::new(fut.compat())
     }
     /// Import private key with address.
@@ -76,7 +88,7 @@ where
             .service
             .clone()
             .import_account(address, private_key, password)
-            .map_err(map_err);
+            .map_err(|e| map_rpc_err(e.into()));
         Box::new(fut.compat())
     }
 
@@ -86,7 +98,7 @@ where
             .service
             .clone()
             .export_account(address, password)
-            .map_err(map_err);
+            .map_err(|e| map_rpc_err(e.into()));
         Box::new(fut.compat())
     }
 }

--- a/rpc/server/src/module/mod.rs
+++ b/rpc/server/src/module/mod.rs
@@ -12,9 +12,33 @@ pub use self::account_rpc::AccountRpcImpl;
 pub use self::node_rpc::NodeRpcImpl;
 pub use self::state_rpc::StateRpcImpl;
 pub use self::txpool_rpc::TxPoolRpcImpl;
+use starcoin_wallet_api::error::AccountServiceError;
 
 pub fn map_err(err: anyhow::Error) -> jsonrpc_core::Error {
     //TODO error convert.
     error!("rpc return internal_error for: {:?}", err);
     jsonrpc_core::Error::internal_error()
+}
+
+pub fn map_rpc_err(err: RpcError) -> jsonrpc_core::Error {
+    match err {
+        RpcError::InternalError => jsonrpc_core::Error::internal_error(),
+        RpcError::InvalidRequest(message) => jsonrpc_core::Error::invalid_params(message),
+    }
+}
+
+#[derive(Debug)]
+pub enum RpcError {
+    InternalError,
+    InvalidRequest(String),
+}
+
+impl From<AccountServiceError> for RpcError {
+    fn from(err: AccountServiceError) -> Self {
+        match err {
+            AccountServiceError::AccountError(_) => RpcError::InternalError,
+            AccountServiceError::OtherError(_) => RpcError::InternalError,
+            e @ _ => RpcError::InvalidRequest(format!("{}", e)),
+        }
+    }
 }

--- a/wallet/api/Cargo.toml
+++ b/wallet/api/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
+thiserror = "1.0"
 async-trait = "0.1"
 serde = { version = "1.0", default-features = false }
 starcoin-logger = {path = "../../commons/logger"}

--- a/wallet/api/src/error.rs
+++ b/wallet/api/src/error.rs
@@ -1,0 +1,76 @@
+use anyhow::format_err;
+use starcoin_types::account_address::AccountAddress;
+use thiserror::Error;
+#[derive(Error, Debug)]
+pub enum AccountServiceError {
+    // param error
+    #[error("account with address {0} not exists")]
+    AccountNotExist(AccountAddress),
+    #[error("account with address {0} already exists")]
+    AccountAlreadyExist(AccountAddress),
+    #[error("account {0} is locked")]
+    AccountLocked(AccountAddress),
+    #[error("cannot remove default account {0}")]
+    RemoveDefaultAccountError(AccountAddress),
+    #[error("invalid password, cannot decrypt account {0}")]
+    InvalidPassword(AccountAddress),
+    #[error("invalid private key")]
+    InvalidPrivateKey,
+
+    // service error
+    #[error("account error, {0:?}")]
+    AccountError(anyhow::Error),
+    #[error("other error: {0:?}")]
+    OtherError(Box<dyn std::error::Error + Send + Sync + 'static>),
+}
+
+impl From<WalletError> for AccountServiceError {
+    fn from(err: WalletError) -> Self {
+        match err {
+            WalletError::AccountNotExist(a) => AccountServiceError::AccountNotExist(a),
+            WalletError::AccountAlreadyExist(a) => AccountServiceError::AccountAlreadyExist(a),
+            WalletError::AccountLocked(a) => AccountServiceError::AccountLocked(a),
+            WalletError::RemoveDefaultAccountError(a) => {
+                AccountServiceError::RemoveDefaultAccountError(a)
+            }
+            WalletError::InvalidPassword(a) => AccountServiceError::InvalidPassword(a),
+            WalletError::InvalidPrivateKey => AccountServiceError::InvalidPrivateKey,
+
+            WalletError::TransactionSignError(e) => AccountServiceError::AccountError(e),
+            WalletError::DecryptPrivateKeyError(e) => AccountServiceError::AccountError(e),
+            WalletError::AccountPrivateKeyMissing(a) => AccountServiceError::AccountError(
+                format_err!("no private key data associate with address {}", a),
+            ),
+            WalletError::StoreError(e) => AccountServiceError::AccountError(e),
+        }
+    }
+}
+
+/// wallet error is used in wallet impl, to decouple from service.
+#[derive(Error, Debug)]
+pub enum WalletError {
+    // param error
+    #[error("account with address {0} not exists")]
+    AccountNotExist(AccountAddress),
+    #[error("account with address {0} already exists")]
+    AccountAlreadyExist(AccountAddress),
+    #[error("account {0} is locked")]
+    AccountLocked(AccountAddress),
+    #[error("cannot remove default account {0}")]
+    RemoveDefaultAccountError(AccountAddress),
+
+    #[error("invalid password, cannot decrypt account {0}")]
+    InvalidPassword(AccountAddress),
+    #[error("invalid private key")]
+    InvalidPrivateKey,
+
+    // logic error
+    #[error("transaction sign error, {0:?}")]
+    TransactionSignError(anyhow::Error),
+    #[error("decrypt private key error, {0:?}")]
+    DecryptPrivateKeyError(anyhow::Error),
+    #[error("no private key data associate with address {0}")]
+    AccountPrivateKeyMissing(AccountAddress),
+    #[error("account vault store error, {0:?}")]
+    StoreError(#[from] anyhow::Error),
+}

--- a/wallet/api/src/error.rs
+++ b/wallet/api/src/error.rs
@@ -37,7 +37,7 @@ impl From<WalletError> for AccountServiceError {
             WalletError::InvalidPrivateKey => AccountServiceError::InvalidPrivateKey,
 
             WalletError::TransactionSignError(e) => AccountServiceError::AccountError(e),
-            WalletError::DecryptPrivateKeyError(e) => AccountServiceError::AccountError(e),
+            // WalletError::DecryptPrivateKeyError(e) => AccountServiceError::AccountError(e),
             WalletError::AccountPrivateKeyMissing(a) => AccountServiceError::AccountError(
                 format_err!("no private key data associate with address {}", a),
             ),
@@ -67,8 +67,8 @@ pub enum WalletError {
     // logic error
     #[error("transaction sign error, {0:?}")]
     TransactionSignError(anyhow::Error),
-    #[error("decrypt private key error, {0:?}")]
-    DecryptPrivateKeyError(anyhow::Error),
+    // #[error("decrypt private key error, {0:?}")]
+    // DecryptPrivateKeyError(anyhow::Error),
     #[error("no private key data associate with address {0}")]
     AccountPrivateKeyMissing(AccountAddress),
     #[error("account vault store error, {0:?}")]

--- a/wallet/api/src/lib.rs
+++ b/wallet/api/src/lib.rs
@@ -1,138 +1,16 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
-use rand::prelude::*;
-use serde::{Deserialize, Serialize};
-use starcoin_crypto::ed25519::Ed25519PublicKey;
-use starcoin_crypto::{test_utils::KeyPair, Uniform};
-use starcoin_types::account_address::{AccountAddress, AuthenticationKey};
-use starcoin_types::transaction::{RawUserTransaction, SignedUserTransaction};
-use std::time::Duration;
+pub mod error;
+mod service;
+mod store;
+mod types;
+mod wallet;
+
+pub use service::*;
+pub use store::*;
+pub use types::*;
+pub use wallet::*;
 
 #[cfg(any(test, feature = "mock"))]
 pub mod mock;
-
-#[derive(Clone, Debug, Hash, Serialize, Deserialize)]
-pub struct WalletAccount {
-    //TODO should contains a unique local name?
-    //name: String,
-    pub address: AccountAddress,
-    /// This account is default at current wallet.
-    /// Every wallet must has one default account.
-    pub is_default: bool,
-    pub public_key: Ed25519PublicKey,
-}
-
-impl WalletAccount {
-    pub fn new(address: AccountAddress, public_key: Ed25519PublicKey, is_default: bool) -> Self {
-        Self {
-            address,
-            public_key,
-            is_default,
-        }
-    }
-
-    pub fn get_auth_key(&self) -> AuthenticationKey {
-        AuthenticationKey::from_public_key(&self.public_key)
-    }
-
-    pub fn address(&self) -> &AccountAddress {
-        &self.address
-    }
-
-    pub fn random() -> Self {
-        let mut seed_rng = rand::rngs::OsRng::new().expect("can't access OsRng");
-        let seed_buf: [u8; 32] = seed_rng.gen();
-        let mut rng: StdRng = SeedableRng::from_seed(seed_buf);
-        let key_pair = KeyPair::generate_for_testing(&mut rng);
-        let address = AccountAddress::from_public_key(&key_pair.public_key);
-        WalletAccount {
-            address,
-            is_default: false,
-            public_key: key_pair.public_key,
-        }
-    }
-}
-
-pub trait Wallet {
-    fn create_account(&self, password: &str) -> Result<WalletAccount>;
-
-    fn get_account(&self, address: &AccountAddress) -> Result<Option<WalletAccount>>;
-
-    fn import_account(
-        &self,
-        address: AccountAddress,
-        private_key: Vec<u8>,
-        password: &str,
-    ) -> Result<WalletAccount>;
-
-    /// Return the private key as bytes for `address`
-    fn export_account(&self, address: &AccountAddress, password: &str) -> Result<Vec<u8>>;
-
-    fn contains(&self, address: &AccountAddress) -> Result<bool>;
-
-    fn unlock_account(
-        &self,
-        address: AccountAddress,
-        password: &str,
-        duration: Duration,
-    ) -> Result<()>;
-
-    fn lock_account(&self, address: AccountAddress) -> Result<()>;
-
-    /// Sign transaction by txn sender's Account.
-    /// If the wallet is protected by password, should unlock the sender's account first.
-    fn sign_txn(&self, raw_txn: RawUserTransaction) -> Result<SignedUserTransaction>;
-
-    /// Return the default account
-    fn get_default_account(&self) -> Result<Option<WalletAccount>>;
-
-    fn get_accounts(&self) -> Result<Vec<WalletAccount>>;
-
-    /// Set the address's Account to default account, and unset the origin default account.
-    fn set_default(&self, address: &AccountAddress) -> Result<()>;
-
-    /// Remove account by address.
-    /// Wallet must ensure that the default account can not bean removed.
-    fn remove_account(&self, address: &AccountAddress) -> Result<()>;
-}
-
-pub trait WalletStore {
-    fn get_account(&self, address: &AccountAddress) -> Result<Option<WalletAccount>>;
-    fn save_account(&self, account: WalletAccount) -> Result<()>;
-    fn remove_account(&self, address: &AccountAddress) -> Result<()>;
-    fn get_accounts(&self) -> Result<Vec<WalletAccount>>;
-    fn save_to_account(&self, address: &AccountAddress, key: String, value: Vec<u8>) -> Result<()>;
-    fn get_from_account(&self, address: &AccountAddress, key: &str) -> Result<Option<Vec<u8>>>;
-}
-
-pub trait WalletService: Wallet {}
-
-#[async_trait::async_trait]
-pub trait WalletAsyncService: Clone + std::marker::Unpin + Send + Sync {
-    async fn create_account(self, password: String) -> Result<WalletAccount>;
-
-    async fn get_default_account(self) -> Result<Option<WalletAccount>>;
-
-    async fn get_accounts(self) -> Result<Vec<WalletAccount>>;
-
-    async fn get_account(self, address: AccountAddress) -> Result<Option<WalletAccount>>;
-
-    async fn sign_txn(self, raw_txn: RawUserTransaction) -> Result<SignedUserTransaction>;
-    async fn unlock_account(
-        self,
-        address: AccountAddress,
-        password: String,
-        duration: std::time::Duration,
-    ) -> Result<()>;
-    async fn import_account(
-        self,
-        address: AccountAddress,
-        private_key: Vec<u8>,
-        password: String,
-    ) -> Result<WalletAccount>;
-
-    /// Return the private key as bytes for `address`
-    async fn export_account(self, address: AccountAddress, password: String) -> Result<Vec<u8>>;
-}

--- a/wallet/api/src/mock/keypair_wallet.rs
+++ b/wallet/api/src/mock/keypair_wallet.rs
@@ -1,9 +1,10 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::error::WalletError;
 use crate::mock::MemWalletStore;
-use crate::{Wallet, WalletAccount, WalletStore};
-use anyhow::{ensure, format_err, Result};
+use crate::{Wallet, WalletAccount, WalletResult, WalletStore};
+use anyhow::{format_err, Result};
 use rand::prelude::*;
 use starcoin_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 use starcoin_crypto::Uniform;
@@ -43,7 +44,7 @@ where
         Ok(wallet)
     }
 
-    fn save_account(&self, account: WalletAccount, key_pair: KeyPair) -> Result<()> {
+    fn save_account(&self, account: WalletAccount, key_pair: KeyPair) -> WalletResult<()> {
         let address = account.address;
         self.store.save_account(account)?;
         self.store.save_to_account(
@@ -54,17 +55,21 @@ where
         Ok(())
     }
 
-    fn get_key_pair(&self, address: &AccountAddress) -> Result<KeyPair> {
-        self.store
-            .get_from_account(address, KEY_NAME_PRIVATE_KEY)
-            .and_then(|value| {
-                value.ok_or(format_err!(
-                    "Can not find private_key by address: {:?}",
-                    address
-                ))
-            })
-            .and_then(|value| Ok(Ed25519PrivateKey::try_from(value.as_slice())?))
-            .and_then(|private_key| Ok(KeyPair::from(private_key)))
+    fn get_key_pair(&self, address: &AccountAddress) -> WalletResult<KeyPair> {
+        let private_key = self.store.get_from_account(address, KEY_NAME_PRIVATE_KEY)?;
+        if private_key.is_none() {
+            return Err(WalletError::StoreError(format_err!(
+                "canot find private key by address: {}",
+                address
+            )));
+        }
+        let private_key = private_key.unwrap();
+        let private_key = Ed25519PrivateKey::try_from(private_key.as_slice()).map_err(|_| {
+            WalletError::StoreError(format_err!(
+                "cannot decode private key from underline bytes"
+            ))
+        })?;
+        Ok(KeyPair::from(private_key))
     }
 }
 
@@ -74,7 +79,7 @@ impl<S> Wallet for KeyPairWallet<S>
 where
     S: WalletStore,
 {
-    fn create_account(&self, _password: &str) -> Result<WalletAccount> {
+    fn create_account(&self, _password: &str) -> WalletResult<WalletAccount> {
         let mut seed_rng = rand::rngs::OsRng::new().expect("can't access OsRng");
         let seed_buf: [u8; 32] = seed_rng.gen();
         let mut rng: StdRng = SeedableRng::from_seed(seed_buf);
@@ -87,8 +92,8 @@ where
         Ok(account)
     }
 
-    fn get_account(&self, address: &AccountAddress) -> Result<Option<WalletAccount>> {
-        self.store.get_account(address)
+    fn get_account(&self, address: &AccountAddress) -> WalletResult<Option<WalletAccount>> {
+        Ok(self.store.get_account(address)?)
     }
 
     fn import_account(
@@ -96,19 +101,20 @@ where
         address: AccountAddress,
         private_key: Vec<u8>,
         _password: &str,
-    ) -> Result<WalletAccount> {
-        let private_key = Ed25519PrivateKey::try_from(private_key.as_slice())?;
+    ) -> WalletResult<WalletAccount> {
+        let private_key = Ed25519PrivateKey::try_from(private_key.as_slice())
+            .map_err(|_e| WalletError::InvalidPrivateKey)?;
         let key_pair = KeyPair::from(private_key);
         let account = WalletAccount::new(address, key_pair.public_key.clone(), false);
         self.save_account(account.clone(), key_pair)?;
         Ok(account)
     }
-    fn export_account(&self, address: &AccountAddress, _password: &str) -> Result<Vec<u8>> {
+    fn export_account(&self, address: &AccountAddress, _password: &str) -> WalletResult<Vec<u8>> {
         self.get_key_pair(address)
             .map(|kp| kp.private_key.to_bytes().to_vec())
     }
 
-    fn contains(&self, address: &AccountAddress) -> Result<bool> {
+    fn contains(&self, address: &AccountAddress) -> WalletResult<bool> {
         Ok(self.store.get_account(address)?.map(|_| true).is_some())
     }
 
@@ -117,28 +123,28 @@ where
         _address: AccountAddress,
         _password: &str,
         _duration: Duration,
-    ) -> Result<()> {
+    ) -> WalletResult<()> {
         //do nothing
         Ok(())
     }
 
-    fn lock_account(&self, _address: AccountAddress) -> Result<()> {
+    fn lock_account(&self, _address: AccountAddress) -> WalletResult<()> {
         //do nothing
         Ok(())
     }
 
-    fn sign_txn(&self, raw_txn: RawUserTransaction) -> Result<SignedUserTransaction> {
+    fn sign_txn(&self, raw_txn: RawUserTransaction) -> WalletResult<SignedUserTransaction> {
         let address = raw_txn.sender();
-        ensure!(
-            self.contains(&address)?,
-            "Can not find account by address: {:?}",
-            address
-        );
+        if !self.contains(&address)? {
+            return Err(WalletError::AccountNotExist(address.clone()));
+        }
         let key_pair = self.get_key_pair(&address)?;
-        key_pair.sign_txn(raw_txn)
+        key_pair
+            .sign_txn(raw_txn)
+            .map_err(|e| WalletError::TransactionSignError(e))
     }
 
-    fn get_default_account(&self) -> Result<Option<WalletAccount>> {
+    fn get_default_account(&self) -> WalletResult<Option<WalletAccount>> {
         Ok(self
             .store
             .get_accounts()?
@@ -147,15 +153,14 @@ where
             .cloned())
     }
 
-    fn get_accounts(&self) -> Result<Vec<WalletAccount>> {
-        self.store.get_accounts()
+    fn get_accounts(&self) -> WalletResult<Vec<WalletAccount>> {
+        Ok(self.store.get_accounts()?)
     }
 
-    fn set_default(&self, address: &AccountAddress) -> Result<()> {
-        let mut target = self.get_account(address)?.ok_or(format_err!(
-            "Can not find account by address: {:?}",
-            address
-        ))?;
+    fn set_default(&self, address: &AccountAddress) -> WalletResult<()> {
+        let mut target = self
+            .get_account(address)?
+            .ok_or(WalletError::AccountNotExist(address.clone()))?;
 
         let default = self.get_default_account()?;
         if let Some(mut default) = default {
@@ -172,11 +177,13 @@ where
         Ok(())
     }
 
-    fn remove_account(&self, address: &AccountAddress) -> Result<()> {
+    fn remove_account(&self, address: &AccountAddress) -> WalletResult<()> {
         let account = self.get_account(address)?;
         match account {
             Some(account) => {
-                ensure!(!account.is_default, "Can not remove default account.");
+                if account.is_default {
+                    return Err(WalletError::RemoveDefaultAccountError(address.clone()));
+                }
                 self.store.remove_account(address)?;
             }
             None => {}

--- a/wallet/api/src/mock/mock_wallet_service.rs
+++ b/wallet/api/src/mock/mock_wallet_service.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::mock::{KeyPairWallet, MemWalletStore};
-use crate::{Wallet, WalletAccount, WalletAsyncService};
-use anyhow::{Error, Result};
+use crate::{ServiceResult, Wallet, WalletAccount, WalletAsyncService};
+use anyhow::Result;
 use starcoin_types::account_address::AccountAddress;
 use starcoin_types::transaction::{RawUserTransaction, SignedUserTransaction};
 use std::sync::Arc;
@@ -24,24 +24,24 @@ impl MockWalletService {
 
 #[async_trait::async_trait]
 impl WalletAsyncService for MockWalletService {
-    async fn create_account(self, password: String) -> Result<WalletAccount> {
-        self.wallet.create_account(password.as_str())
+    async fn create_account(self, password: String) -> ServiceResult<WalletAccount> {
+        Ok(self.wallet.create_account(password.as_str())?)
     }
 
-    async fn get_default_account(self) -> Result<Option<WalletAccount>> {
-        self.wallet.get_default_account()
+    async fn get_default_account(self) -> ServiceResult<Option<WalletAccount>> {
+        Ok(self.wallet.get_default_account()?)
     }
 
-    async fn get_accounts(self) -> Result<Vec<WalletAccount>> {
-        self.wallet.get_accounts()
+    async fn get_accounts(self) -> ServiceResult<Vec<WalletAccount>> {
+        Ok(self.wallet.get_accounts()?)
     }
 
-    async fn get_account(self, address: AccountAddress) -> Result<Option<WalletAccount>> {
-        self.wallet.get_account(&address)
+    async fn get_account(self, address: AccountAddress) -> ServiceResult<Option<WalletAccount>> {
+        Ok(self.wallet.get_account(&address)?)
     }
 
-    async fn sign_txn(self, raw_txn: RawUserTransaction) -> Result<SignedUserTransaction> {
-        self.wallet.sign_txn(raw_txn)
+    async fn sign_txn(self, raw_txn: RawUserTransaction) -> ServiceResult<SignedUserTransaction> {
+        Ok(self.wallet.sign_txn(raw_txn)?)
     }
 
     async fn unlock_account(
@@ -49,9 +49,10 @@ impl WalletAsyncService for MockWalletService {
         address: AccountAddress,
         password: String,
         duration: Duration,
-    ) -> Result<(), Error> {
-        self.wallet
-            .unlock_account(address, password.as_str(), duration)
+    ) -> ServiceResult<()> {
+        Ok(self
+            .wallet
+            .unlock_account(address, password.as_str(), duration)?)
     }
 
     async fn import_account(
@@ -59,13 +60,18 @@ impl WalletAsyncService for MockWalletService {
         address: AccountAddress,
         private_key: Vec<u8>,
         password: String,
-    ) -> Result<WalletAccount> {
-        self.wallet
-            .import_account(address, private_key, password.as_str())
+    ) -> ServiceResult<WalletAccount> {
+        Ok(self
+            .wallet
+            .import_account(address, private_key, password.as_str())?)
     }
 
     /// Return the private key as bytes for `address`
-    async fn export_account(self, address: AccountAddress, password: String) -> Result<Vec<u8>> {
-        self.wallet.export_account(&address, password.as_str())
+    async fn export_account(
+        self,
+        address: AccountAddress,
+        password: String,
+    ) -> ServiceResult<Vec<u8>> {
+        Ok(self.wallet.export_account(&address, password.as_str())?)
     }
 }

--- a/wallet/api/src/service.rs
+++ b/wallet/api/src/service.rs
@@ -1,0 +1,43 @@
+// Copyright (c) The Starcoin Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::AccountServiceError;
+use crate::{Wallet, WalletAccount};
+use starcoin_types::account_address::AccountAddress;
+use starcoin_types::transaction::{RawUserTransaction, SignedUserTransaction};
+
+pub type ServiceResult<T> = std::result::Result<T, AccountServiceError>;
+
+pub trait WalletService: Wallet {}
+
+#[async_trait::async_trait]
+pub trait WalletAsyncService: Clone + std::marker::Unpin + Send + Sync {
+    async fn create_account(self, password: String) -> ServiceResult<WalletAccount>;
+
+    async fn get_default_account(self) -> ServiceResult<Option<WalletAccount>>;
+
+    async fn get_accounts(self) -> ServiceResult<Vec<WalletAccount>>;
+
+    async fn get_account(self, address: AccountAddress) -> ServiceResult<Option<WalletAccount>>;
+
+    async fn sign_txn(self, raw_txn: RawUserTransaction) -> ServiceResult<SignedUserTransaction>;
+    async fn unlock_account(
+        self,
+        address: AccountAddress,
+        password: String,
+        duration: std::time::Duration,
+    ) -> ServiceResult<()>;
+    async fn import_account(
+        self,
+        address: AccountAddress,
+        private_key: Vec<u8>,
+        password: String,
+    ) -> ServiceResult<WalletAccount>;
+
+    /// Return the private key as bytes for `address`
+    async fn export_account(
+        self,
+        address: AccountAddress,
+        password: String,
+    ) -> ServiceResult<Vec<u8>>;
+}

--- a/wallet/api/src/store.rs
+++ b/wallet/api/src/store.rs
@@ -1,0 +1,15 @@
+// Copyright (c) The Starcoin Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::WalletAccount;
+use anyhow::Result;
+use starcoin_types::account_address::AccountAddress;
+
+pub trait WalletStore {
+    fn get_account(&self, address: &AccountAddress) -> Result<Option<WalletAccount>>;
+    fn save_account(&self, account: WalletAccount) -> Result<()>;
+    fn remove_account(&self, address: &AccountAddress) -> Result<()>;
+    fn get_accounts(&self) -> Result<Vec<WalletAccount>>;
+    fn save_to_account(&self, address: &AccountAddress, key: String, value: Vec<u8>) -> Result<()>;
+    fn get_from_account(&self, address: &AccountAddress, key: &str) -> Result<Option<Vec<u8>>>;
+}

--- a/wallet/api/src/types.rs
+++ b/wallet/api/src/types.rs
@@ -1,0 +1,50 @@
+// Copyright (c) The Starcoin Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use rand::prelude::*;
+use serde::{Deserialize, Serialize};
+use starcoin_crypto::ed25519::Ed25519PublicKey;
+use starcoin_crypto::{test_utils::KeyPair, Uniform};
+use starcoin_types::account_address::{AccountAddress, AuthenticationKey};
+
+#[derive(Clone, Debug, Hash, Serialize, Deserialize)]
+pub struct WalletAccount {
+    //TODO should contains a unique local name?
+    //name: String,
+    pub address: AccountAddress,
+    /// This account is default at current wallet.
+    /// Every wallet must has one default account.
+    pub is_default: bool,
+    pub public_key: Ed25519PublicKey,
+}
+
+impl WalletAccount {
+    pub fn new(address: AccountAddress, public_key: Ed25519PublicKey, is_default: bool) -> Self {
+        Self {
+            address,
+            public_key,
+            is_default,
+        }
+    }
+
+    pub fn get_auth_key(&self) -> AuthenticationKey {
+        AuthenticationKey::from_public_key(&self.public_key)
+    }
+
+    pub fn address(&self) -> &AccountAddress {
+        &self.address
+    }
+
+    pub fn random() -> Self {
+        let mut seed_rng = rand::rngs::OsRng::new().expect("can't access OsRng");
+        let seed_buf: [u8; 32] = seed_rng.gen();
+        let mut rng: StdRng = SeedableRng::from_seed(seed_buf);
+        let key_pair = KeyPair::generate_for_testing(&mut rng);
+        let address = AccountAddress::from_public_key(&key_pair.public_key);
+        WalletAccount {
+            address,
+            is_default: false,
+            public_key: key_pair.public_key,
+        }
+    }
+}

--- a/wallet/api/src/wallet.rs
+++ b/wallet/api/src/wallet.rs
@@ -1,0 +1,53 @@
+// Copyright (c) The Starcoin Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error::WalletError;
+use crate::WalletAccount;
+use starcoin_types::account_address::AccountAddress;
+use starcoin_types::transaction::{RawUserTransaction, SignedUserTransaction};
+use std::time::Duration;
+
+pub type WalletResult<T> = std::result::Result<T, WalletError>;
+
+pub trait Wallet {
+    fn create_account(&self, password: &str) -> WalletResult<WalletAccount>;
+
+    fn get_account(&self, address: &AccountAddress) -> WalletResult<Option<WalletAccount>>;
+
+    fn import_account(
+        &self,
+        address: AccountAddress,
+        private_key: Vec<u8>,
+        password: &str,
+    ) -> WalletResult<WalletAccount>;
+
+    /// Return the private key as bytes for `address`
+    fn export_account(&self, address: &AccountAddress, password: &str) -> WalletResult<Vec<u8>>;
+
+    fn contains(&self, address: &AccountAddress) -> WalletResult<bool>;
+
+    fn unlock_account(
+        &self,
+        address: AccountAddress,
+        password: &str,
+        duration: Duration,
+    ) -> WalletResult<()>;
+
+    fn lock_account(&self, address: AccountAddress) -> WalletResult<()>;
+
+    /// Sign transaction by txn sender's Account.
+    /// If the wallet is protected by password, should unlock the sender's account first.
+    fn sign_txn(&self, raw_txn: RawUserTransaction) -> WalletResult<SignedUserTransaction>;
+
+    /// Return the default account
+    fn get_default_account(&self) -> WalletResult<Option<WalletAccount>>;
+
+    fn get_accounts(&self) -> WalletResult<Vec<WalletAccount>>;
+
+    /// Set the address's Account to default account, and unset the origin default account.
+    fn set_default(&self, address: &AccountAddress) -> WalletResult<()>;
+
+    /// Remove account by address.
+    /// Wallet must ensure that the default account can not bean removed.
+    fn remove_account(&self, address: &AccountAddress) -> WalletResult<()>;
+}

--- a/wallet/lib/src/keystore_wallet.rs
+++ b/wallet/lib/src/keystore_wallet.rs
@@ -257,7 +257,7 @@ where
 
         let key_data = key_data.unwrap();
         let plain_key_data = decrypt(password.as_bytes(), &key_data)
-            .map_err(|e| WalletError::DecryptPrivateKeyError(e))?;
+            .map_err(|_e| WalletError::InvalidPassword(address.clone()))?;
         let private_key = Ed25519PrivateKey::try_from(plain_key_data.as_slice()).map_err(|_e| {
             WalletError::StoreError(format_err!("underline vault store corrupted"))
         })?;

--- a/wallet/service/src/message.rs
+++ b/wallet/service/src/message.rs
@@ -3,10 +3,9 @@
 
 use actix::clock::Duration;
 use actix::Message;
-use anyhow::Result;
 use starcoin_types::account_address::AccountAddress;
 use starcoin_types::transaction::{RawUserTransaction, SignedUserTransaction};
-use starcoin_wallet_api::WalletAccount;
+use starcoin_wallet_api::{WalletAccount, WalletResult};
 
 #[derive(Debug, Clone)]
 pub enum WalletRequest {
@@ -28,7 +27,7 @@ pub enum WalletRequest {
 }
 
 impl Message for WalletRequest {
-    type Result = Result<WalletResponse>;
+    type Result = WalletResult<WalletResponse>;
 }
 
 #[derive(Debug, Clone)]

--- a/wallet/service/src/service.rs
+++ b/wallet/service/src/service.rs
@@ -1,11 +1,10 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use actix::clock::Duration;
-use anyhow::Result;
 use starcoin_types::account_address::AccountAddress;
 use starcoin_types::transaction::{RawUserTransaction, SignedUserTransaction};
-use starcoin_wallet_api::{Wallet, WalletAccount, WalletService};
+use starcoin_wallet_api::{Wallet, WalletAccount, WalletResult, WalletService};
+use std::time::Duration;
 
 pub struct WalletServiceImpl<W>
 where
@@ -30,11 +29,11 @@ impl<W> Wallet for WalletServiceImpl<W>
 where
     W: Wallet,
 {
-    fn create_account(&self, password: &str) -> Result<WalletAccount> {
+    fn create_account(&self, password: &str) -> WalletResult<WalletAccount> {
         self.wallet.create_account(password)
     }
 
-    fn get_account(&self, address: &AccountAddress) -> Result<Option<WalletAccount>> {
+    fn get_account(&self, address: &AccountAddress) -> WalletResult<Option<WalletAccount>> {
         self.wallet.get_account(address)
     }
 
@@ -43,15 +42,15 @@ where
         address: AccountAddress,
         private_key: Vec<u8>,
         password: &str,
-    ) -> Result<WalletAccount> {
+    ) -> WalletResult<WalletAccount> {
         self.wallet.import_account(address, private_key, password)
     }
 
-    fn export_account(&self, address: &AccountAddress, password: &str) -> Result<Vec<u8>> {
+    fn export_account(&self, address: &AccountAddress, password: &str) -> WalletResult<Vec<u8>> {
         self.wallet.export_account(address, password)
     }
 
-    fn contains(&self, address: &AccountAddress) -> Result<bool> {
+    fn contains(&self, address: &AccountAddress) -> WalletResult<bool> {
         self.wallet.contains(address)
     }
 
@@ -60,31 +59,31 @@ where
         address: AccountAddress,
         password: &str,
         duration: Duration,
-    ) -> Result<()> {
+    ) -> WalletResult<()> {
         self.wallet.unlock_account(address, password, duration)
     }
 
-    fn lock_account(&self, address: AccountAddress) -> Result<()> {
+    fn lock_account(&self, address: AccountAddress) -> WalletResult<()> {
         self.wallet.lock_account(address)
     }
 
-    fn sign_txn(&self, raw_txn: RawUserTransaction) -> Result<SignedUserTransaction> {
+    fn sign_txn(&self, raw_txn: RawUserTransaction) -> WalletResult<SignedUserTransaction> {
         self.wallet.sign_txn(raw_txn)
     }
 
-    fn get_default_account(&self) -> Result<Option<WalletAccount>> {
+    fn get_default_account(&self) -> WalletResult<Option<WalletAccount>> {
         self.wallet.get_default_account()
     }
 
-    fn get_accounts(&self) -> Result<Vec<WalletAccount>> {
+    fn get_accounts(&self) -> WalletResult<Vec<WalletAccount>> {
         self.wallet.get_accounts()
     }
 
-    fn set_default(&self, address: &AccountAddress) -> Result<()> {
+    fn set_default(&self, address: &AccountAddress) -> WalletResult<()> {
         self.wallet.set_default(address)
     }
 
-    fn remove_account(&self, address: &AccountAddress) -> Result<()> {
+    fn remove_account(&self, address: &AccountAddress) -> WalletResult<()> {
         self.wallet.remove_account(address)
     }
 }


### PR DESCRIPTION
desgin and specific error for wallet account service.
Basically, They're WalletError, AccountServiceError.

WalletError is the most detailed one.
ServiceError make use these error kinds to display module level error.
For users, there is a RpcError to display api level error.