### PR TITLE
[scmd] enhancement

### DIFF
--- a/commons/scmd/examples/hello_main.rs
+++ b/commons/scmd/examples/hello_main.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
-#[structopt(name = "hello_app")]
+#[structopt(name = "hello")]
 struct GlobalOpts {
     #[structopt(short = "c", default_value = "0")]
     counter: usize,
@@ -53,7 +53,7 @@ impl User {
 #[derive(Debug, StructOpt)]
 #[structopt(name = "list")]
 struct ListOpts {
-    #[structopt(long, default_value = "5")]
+    #[structopt(long, short = "c", default_value = "5")]
     count: usize,
 }
 
@@ -191,7 +191,7 @@ struct TestOpts {
     debug: bool,
 }
 
-fn main() -> Result<()> {
+pub(crate) fn init_context() -> CmdContext<Counter, GlobalOpts> {
     let context = CmdContext::<Counter, GlobalOpts>::with_default_action(
         |global_opt| -> Result<Counter> { Ok(Counter::new(global_opt.counter)) },
         |_app, _opt, _state| {
@@ -236,6 +236,31 @@ fn main() -> Result<()> {
                 Ok(())
             },
         ))
-        .exec();
+}
+
+fn main() -> Result<()> {
+    let context = init_context();
+    context.exec();
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_execute_command_with_args() -> Result<()> {
+        let context = init_context();
+        let count = 10;
+        let result = context.exec_with_args::<Vec<User>>(vec![
+            "hello",
+            "-r",
+            "test_required",
+            "list",
+            "-c",
+            format!("{}", count).as_str(),
+        ])?;
+        assert_eq!(result.len(), count);
+        Ok(())
+    }
 }

--- a/commons/scmd/src/result.rs
+++ b/commons/scmd/src/result.rs
@@ -24,16 +24,27 @@ impl FromStr for OutputFormat {
     }
 }
 
-pub fn print_action_result(value: Value, format: OutputFormat) -> Result<()> {
+pub fn print_action_result(format: OutputFormat, result: Result<Value>) -> Result<()> {
     match format {
-        OutputFormat::JSON => print_json(value),
-        OutputFormat::TABLE => print_table(value),
+        OutputFormat::JSON => {
+            let value = match result {
+                Ok(value) => json!({ "ok": value }),
+                Err(err) => json!({"err": err.to_string()}),
+            };
+            print_json(value)
+        }
+        OutputFormat::TABLE => {
+            let value = match result {
+                Ok(value) => value,
+                Err(err) => json!({"err": err.to_string()}),
+            };
+            print_table(value)
+        }
     }
 }
 
 pub fn print_json(value: Value) -> Result<()> {
-    let result = json!({ "result": value });
-    let json = serde_json::to_string_pretty(&result)?;
+    let json = serde_json::to_string_pretty(&value)?;
     println!("{}", json);
     Ok(())
 }


### PR DESCRIPTION
1. 支持 exec_with_args，可以直接传递 args 去执行某个命令，并可以直接获取到命令执行的结果。
2. 优化 CmdContext 的初始化方式，方便集成测试。

resolve #617 