### PR TITLE
[storage&rpc]: fix txn info store

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -14,6 +14,7 @@ jobs:
   build-and-test:
     name: build and test
     runs-on: self-hosted
+    timeout-minutes: 60
     steps:
       - name: checkout
         uses: actions/checkout@v1

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{ensure, format_err, Error, Result};
+use anyhow::{ensure, format_err, Result};
 use config::NodeConfig;
 use crypto::{hash::PlainCryptoHash, HashValue};
 use executor::block_executor::BlockExecutor;
@@ -242,23 +242,15 @@ where
         Ok(None)
     }
 
-    fn get_block_transactions(&self, block_id: HashValue) -> Result<Vec<TransactionInfo>, Error> {
-        let mut txn_vec = vec![];
-        let vec_hash = self.storage.get_block_transactions(block_id)?;
-        for hash in vec_hash {
-            if let Some(transaction_info) = self.get_transaction_info(hash)? {
-                txn_vec.push(transaction_info);
-            }
-        }
-        Ok(txn_vec)
-    }
-
     fn get_transaction(&self, txn_hash: HashValue) -> Result<Option<Transaction>> {
         self.storage.get_transaction(txn_hash)
     }
 
-    fn get_transaction_info(&self, hash: HashValue) -> Result<Option<TransactionInfo>> {
-        self.storage.get_transaction_info(hash)
+    fn get_transaction_info_by_version(&self, version: u64) -> Result<Option<TransactionInfo>> {
+        match self.txn_accumulator.get_leaf(version)? {
+            None => Ok(None),
+            Some(hash) => self.storage.get_transaction_info(hash),
+        }
     }
 
     fn create_block_template(
@@ -303,6 +295,39 @@ where
             }
         }
         false
+    }
+}
+
+impl<C, S> BlockChain<C, S>
+where
+    C: Consensus,
+    S: Store,
+{
+    fn save(
+        &mut self,
+        block_id: HashValue,
+        transactions: Vec<Transaction>,
+        txn_infos: Vec<TransactionInfo>,
+    ) -> Result<()> {
+        ensure!(
+            transactions.len() == txn_infos.len(),
+            "block txns' length should be equal to txn infos' length"
+        );
+        let txn_id_vec = transactions
+            .iter()
+            .cloned()
+            .map(|user_txn| user_txn.id())
+            .collect::<Vec<HashValue>>();
+        // save block's transactions
+        self.storage.save_block_transactions(block_id, txn_id_vec)?;
+        // save transactions
+        self.storage.save_transaction_batch(transactions)?;
+
+        let txn_info_ids: Vec<_> = txn_infos.iter().map(|info| info.crypto_hash()).collect();
+        self.storage
+            .save_block_txn_info_ids(block_id, txn_info_ids)?;
+        self.storage.save_transaction_infos(txn_infos)?;
+        Ok(())
     }
 }
 
@@ -418,8 +443,7 @@ where
             total_difficulty,
         );
         // save block's transaction relationship and save transaction
-        self.save(header.id(), txns)?;
-        self.storage.save_transaction_infos(vec_transaction_info)?;
+        self.save(header.id(), txns, vec_transaction_info)?;
         self.commit(block.clone(), block_info, BlockState::Executed)?;
         Ok(true)
     }
@@ -437,19 +461,6 @@ where
         self.chain_state =
             ChainStateDB::new(self.storage.clone(), Some(self.head.header().state_root()));
         debug!("save block {:?} succ.", block_id);
-        Ok(())
-    }
-
-    fn save(&mut self, block_id: HashValue, transactions: Vec<Transaction>) -> Result<()> {
-        let txn_id_vec = transactions
-            .iter()
-            .cloned()
-            .map(|user_txn| user_txn.id())
-            .collect::<Vec<HashValue>>();
-        // save block's transactions
-        self.storage.save_block_transactions(block_id, txn_id_vec)?;
-        // save transactions
-        self.storage.save_transaction_batch(transactions)?;
         Ok(())
     }
 

