### PR TITLE
cli: support execute move source file and move bytecode file

### DIFF
--- a/cmd/starcoin/src/dev/execute_cmd.rs
+++ b/cmd/starcoin/src/dev/execute_cmd.rs
@@ -8,13 +8,14 @@ use scmd::{CommandAction, ExecContext};
 use starcoin_crypto::hash::{HashValue, PlainCryptoHash};
 use starcoin_move_compiler::shared::Address;
 use starcoin_move_compiler::{
-    command_line::parse_address, MOVE_COMPILED_EXTENSION, MOVE_EXTENSION,
+    command_line::parse_address, compiled_unit::CompiledUnit, MOVE_COMPILED_EXTENSION,
+    MOVE_EXTENSION,
 };
 use starcoin_rpc_client::RemoteStateReader;
 use starcoin_state_api::AccountStateReader;
 use starcoin_types::account_address::AccountAddress;
 use starcoin_types::transaction::{
-    parse_transaction_argument, RawUserTransaction, Script, TransactionArgument,
+    parse_transaction_argument, Module, RawUserTransaction, Script, TransactionArgument,
 };
 use starcoin_vm_types::{language_storage::TypeTag, parser::parse_type_tag};
 use std::fs::OpenOptions;
@@ -109,7 +110,7 @@ impl CommandAction for ExecuteCommand {
             .extension()
             .map(|os_str| os_str.to_str().expect("file extension should is utf8 str"))
             .unwrap_or_else(|| "");
-        let bytecode = if ext == MOVE_EXTENSION {
+        let (bytecode, is_script) = if ext == MOVE_EXTENSION {
             let temp_dir = ctx.state().temp_dir();
             let source_file_path = starcoin_move_compiler::process_source_tpl_file(
                 temp_dir,
@@ -136,7 +137,11 @@ impl CommandAction for ExecuteCommand {
                 Ok(r) => r,
             };
             let compile_result = compile_units.pop().unwrap();
-            compile_result.serialize()
+            let is_script = match compile_result {
+                CompiledUnit::Module { .. } => false,
+                CompiledUnit::Script { .. } => true,
+            };
+            (compile_result.serialize(), is_script)
         } else if ext == MOVE_COMPILED_EXTENSION {
             let mut file = OpenOptions::new()
                 .read(true)
@@ -144,15 +149,25 @@ impl CommandAction for ExecuteCommand {
                 .open(bytecode_path)?;
             let mut bytecode = vec![];
             file.read_to_end(&mut bytecode)?;
-            let _compiled_script = match starcoin_vm_types::file_format::CompiledScript::deserialize(
+            let is_script = match starcoin_vm_types::file_format::CompiledScript::deserialize(
                 bytecode.as_slice(),
             ) {
-                Err(e) => {
-                    bail!("invalid bytecode file, cannot deserialize as script, {}", e);
+                Err(_) => {
+                    match starcoin_vm_types::file_format::CompiledModule::deserialize(
+                        bytecode.as_slice(),
+                    ) {
+                        Ok(_) => false,
+                        Err(e) => {
+                            bail!(
+                                "invalid bytecode file, cannot deserialize as script or module, {}",
+                                e
+                            );
+                        }
+                    }
                 }
-                Ok(s) => s,
+                Ok(_) => true,
             };
-            bytecode
+            (bytecode, is_script)
         } else {
             bail!("Only support *.move or *.mv file");
         };
@@ -168,14 +183,25 @@ impl CommandAction for ExecuteCommand {
         }
         let account_resource = account_resource.unwrap();
         let expiration_time = Duration::from_secs(opt.expiration_time);
-        let script_txn = RawUserTransaction::new_script(
-            sender,
-            account_resource.sequence_number(),
-            Script::new(bytecode, opt.type_tags.clone(), args),
-            opt.max_gas_amount,
-            opt.gas_price,
-            expiration_time,
-        );
+        let script_txn = if is_script {
+            RawUserTransaction::new_script(
+                sender,
+                account_resource.sequence_number(),
+                Script::new(bytecode, opt.type_tags.clone(), args),
+                opt.max_gas_amount,
+                opt.gas_price,
+                expiration_time,
+            )
+        } else {
+            RawUserTransaction::new_module(
+                sender,
+                account_resource.sequence_number(),
+                Module::new(bytecode),
+                opt.max_gas_amount,
+                opt.gas_price,
+                expiration_time,
+            )
+        };
 
         let signed_txn = client.wallet_sign_txn(script_txn)?;
         let txn_hash = signed_txn.crypto_hash();

--- a/vm/compiler/src/lib.rs
+++ b/vm/compiler/src/lib.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use move_lang::compiled_unit::CompiledUnit;
 pub use move_lang::{
     move_check, move_check_no_report, move_compile, move_compile_no_report,
-    move_compile_to_expansion_no_report, MOVE_EXTENSION,
+    move_compile_to_expansion_no_report, MOVE_COMPILED_EXTENSION, MOVE_EXTENSION,
 };
 use starcoin_vm_types::account_address::AccountAddress;
 


### PR DESCRIPTION
Make Execute support exec bytecode or move source, move source can be script or module.
If it's module, a module txn will be submitted.