### PR TITLE
[rpc]: add chain watcher in client module

### DIFF
--- a/docs/deploy_move_contract.md
+++ b/docs/deploy_move_contract.md
@@ -12,10 +12,12 @@ Then, let contracting!
 
 
 ```move
+script {
 use 0x0::LibraAccount;
 
 fun main<Token>(payee: address, auth_key_prefix: vector<u8>, amount: u64) {
     LibraAccount::pay_from_sender<Token>(payee, auth_key_prefix, amount)
+}
 }
 ```
 
@@ -26,7 +28,7 @@ and save it in the starcoin project dir.
 In starcoin console, run:
 
 ```bash
-starcoin% wallet compile -o build/ -f peer_to_peer.move -s 759e96a81c7f0c828cd3bf1cc84239cb
+starcoin% dev compile -o build/ -f peer_to_peer.move -s 759e96a81c7f0c828cd3bf1cc84239cb
 build/peer_to_peer.mv
 ```
 
@@ -69,7 +71,7 @@ starcoin% wallet show 1d8133a0c1a07366de459fb08d28d2a6
 5. execute the script.(will build a transaction and submit to chain).
 
 ```bash
-starcoin% wallet execute -a 759e96a81c7f0c828cd3bf1cc84239cb -f build/peer_to_peer.mv -g 1000000 -t 0x0::Starcoin::T --arg 0x1d8133a0c1a07366de459fb08d28d2a6 --arg b"7bc6066656bb248755686d2ab78aef14" --arg 100000
+starcoin% dev execute -a 759e96a81c7f0c828cd3bf1cc84239cb -f build/peer_to_peer.mv -g 1000000 -t 0x0::Starcoin::T --arg 0x1d8133a0c1a07366de459fb08d28d2a6 --arg b"7bc6066656bb248755686d2ab78aef14" --arg 100000
 621f7f59fec2a3dc5bd9ee34897278b03cc4f804e0fe531e745276e579779c0d
 ```
 

--- a/rpc/api/src/types/pubsub.rs
+++ b/rpc/api/src/types/pubsub.rs
@@ -12,12 +12,13 @@ use starcoin_types::block::BlockHeader;
 use starcoin_types::event::EventKey;
 use starcoin_types::filter::Filter;
 use std::convert::TryInto;