--- a/chain/src/chain_service.rs
+++ b/chain/src/chain_service.rs
@@ -23,7 +23,7 @@ use types::{
     block::{Block, BlockDetail, BlockHeader, BlockInfo, BlockNumber, BlockState, BlockTemplate},
     startup_info::StartupInfo,
     system_events::NewHeadBlock,
-    transaction::{SignedUserTransaction, TransactionInfo},
+    transaction::{SignedUserTransaction, Transaction, TransactionInfo},
     BLOCK_PROTOCOL_NAME,
 };
 
@@ -355,24 +355,8 @@ where
         }
     }
 
-    fn master_head_block(&self) -> Block {
-        self.get_master().head_block()
-    }
-
-    fn master_head_header(&self) -> BlockHeader {
-        self.get_master().current_header()
-    }
-
     fn get_header_by_hash(&self, hash: HashValue) -> Result<Option<BlockHeader>> {
         self.storage.get_block_header_by_hash(hash)
-    }
-
-    fn master_block_by_number(&self, number: BlockNumber) -> Result<Option<Block>> {
-        self.get_master().get_block_by_number(number)
-    }
-
-    fn master_block_header_by_number(&self, number: BlockNumber) -> Result<Option<BlockHeader>> {
-        self.get_master().get_header_by_number(number)
     }
 
     fn get_block_by_hash(&self, hash: HashValue) -> Result<Option<Block>> {
@@ -385,6 +369,49 @@ where
 
     fn get_block_info_by_hash(&self, hash: HashValue) -> Result<Option<BlockInfo>> {
         self.storage.get_block_info(hash)
+    }
+
+    fn get_transaction(&self, txn_hash: HashValue) -> Result<Option<Transaction>, Error> {
+        self.storage.get_transaction(txn_hash)
+    }
+    fn get_block_txn_infos(&self, block_id: HashValue) -> Result<Vec<TransactionInfo>, Error> {
+        self.storage.get_block_transaction_infos(block_id)
+    }
+
+    fn get_txn_info_by_block_and_index(
+        &self,
+        block_id: HashValue,
+        idx: u64,
+    ) -> Result<Option<TransactionInfo>, Error> {
+        self.storage
+            .get_transaction_info_by_block_and_index(block_id, idx)
+    }
+
+    fn master_head_header(&self) -> BlockHeader {
+        self.get_master().current_header()
+    }
+
+    fn master_head_block(&self) -> Block {
+        self.get_master().head_block()
+    }
+
+    fn master_block_by_number(&self, number: BlockNumber) -> Result<Option<Block>> {
+        self.get_master().get_block_by_number(number)
+    }
+
+    fn master_block_header_by_number(&self, number: BlockNumber) -> Result<Option<BlockHeader>> {
+        self.get_master().get_header_by_number(number)
+    }
+    fn master_startup_info(&self) -> StartupInfo {
+        self.startup_info.clone()
+    }
+
+    fn master_blocks_by_number(
+        &self,
+        number: Option<BlockNumber>,
+        count: u64,
+    ) -> Result<Vec<Block>> {
+        self.get_master().get_blocks_by_number(number, count)
     }
 
     fn create_block_template(
@@ -408,25 +435,5 @@ where
         } else {
             Err(format_err!("Block {:?} not exist.", block_id))
         }
-    }
-
-    fn master_startup_info(&self) -> StartupInfo {
-        self.startup_info.clone()
-    }
-
-    fn master_blocks_by_number(
-        &self,
-        number: Option<BlockNumber>,
-        count: u64,
-    ) -> Result<Vec<Block>> {
-        self.get_master().get_blocks_by_number(number, count)
-    }
-
-    fn get_transaction(&self, hash: HashValue) -> Result<Option<TransactionInfo>, Error> {
-        self.get_master().get_transaction_info(hash)
-    }
-
-    fn get_block_txn_ids(&self, block_id: HashValue) -> Result<Vec<TransactionInfo>, Error> {
-        self.get_master().get_block_transactions(block_id)
     }
 }

--- a/chain/src/message/mod.rs
+++ b/chain/src/message/mod.rs
@@ -7,7 +7,7 @@ use types::{
     account_address::AccountAddress,
     block::{Block, BlockHeader, BlockInfo, BlockNumber, BlockState, BlockTemplate},
     startup_info::{ChainInfo, StartupInfo},
-    transaction::{SignedUserTransaction, TransactionInfo},
+    transaction::{SignedUserTransaction, Transaction, TransactionInfo},
 };
 
 #[derive(Clone)]
@@ -30,7 +30,11 @@ pub enum ChainRequest {
     GetStartupInfo(),
     GetHeadChainInfo(),
     GetTransaction(HashValue),
-    GetTransactionIdByBlock(HashValue),
+    GetBlockTransactionInfos(HashValue),
+    GetTransactionInfoByBlockAndIndex {
+        block_id: HashValue,
+        txn_idx: u64,
+    },
     GetBlocksByNumber(Option<BlockNumber>, u64),
     GetBlockStateByHash(HashValue),
 }
@@ -48,9 +52,10 @@ pub enum ChainResponse {
     HashValue(HashValue),
     StartupInfo(StartupInfo),
     ChainInfo(ChainInfo),
-    Transaction(TransactionInfo),
+    Transaction(Box<Transaction>),
     VecBlock(Vec<Block>),
-    VecTransactionInfo(Vec<TransactionInfo>),
+    BlockTransactionInfos(Vec<TransactionInfo>),
+    TransactionInfo(Option<TransactionInfo>),
     None,
     Conn(ConnectResult<()>),
     BlockState(Option<Box<BlockState>>),

--- a/chain/src/mock/mock_chain_service.rs
+++ b/chain/src/mock/mock_chain_service.rs
@@ -8,7 +8,7 @@ use types::{
     account_address::AccountAddress,
     block::{Block, BlockHeader, BlockInfo, BlockNumber, BlockState, BlockTemplate},
     startup_info::{ChainInfo, StartupInfo},
-    transaction::{SignedUserTransaction, TransactionInfo},
+    transaction::{SignedUserTransaction, Transaction, TransactionInfo},
 };
 
 //TODO implement Mock service
@@ -18,6 +18,14 @@ pub struct MockChainService;
 #[async_trait::async_trait]
 impl ChainAsyncService for MockChainService {
     async fn try_connect(self, _block: Block) -> Result<ConnectResult<()>> {
+        unimplemented!()
+    }
+
+    async fn try_connect_with_block_info(
+        &mut self,
+        _block: Block,
+        _block_info: BlockInfo,
+    ) -> Result<ConnectResult<()>, Error> {
         unimplemented!()
     }
 
@@ -33,19 +41,23 @@ impl ChainAsyncService for MockChainService {
         unimplemented!()
     }
 
-    async fn master_block_header_by_number(self, _number: BlockNumber) -> Result<BlockHeader> {
-        unimplemented!()
-    }
-
-    async fn try_connect_with_block_info(
-        &mut self,
-        _block: Block,
-        _block_info: BlockInfo,
-    ) -> Result<ConnectResult<()>, Error> {
-        unimplemented!()
-    }
-
     async fn get_block_info_by_hash(self, _hash: &HashValue) -> Result<Option<BlockInfo>> {
+        unimplemented!()
+    }
+
+    async fn get_transaction(self, _txn_id: HashValue) -> Result<Transaction> {
+        unimplemented!()
+    }
+
+    async fn get_block_txn_infos(self, _block_id: HashValue) -> Result<Vec<TransactionInfo>> {
+        unimplemented!()
+    }
+
+    async fn get_txn_info_by_block_and_index(
+        self,
+        _block_id: HashValue,
+        _idx: u64,
+    ) -> Result<Option<TransactionInfo>, Error> {
         unimplemented!()
     }
 
@@ -69,19 +81,15 @@ impl ChainAsyncService for MockChainService {
         unimplemented!()
     }
 
+    async fn master_block_header_by_number(self, _number: BlockNumber) -> Result<BlockHeader> {
+        unimplemented!()
+    }
+
     async fn master_startup_info(self) -> Result<StartupInfo> {
         unimplemented!()
     }
 
     async fn master_head(self) -> Result<ChainInfo> {
-        unimplemented!()
-    }
-
-    async fn get_transaction(self, _txn_id: HashValue) -> Result<TransactionInfo> {
-        unimplemented!()
-    }
-
-    async fn get_block_txn(self, _block_id: HashValue) -> Result<Vec<TransactionInfo>> {
         unimplemented!()
     }
 

--- a/cmd/starcoin/src/chain/get_block_cmd.rs
+++ b/cmd/starcoin/src/chain/get_block_cmd.rs
@@ -12,8 +12,8 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 #[structopt(name = "get_block")]
 pub struct GetOpt {
-    #[structopt(name = "hash")]
-    hash: String,
+    #[structopt(name = "hash", parse(try_from_str = HashValue::from_hex))]
+    hash: HashValue,
 }
 
 pub struct GetBlockCommand;
@@ -30,7 +30,7 @@ impl CommandAction for GetBlockCommand {
     ) -> Result<Self::ReturnItem> {
         let client = ctx.state().client();
         let opt = ctx.opt();
-        let block = client.chain_get_block_by_hash(HashValue::from_hex(&opt.hash).unwrap())?;
+        let block = client.chain_get_block_by_hash(opt.hash)?;
 
         Ok(block.into())
     }

--- a/cmd/starcoin/src/chain/get_block_cmd.rs
+++ b/cmd/starcoin/src/chain/get_block_cmd.rs
@@ -12,7 +12,7 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 #[structopt(name = "get_block")]
 pub struct GetOpt {
-    #[structopt(name = "hash", parse(try_from_str = HashValue::from_hex))]
+    #[structopt(name = "hash")]
     hash: HashValue,
 }
 

--- a/cmd/starcoin/src/chain/get_txn_by_block_cmd.rs
+++ b/cmd/starcoin/src/chain/get_txn_by_block_cmd.rs
@@ -12,8 +12,8 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 #[structopt(name = "get_txn_by_block")]
 pub struct GetOpt {
-    #[structopt(name = "hash")]
-    hash: String,
+    #[structopt(name = "hash", parse(try_from_str = HashValue::from_hex))]
+    hash: HashValue,
 }
 
 pub struct GetTxnByBlockCommand;
@@ -30,8 +30,7 @@ impl CommandAction for GetTxnByBlockCommand {
     ) -> Result<Self::ReturnItem> {
         let client = ctx.state().client();
         let opt = ctx.opt();
-        let vec_transaction_info =
-            client.chain_get_txn_by_block(HashValue::from_hex(&opt.hash).unwrap())?;
+        let vec_transaction_info = client.chain_get_txn_by_block(opt.hash)?;
 
         Ok(vec_transaction_info)
     }

--- a/cmd/starcoin/src/chain/get_txn_by_block_cmd.rs
+++ b/cmd/starcoin/src/chain/get_txn_by_block_cmd.rs
@@ -12,7 +12,7 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 #[structopt(name = "get_txn_by_block")]
 pub struct GetOpt {
-    #[structopt(name = "hash", parse(try_from_str = HashValue::from_hex))]
+    #[structopt(name = "hash")]
     hash: HashValue,
 }
 

--- a/cmd/starcoin/src/chain/get_txn_cmd.rs
+++ b/cmd/starcoin/src/chain/get_txn_cmd.rs
@@ -12,7 +12,7 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 #[structopt(name = "get_txn")]
 pub struct GetOpt {
-    #[structopt(name = "txn-hash", parse(try_from_str = HashValue::from_hex))]
+    #[structopt(name = "txn-hash")]
     hash: HashValue,
 }
 

--- a/cmd/starcoin/src/chain/get_txn_cmd.rs
+++ b/cmd/starcoin/src/chain/get_txn_cmd.rs
@@ -6,13 +6,13 @@ use crate::StarcoinOpt;
 use anyhow::Result;
 use scmd::{CommandAction, ExecContext};
 use starcoin_crypto::HashValue;
-use starcoin_types::transaction::TransactionInfo;
+use starcoin_types::transaction::Transaction;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "get_txn")]
 pub struct GetOpt {
-    #[structopt(name = "hash")]
+    #[structopt(name = "txn-hash")]
     hash: String,
 }
 