+
 /// Subscription kind.
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Hash, Clone)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 pub enum Kind {
-    /// New block headers subscription.
+    /// New block subscription.
     NewHeads,
     /// Events subscription.
     Events,
@@ -28,8 +29,8 @@ pub enum Kind {
 /// Subscription result.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Result {
-    /// New block header.
-    Header(Box<BlockHeader>),
+    /// New block.
+    Block(Box<ThinBlock>),
     /// Transaction hash
     TransactionHash(Vec<HashValue>),
     Event(Box<Event>),
@@ -41,11 +42,36 @@ impl Serialize for Result {
         S: Serializer,
     {
         match *self {
-            Result::Header(ref header) => header.serialize(serializer),
+            Result::Block(ref header) => header.serialize(serializer),
             Result::Event(ref evt) => evt.serialize(serializer),
             Result::TransactionHash(ref hash) => hash.serialize(serializer),
             // Result::SyncState(ref sync) => sync.serialize(serializer),
         }
+    }
+}
+
+/// Block with only txn hashes.
+#[derive(Default, Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
+pub struct ThinBlock {
+    #[serde(flatten)]
+    header: BlockHeader,
+    #[serde(rename = "txn_hashes")]
+    body: Vec<HashValue>,
+}
+impl ThinBlock {
+    pub fn new(header: BlockHeader, txn_hashes: Vec<HashValue>) -> Self {
+        Self {
+            header,
+            body: txn_hashes,
+        }
+    }
+    pub fn header(&self) -> &BlockHeader {
+        &self.header
+    }
+    pub fn body(&self) -> &[HashValue] {
+        &self.body
     }
 }
 

--- a/rpc/client/src/chain_watcher.rs
+++ b/rpc/client/src/chain_watcher.rs
@@ -11,6 +11,7 @@ use starcoin_rpc_api::types::pubsub;
 use starcoin_types::block::BlockNumber;
 use std::collections::HashMap;
 
+#[derive(Debug)]
 pub struct ChainWatcher {
     inner: PubSubClient,
     watched_blocks: HashMap<BlockNumber, Vec<Responder>>,

--- a/rpc/client/src/chain_watcher.rs
+++ b/rpc/client/src/chain_watcher.rs
@@ -1,0 +1,126 @@
+use crate::pubsub_client::PubSubClient;
+use actix::prelude::*;
+use actix::AsyncContext;
+use futures::channel::oneshot;
+use futures::compat::Stream01CompatExt;
+use jsonrpc_core_client::RpcError;
+pub use pubsub::ThinBlock;
+use starcoin_crypto::HashValue;
+use starcoin_logger::prelude::*;
+use starcoin_rpc_api::types::pubsub;
+use starcoin_types::block::BlockNumber;
+use std::collections::HashMap;
+
+pub struct ChainWatcher {
+    inner: PubSubClient,
+    watched_blocks: HashMap<BlockNumber, Vec<Responder>>,
+    watched_txns: HashMap<HashValue, Responder>,
+}
+impl ChainWatcher {
+    pub fn launch(pubsub_client: PubSubClient) -> Addr<Self> {
+        let actor = Self {
+            inner: pubsub_client,
+            watched_txns: Default::default(),
+            watched_blocks: Default::default(),
+        };
+        actor.start()
+    }
+}
+
+impl Actor for ChainWatcher {
+    type Context = Context<Self>;
+    fn started(&mut self, ctx: &mut Self::Context) {
+        let client = self.inner.clone();
+        async move {
+            client.subscribe_new_block().await
+        }.into_actor(self)
+            .then(|res, act, ctx| {
+                match res {
+                    Ok(s) => {
+                        ctx.add_stream(s.compat());
+                    }
+                    Err(e) => {
+                        error!(target: "chain_watcher", "fail to subscribe new block event, err: {}", &e);
+                        ctx.terminate();
+                    }
+                }
+                async {}.into_actor(act)
+            })
+            .wait(ctx);
+    }
+}
+
+pub type WatchResult = Result<pubsub::ThinBlock, anyhow::Error>;
+type Responder = oneshot::Sender<WatchResult>;
+
+#[derive(Clone, Copy, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub struct WatchBlock(BlockNumber);
+
+impl Message for WatchBlock {
+    type Result = oneshot::Receiver<WatchResult>;
+}
+
+#[derive(Clone, Copy, Eq, Hash, PartialEq, PartialOrd, Ord)]
+pub struct WatchTxn {
+    txn_hash: HashValue,
+}
+
+impl Message for WatchTxn {
+    type Result = oneshot::Receiver<WatchResult>;
+}
+
+impl Handler<WatchBlock> for ChainWatcher {
+    type Result = MessageResult<WatchBlock>;
+
+    /// This method is called for every message received by this actor.
+    fn handle(&mut self, msg: WatchBlock, _ctx: &mut Self::Context) -> Self::Result {
+        let (tx, rx) = oneshot::channel();
+        self.watched_blocks.entry(msg.0).or_insert(vec![]).push(tx);
+        MessageResult(rx)
+    }
+}
+
+impl Handler<WatchTxn> for ChainWatcher {
+    type Result = MessageResult<WatchTxn>;
+
+    /// This method is called for every message received by this actor.
+    fn handle(&mut self, msg: WatchTxn, _ctx: &mut Self::Context) -> Self::Result {
+        let (tx, rx) = oneshot::channel();
+        self.watched_txns.entry(msg.txn_hash).or_insert(tx);
+        MessageResult(rx)
+    }
+}
+
+type BlockEvent = Result<pubsub::ThinBlock, RpcError>;
+impl actix::StreamHandler<BlockEvent> for ChainWatcher {
+    fn handle(&mut self, item: BlockEvent, _ctx: &mut Self::Context) {
+        match &item {
+            Ok(b) => {
+                if let Some(responders) = self.watched_blocks.remove(&b.header().number()) {
+                    for r in responders {
+                        let _ = r.send(Ok(b.clone()));
+                    }
+                }
+                for txn in b.body() {
+                    if let Some(r) = self.watched_txns.remove(txn) {
+                        let _ = r.send(Ok(b.clone()));
+                    }
+                }
+            }
+            Err(e) => {
+                // if any error happen in subscription, return error to client
+                for (_, responders) in self.watched_blocks.drain() {
+                    for r in responders {
+                        let e = anyhow::format_err!("{}", e);
+                        let _ = r.send(Err(e));
+                    }
+                }
+                for (_, responder) in self.watched_txns.drain() {
+                    let e = anyhow::format_err!("{}", e);
+                    let _ = responder.send(Err(e));
+                }
+            }
+        }
+    }
+    // fn finished(&mut self, ctx: &mut Self::Context) {}
+}

--- a/rpc/client/src/chain_watcher.rs
+++ b/rpc/client/src/chain_watcher.rs
@@ -54,7 +54,7 @@ pub type WatchResult = Result<pubsub::ThinBlock, anyhow::Error>;
 type Responder = oneshot::Sender<WatchResult>;
 
 #[derive(Clone, Copy, Eq, Hash, PartialEq, PartialOrd, Ord)]
-pub struct WatchBlock(BlockNumber);
+pub struct WatchBlock(pub BlockNumber);
 
 impl Message for WatchBlock {
     type Result = oneshot::Receiver<WatchResult>;
@@ -62,7 +62,7 @@ impl Message for WatchBlock {
 
 #[derive(Clone, Copy, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct WatchTxn {
-    txn_hash: HashValue,
+    pub txn_hash: HashValue,
 }
 
 impl Message for WatchTxn {

--- a/rpc/client/src/lib.rs
+++ b/rpc/client/src/lib.rs
@@ -1,7 +1,9 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2
 
+use actix::{Addr, System};
 use failure::Fail;
+use futures::channel::oneshot;
 use futures::{future::FutureExt, select, stream::StreamExt, TryStream, TryStreamExt};
 use futures01::future::Future as Future01;
 use jsonrpc_core::{MetaIoHandler, Metadata};
@@ -31,6 +33,7 @@ pub mod chain_watcher;
 mod pubsub_client;
 mod remote_state_reader;
 
+use crate::chain_watcher::{ChainWatcher, WatchBlock, WatchTxn};
 use crate::pubsub_client::PubSubClient;
 pub use crate::remote_state_reader::RemoteStateReader;
 use starcoin_rpc_api::node::NodeInfo;
@@ -42,11 +45,12 @@ use starcoin_types::peer_info::PeerInfo;
 use starcoin_types::startup_info::ChainInfo;
 use std::collections::HashMap;
 use std::sync::Arc;
+use tokio::task::LocalSet;
 
 #[derive(Debug, Clone)]
 enum ConnSource {
     Ipc(PathBuf, Arc<Reactor>),
-    WebSocket,
+    WebSocket(String),
     Local,
 }
 
@@ -54,6 +58,7 @@ pub struct RpcClient {
     inner: RefCell<Option<RpcClientInner>>,
     rt: RefCell<Runtime>,
     conn_source: ConnSource,
+    chain_watcher: Addr<ChainWatcher>,
 }
 
 struct ConnectionProvider {
@@ -82,11 +87,23 @@ impl ConnectionProvider {
 }
 
 impl RpcClient {
-    pub(crate) fn new(conn_source: ConnSource, inner: RpcClientInner, rt: Runtime) -> Self {
+    pub(crate) fn new(conn_source: ConnSource, inner: RpcClientInner, mut rt: Runtime) -> Self {
+        let (tx, rx) = oneshot::channel();
+        let pubsub_client = inner.pubsub_client.clone();
+        std::thread::spawn(move || {
+            let sys = System::new("client-actix-system");
+            let watcher = ChainWatcher::launch(pubsub_client);
+
+            tx.send(watcher);
+            sys.run();
+        });
+        let watcher = rt.block_on_std(rx).unwrap();
+
         Self {
             inner: RefCell::new(Some(inner)),
             rt: RefCell::new(rt),
             conn_source,
+            chain_watcher: watcher,
         }
     }
     pub fn connect_websocket(url: &str) -> anyhow::Result<Self> {
@@ -94,7 +111,11 @@ impl RpcClient {
 
         let conn = ws::try_connect(url).map_err(|e| anyhow::Error::new(e.compat()))?;
         let client = rt.block_on(conn.map_err(map_err))?;
-        Ok(Self::new(ConnSource::WebSocket, client, rt))
+        Ok(Self::new(
+            ConnSource::WebSocket(url.to_string()),
+            client,
+            rt,
+        ))
     }
 
     pub fn connect_local<THandler, TMetadata>(handler: THandler) -> Self
@@ -137,6 +158,23 @@ impl RpcClient {
             client_inner,
             rt,
         ))
+    }
+
+    pub fn watch_txn(&self, txn_hash: HashValue) -> anyhow::Result<ThinBlock> {
+        let f = async move {
+            let r = self.chain_watcher.send(WatchTxn { txn_hash }).await?;
+
+            let r = r.await?;
+            r
+        };
+        self.rt.borrow_mut().block_on_std(f)
+    }
+    pub fn watch_block(&self, block_number: BlockNumber) -> anyhow::Result<ThinBlock> {
+        let f = async move {
+            let r = self.chain_watcher.send(WatchBlock(block_number)).await?;
+            r.await?
+        };
+        self.rt.borrow_mut().block_on_std(f)
     }
 
     pub fn node_status(&self) -> anyhow::Result<bool> {

--- a/rpc/client/src/lib.rs
+++ b/rpc/client/src/lib.rs
@@ -27,6 +27,7 @@ use tokio01::reactor::Reactor;
 use tokio_compat::prelude::*;
 use tokio_compat::runtime::Runtime;
 
+pub mod chain_watcher;
 mod pubsub_client;
 mod remote_state_reader;
 
@@ -35,7 +36,8 @@ pub use crate::remote_state_reader::RemoteStateReader;
 use starcoin_rpc_api::node::NodeInfo;
 use starcoin_rpc_api::types::event::Event;
 use starcoin_rpc_api::types::pubsub::EventFilter;
-use starcoin_types::block::{Block, BlockHeader, BlockNumber};
+use starcoin_rpc_api::types::pubsub::ThinBlock;
+use starcoin_types::block::{Block, BlockNumber};
 use starcoin_types::peer_info::PeerInfo;
 use starcoin_types::startup_info::ChainInfo;
 use std::collections::HashMap;
@@ -375,7 +377,7 @@ impl RpcClient {
     }
     pub fn subscribe_new_blocks(
         &self,
-    ) -> anyhow::Result<impl TryStream<Ok = BlockHeader, Error = anyhow::Error>> {
+    ) -> anyhow::Result<impl TryStream<Ok = ThinBlock, Error = anyhow::Error>> {
         self.call_rpc_blocking(|inner| async move {
             let res = inner.pubsub_client.subscribe_new_block().await;
             res.map(|s| s.compat().map_err(map_err))

--- a/rpc/client/src/pubsub_client.rs
+++ b/rpc/client/src/pubsub_client.rs
@@ -1,8 +1,7 @@
 use futures::compat::Future01CompatExt;
 use jsonrpc_core_client::*;
 use starcoin_crypto::HashValue;
-use starcoin_rpc_api::types::{event::Event, pubsub::EventFilter, pubsub::Kind};
-use starcoin_types::block::BlockHeader;
+use starcoin_rpc_api::types::{event::Event, pubsub::EventFilter, pubsub::Kind, pubsub::ThinBlock};
 
 const STARCOIN_SUBSCRIPTION: &str = "starcoin_subscription";
 const STARCOIN_SUBSCRIBE: &str = "starcoin_subscribe";
@@ -38,14 +37,14 @@ impl PubSubClient {
     }
     pub async fn subscribe_new_block(
         &self,
-    ) -> Result<TypedSubscriptionStream<BlockHeader>, RpcError> {
+    ) -> Result<TypedSubscriptionStream<ThinBlock>, RpcError> {
         self.client
             .subscribe(
                 STARCOIN_SUBSCRIBE,
                 vec![Kind::NewHeads],
                 STARCOIN_SUBSCRIPTION,
                 STARCOIN_UNSUBSCRIBE,
-                "BlockHeader",
+                "ThinBlock",
             )
             .compat()
             .await

--- a/rpc/client/src/pubsub_client.rs
+++ b/rpc/client/src/pubsub_client.rs
@@ -11,6 +11,12 @@ pub struct PubSubClient {
     client: TypedClient,
 }
 
+impl std::fmt::Debug for PubSubClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "PubSubClient")
+    }
+}
+
 impl From<RpcChannel> for PubSubClient {
     fn from(channel: RpcChannel) -> Self {
         PubSubClient {


### PR DESCRIPTION
implement a chain watcher.

Client and watch block by block number, and watch txn by txn hash.
In both case, corresponding block info will be returned to client.