@@ -22,7 +22,7 @@ impl CommandAction for GetTransactionCommand {
     type State = CliState;
     type GlobalOpt = StarcoinOpt;
     type Opt = GetOpt;
-    type ReturnItem = TransactionInfo;
+    type ReturnItem = Transaction;
 
     fn run(
         &self,
@@ -30,9 +30,8 @@ impl CommandAction for GetTransactionCommand {
     ) -> Result<Self::ReturnItem> {
         let client = ctx.state().client();
         let opt = ctx.opt();
-        let transaction_info =
-            client.chain_get_transaction(HashValue::from_hex(&opt.hash).unwrap())?;
+        let transaction = client.chain_get_transaction(HashValue::from_hex(&opt.hash).unwrap())?;
 
-        Ok(transaction_info)
+        Ok(transaction)
     }
 }

--- a/cmd/starcoin/src/chain/get_txn_cmd.rs
+++ b/cmd/starcoin/src/chain/get_txn_cmd.rs
@@ -12,8 +12,8 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 #[structopt(name = "get_txn")]
 pub struct GetOpt {
-    #[structopt(name = "txn-hash")]
-    hash: String,
+    #[structopt(name = "txn-hash", parse(try_from_str = HashValue::from_hex))]
+    hash: HashValue,
 }
 
 pub struct GetTransactionCommand;
@@ -30,7 +30,7 @@ impl CommandAction for GetTransactionCommand {
     ) -> Result<Self::ReturnItem> {
         let client = ctx.state().client();
         let opt = ctx.opt();
-        let transaction = client.chain_get_transaction(HashValue::from_hex(&opt.hash).unwrap())?;
+        let transaction = client.chain_get_transaction(opt.hash)?;
 
         Ok(transaction)
     }

--- a/cmd/starcoin/src/chain/get_txn_info_cmd.rs
+++ b/cmd/starcoin/src/chain/get_txn_info_cmd.rs
@@ -1,0 +1,42 @@
+// Copyright (c) The Starcoin Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli_state::CliState;
+use crate::StarcoinOpt;
+use anyhow::Result;
+use scmd::{CommandAction, ExecContext};
+use starcoin_crypto::HashValue;
+use starcoin_types::transaction::TransactionInfo;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "get_txn_info")]
+pub struct GetTransactionInfoOpt {
+    #[structopt(name = "block-hash")]
+    block_hash: String,
+    #[structopt(name = "idx", help = "the index(start from 0) of the txn in the block")]
+    idx: u64,
+}
+
+pub struct GetTransactionInfoCommand;
+
+impl CommandAction for GetTransactionInfoCommand {
+    type State = CliState;
+    type GlobalOpt = StarcoinOpt;
+    type Opt = GetTransactionInfoOpt;
+    type ReturnItem = Option<TransactionInfo>;
+
+    fn run(
+        &self,
+        ctx: &ExecContext<Self::State, Self::GlobalOpt, Self::Opt>,
+    ) -> Result<Self::ReturnItem> {
+        let client = ctx.state().client();
+        let opt = ctx.opt();
+        let transaction_info = client.chain_get_txn_info_by_block_and_index(
+            HashValue::from_hex(&opt.block_hash).unwrap(),
+            opt.idx,
+        )?;
+
+        Ok(transaction_info)
+    }
+}

--- a/cmd/starcoin/src/chain/get_txn_info_cmd.rs
+++ b/cmd/starcoin/src/chain/get_txn_info_cmd.rs
@@ -12,7 +12,7 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 #[structopt(name = "get_txn_info")]
 pub struct GetTransactionInfoOpt {
-    #[structopt(name = "block-hash", parse(try_from_str = HashValue::from_hex))]
+    #[structopt(name = "block-hash")]
     block_hash: HashValue,
     #[structopt(name = "idx", help = "the index(start from 0) of the txn in the block")]
     idx: u64,

--- a/cmd/starcoin/src/chain/get_txn_info_cmd.rs
+++ b/cmd/starcoin/src/chain/get_txn_info_cmd.rs
@@ -12,8 +12,8 @@ use structopt::StructOpt;
 #[derive(Debug, StructOpt)]
 #[structopt(name = "get_txn_info")]
 pub struct GetTransactionInfoOpt {
-    #[structopt(name = "block-hash")]
-    block_hash: String,
+    #[structopt(name = "block-hash", parse(try_from_str = HashValue::from_hex))]
+    block_hash: HashValue,
     #[structopt(name = "idx", help = "the index(start from 0) of the txn in the block")]
     idx: u64,
 }
@@ -32,10 +32,8 @@ impl CommandAction for GetTransactionInfoCommand {
     ) -> Result<Self::ReturnItem> {
         let client = ctx.state().client();
         let opt = ctx.opt();
-        let transaction_info = client.chain_get_txn_info_by_block_and_index(
-            HashValue::from_hex(&opt.block_hash).unwrap(),
-            opt.idx,
-        )?;
+        let transaction_info =
+            client.chain_get_txn_info_by_block_and_index(opt.block_hash, opt.idx)?;
 
         Ok(transaction_info)
     }

--- a/cmd/starcoin/src/chain/mod.rs
+++ b/cmd/starcoin/src/chain/mod.rs
@@ -6,6 +6,7 @@ mod get_block_by_number_cmd;
 mod get_block_cmd;
 mod get_txn_by_block_cmd;
 mod get_txn_cmd;
+mod get_txn_info_cmd;
 mod list_block_cmd;
 mod show_cmd;
 
@@ -14,5 +15,6 @@ pub use get_block_by_number_cmd::*;
 pub use get_block_cmd::*;
 pub use get_txn_by_block_cmd::*;
 pub use get_txn_cmd::*;
+pub use get_txn_info_cmd::*;
 pub use list_block_cmd::*;
 pub use show_cmd::*;

--- a/cmd/starcoin/src/main.rs
+++ b/cmd/starcoin/src/main.rs
@@ -110,6 +110,7 @@ fn run() -> Result<()> {
                 .subcommand(chain::ListBlockCommand)
                 .subcommand(chain::GetTransactionCommand)
                 .subcommand(chain::GetTxnByBlockCommand)
+                .subcommand(chain::GetTransactionInfoCommand)
                 .subcommand(chain::GetBlockCommand)
                 .subcommand(chain::BranchesCommand),
         )

--- a/core/traits/src/chain.rs
+++ b/core/traits/src/chain.rs
@@ -27,10 +27,11 @@ pub trait ChainReader {
     /// Get latest `count` blocks before `number`. if `number` is absent, use head block number.
     fn get_blocks_by_number(&self, number: Option<BlockNumber>, count: u64) -> Result<Vec<Block>>;
     fn get_block(&self, hash: HashValue) -> Result<Option<Block>>;
-    fn get_block_transactions(&self, block_id: HashValue) -> Result<Vec<TransactionInfo>>;
     fn get_transaction(&self, hash: HashValue) -> Result<Option<Transaction>>;
-    /// get transaction info by transaction info hash.
-    fn get_transaction_info(&self, hash: HashValue) -> Result<Option<TransactionInfo>>;
+
+    /// get txn info at version in main chain.
+    fn get_transaction_info_by_version(&self, version: u64) -> Result<Option<TransactionInfo>>;
+
     fn create_block_template(
         &self,
         author: AccountAddress,
@@ -54,7 +55,6 @@ pub trait ChainWriter {
         block_info: BlockInfo,
         block_state: BlockState,
     ) -> Result<()>;
-    fn save(&mut self, block_id: HashValue, transactions: Vec<Transaction>) -> Result<()>;
     fn chain_state(&mut self) -> &dyn ChainState;
 }
 

--- a/rpc/api/src/chain/mod.rs
+++ b/rpc/api/src/chain/mod.rs
@@ -7,7 +7,7 @@ use jsonrpc_derive::rpc;
 use starcoin_crypto::HashValue;
 use starcoin_types::block::{Block, BlockNumber};
 use starcoin_types::startup_info::ChainInfo;
-use starcoin_types::transaction::TransactionInfo;
+use starcoin_types::transaction::{Transaction, TransactionInfo};
 
 #[rpc]
 pub trait ChainApi {
@@ -29,11 +29,19 @@ pub trait ChainApi {
     ) -> FutureResult<Vec<Block>>;
     /// Get chain transactions
     #[rpc(name = "chain.get_transaction")]
-    fn get_transaction(&self, transaction_id: HashValue) -> FutureResult<TransactionInfo>;
+    fn get_transaction(&self, transaction_id: HashValue) -> FutureResult<Transaction>;
 
-    /// Get chain transactions by block id
-    #[rpc(name = "chain.get_txn_by_block")]
+    /// Get chain transactions infos by block id
+    #[rpc(name = "chain.get_block_txn_infos")]
     fn get_txn_by_block(&self, block_id: HashValue) -> FutureResult<Vec<TransactionInfo>>;
+
+    /// Get txn info of a txn at `idx` of block `block_id`
+    #[rpc(name = "chain.get_txn_info_by_block_and_index")]
+    fn get_txn_info_by_block_and_index(
+        &self,
+        block_id: HashValue,
+        idx: u64,
+    ) -> FutureResult<Option<TransactionInfo>>;
 
     /// Get branches of current chain, first is master.
     #[rpc(name = "chain.branches")]

--- a/rpc/client/src/lib.rs
+++ b/rpc/client/src/lib.rs
@@ -27,7 +27,9 @@ use starcoin_types::account_state::AccountState;
 use starcoin_types::block::{Block, BlockNumber};
 use starcoin_types::peer_info::PeerInfo;
 use starcoin_types::startup_info::ChainInfo;
-use starcoin_types::transaction::{RawUserTransaction, SignedUserTransaction, TransactionInfo};
+use starcoin_types::transaction::{
+    RawUserTransaction, SignedUserTransaction, Transaction, TransactionInfo,
+};
 use starcoin_wallet_api::WalletAccount;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -399,7 +401,7 @@ impl RpcClient {
         .map_err(map_err)
     }
 
-    pub fn chain_get_transaction(&self, txn_id: HashValue) -> anyhow::Result<TransactionInfo> {
+    pub fn chain_get_transaction(&self, txn_id: HashValue) -> anyhow::Result<Transaction> {
         self.call_rpc_blocking(|inner| async move {
             inner.chain_client.get_transaction(txn_id).compat().await
         })
@@ -412,6 +414,21 @@ impl RpcClient {
     ) -> anyhow::Result<Vec<TransactionInfo>> {
         self.call_rpc_blocking(|inner| async move {
             inner.chain_client.get_txn_by_block(block_id).compat().await
+        })
+        .map_err(map_err)
+    }
+
+    pub fn chain_get_txn_info_by_block_and_index(
+        &self,
+        block_id: HashValue,
+        idx: u64,
+    ) -> anyhow::Result<Option<TransactionInfo>> {
+        self.call_rpc_blocking(|inner| async move {
+            inner
+                .chain_client
+                .get_txn_info_by_block_and_index(block_id, idx)
+                .compat()
+                .await
         })
         .map_err(map_err)
     }

--- a/rpc/server/src/module/chain_rpc.rs
+++ b/rpc/server/src/module/chain_rpc.rs
@@ -9,7 +9,7 @@ use starcoin_rpc_api::FutureResult;
 use starcoin_traits::ChainAsyncService;
 use starcoin_types::block::{Block, BlockNumber};
 use starcoin_types::startup_info::ChainInfo;
-use starcoin_types::transaction::TransactionInfo;
+use starcoin_types::transaction::{Transaction, TransactionInfo};
 
 pub struct ChainRpcImpl<S>
 where
@@ -67,7 +67,7 @@ where
         Box::new(fut.compat())
     }
 
-    fn get_transaction(&self, transaction_id: HashValue) -> FutureResult<TransactionInfo> {
+    fn get_transaction(&self, transaction_id: HashValue) -> FutureResult<Transaction> {
         let fut = self
             .service
             .clone()
@@ -80,7 +80,19 @@ where
         let fut = self
             .service
             .clone()
-            .get_block_txn(block_id)
+            .get_block_txn_infos(block_id)
+            .map_err(map_err);
+        Box::new(fut.compat())
+    }
+    fn get_txn_info_by_block_and_index(
+        &self,
+        block_id: HashValue,
+        idx: u64,
+    ) -> FutureResult<Option<TransactionInfo>> {
+        let fut = self
+            .service
+            .clone()
+            .get_txn_info_by_block_and_index(block_id, idx)
             .map_err(map_err);
         Box::new(fut.compat())
     }

--- a/rpc/server/src/module/pubsub/event_subscription_actor.rs
+++ b/rpc/server/src/module/pubsub/event_subscription_actor.rs
@@ -98,11 +98,11 @@ impl ChainNotifyHandlerActor {
 
         let block_number = block.header().number();
         let block_id = block.id();
-        let txns = store.get_block_transactions(block_id)?;
+        let txn_info_ids = store.get_block_txn_info_ids(block_id)?;
         // in reverse order to do limit
         let mut all_events: Vec<ContractEvent> = vec![];
-        for (_i, txn_hash) in txns.into_iter().enumerate().rev() {
-            let txn_info = store.get_transaction_info(txn_hash)?;
+        for (_i, txn_info_id) in txn_info_ids.into_iter().enumerate().rev() {
+            let txn_info = store.get_transaction_info(txn_info_id)?;
             if txn_info.is_none() {
                 continue;
             }

--- a/storage/src/block/mod.rs
+++ b/storage/src/block/mod.rs
@@ -194,7 +194,7 @@ impl BlockStorage {
             number_store: BlockNumberStorage::new(instance.clone()),
             branch_number_store: BranchNumberStorage::new(instance.clone()),
             block_txns_store: BlockTransactionsStorage::new(instance.clone()),
-            block_txn_infos_store: BlockTransactionInfosStorage::new(instance.clone()),
+            block_txn_infos_store: BlockTransactionInfosStorage::new(instance),
         }
     }
     pub fn save(&self, block: Block, state: BlockState) -> Result<()> {

--- a/storage/src/transaction_info/mod.rs
+++ b/storage/src/transaction_info/mod.rs
@@ -29,18 +29,17 @@ impl ValueCodec for TransactionInfo {
 }
 
 impl TransactionInfoStore for TransactionInfoStorage {
-    fn get_transaction_info(&self, txn_hash: HashValue) -> Result<Option<TransactionInfo>, Error> {
-        self.store.get(txn_hash)
-    }
-
-    fn save_transaction_info(&self, txn_info: TransactionInfo) -> Result<(), Error> {
-        self.store.put(txn_info.transaction_hash(), txn_info)
+    fn get_transaction_info(
+        &self,
+        txn_info_hash: HashValue,
+    ) -> Result<Option<TransactionInfo>, Error> {
+        self.store.get(txn_info_hash)
     }
 
     fn save_transaction_infos(&self, vec_txn_info: Vec<TransactionInfo>) -> Result<(), Error> {
         let mut batch = WriteBatch::new();
         for txn_info in vec_txn_info {
-            batch.put(txn_info.transaction_hash(), txn_info)?;
+            batch.put(txn_info.id(), txn_info)?;
         }
         self.store.write_batch(batch)
     }

--- a/vm/types/src/transaction/mod.rs
+++ b/vm/types/src/transaction/mod.rs
@@ -540,6 +540,10 @@ impl TransactionInfo {
         }
     }
 
+    pub fn id(&self) -> HashValue {
+        self.crypto_hash()
+    }
+
     /// Returns the hash of this transaction.
     pub fn transaction_hash(&self) -> HashValue {
         self.transaction_hash


### PR DESCRIPTION
This PR fix txn_info storage.
and refactor(cleanup) some apis in store, chain reader and chain service.
Besides, a new cli cmd called get_txn_info_by_block_and_index is added, which can get txn info of txn at `index` of a `block`.


The API of `get_txn_info_by_version` is implemented, but no cli cmd is exposed for now.
Once the version information of txn is exposed to user, this cli cmd can be implemented then.
I will fire another PR to address this.