### PR TITLE
[integration-test] integration test add enhance of multiple commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1631,6 +1631,15 @@ dependencies = [
 
 [[package]]
 name = "error-chain"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
+name = "error-chain"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d371106cc88ffdfb1eabd7111e432da544f16f3e2d7bf1dfe8bf575f1df045cd"
@@ -2133,8 +2142,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e246e72427f2a2dadc4a94a7db108b52269538d5c0ea0fe5570a707a78115a5"
 dependencies = [
  "derive_builder",
- "pest",
- "pest_derive",
+ "pest 2.1.3",
+ "pest_derive 2.1.0",
  "textwrap",
 ]
 
@@ -2270,8 +2279,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8ae96a0e0dacf151557ccba95a7a80889f8e74a784484377739628fcdb3996"
 dependencies = [
  "log 0.4.8",
- "pest",
- "pest_derive",
+ "pest 2.1.3",
+ "pest_derive 2.1.0",
  "quick-error",
  "serde",
  "serde_json",
@@ -2737,6 +2746,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4b9172132a62451e56142bff9afc91c8e4a4500aa5b847da36815b63bfda916"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonpath"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8061db09019f1879ba586685694fe18279f597b1b3a9dd308f35e596be6cdf7d"
+dependencies = [
+ "error-chain 0.11.0",
+ "pest 1.0.6",
+ "pest_derive 1.0.8",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4786,6 +4808,12 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pest"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fce5d8b5cc33983fc74f78ad552b5522ab41442c4ca91606e4236eb4b5ceefc"
+
+[[package]]
+name = "pest"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
@@ -4795,11 +4823,22 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3294f437119209b084c797604295f40227cffa35c57220b1e99a6ff3bf8ee4"
+dependencies = [
+ "pest 1.0.6",
+ "quote 0.3.15",
+ "syn 0.11.11",
+]
+
+[[package]]
+name = "pest_derive"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
 dependencies = [
- "pest",
+ "pest 2.1.3",
  "pest_generator",
 ]
 
@@ -4809,7 +4848,7 @@ version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
 dependencies = [
- "pest",
+ "pest 2.1.3",
  "pest_meta",
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -4823,7 +4862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
 dependencies = [
  "maplit",
- "pest",
+ "pest 2.1.3",
  "sha-1 0.8.2",
 ]
 
@@ -5189,7 +5228,7 @@ version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bbaa49075179162b49acac1c6aa45fb4dafb5f13cf6794276d77bc7fd95757b"
 dependencies = [
- "error-chain",
+ "error-chain 0.12.2",
  "idna 0.2.0",
  "lazy_static",
  "regex",
@@ -5224,6 +5263,12 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -5719,7 +5764,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d0d62c70781901ff6d68c677e092551ee10223b2149cf8a3d8bd5ab6280894b"
 dependencies = [
- "error-chain",
+ "error-chain 0.12.2",
  "log 0.4.8",
  "serde_json",
 ]
@@ -7708,6 +7753,17 @@ checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 
 [[package]]
 name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+dependencies = [
+ "quote 0.3.15",
+ "synom",
+ "unicode-xid 0.0.4",
+]
+
+[[package]]
+name = "syn"
 version = "0.15.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
@@ -7737,6 +7793,15 @@ dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
  "syn 1.0.33",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+dependencies = [
+ "unicode-xid 0.0.4",
 ]
 
 [[package]]
@@ -7837,6 +7902,7 @@ dependencies = [
  "data-encoding",
  "gherkin_rust 0.8.0",
  "indexmap",
+ "jsonpath",
  "lazy_static",
  "rand 0.7.3",
  "reqwest",
@@ -8536,6 +8602,12 @@ name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 
 [[package]]
 name = "unicode-xid"

--- a/cmd/starcoin/src/lib.rs
+++ b/cmd/starcoin/src/lib.rs
@@ -13,4 +13,76 @@ pub mod state;
 pub mod view;
 pub mod wallet;
 pub use cli_state::CliState;
+use scmd::{CmdContext, Command};
 pub use starcoin_config::StarcoinOpt;
+
+pub fn add_command(
+    context: CmdContext<CliState, StarcoinOpt>,
+) -> CmdContext<CliState, StarcoinOpt> {
+    context
+        .command(
+            Command::with_name("wallet")
+                .subcommand(wallet::CreateCommand)
+                .subcommand(wallet::ShowCommand)
+                .subcommand(wallet::TransferCommand)
+                .subcommand(wallet::AcceptCoinCommand)
+                .subcommand(wallet::ListCommand)
+                .subcommand(wallet::PartialSignTxnCommand)
+                .subcommand(wallet::UnlockCommand)
+                .subcommand(wallet::ExportCommand)
+                .subcommand(wallet::ImportCommand)
+                .subcommand(wallet::ExecuteBuildInCommand),
+        )
+        .command(
+            Command::with_name("state")
+                .subcommand(state::GetCommand)
+                .subcommand(state::GetAccountCommand)
+                .subcommand(state::GetProofCommand)
+                .subcommand(state::GetRootCommand),
+        )
+        .command(
+            Command::with_name("node")
+                .subcommand(node::InfoCommand)
+                .subcommand(node::PeersCommand)
+                .subcommand(node::MetricsCommand),
+        )
+        .command(
+            Command::with_name("chain")
+                .subcommand(chain::ShowCommand)
+                .subcommand(chain::GetBlockByNumberCommand)
+                .subcommand(chain::ListBlockCommand)
+                .subcommand(chain::GetTransactionCommand)
+                .subcommand(chain::GetTxnByBlockCommand)
+                .subcommand(chain::GetTransactionInfoCommand)
+                .subcommand(chain::GetBlockCommand)
+                .subcommand(chain::BranchesCommand),
+        )
+        .command(
+            Command::with_name("dev")
+                .subcommand(dev::GetCoinCommand)
+                .subcommand(dev::CompileCommand)
+                .subcommand(dev::DeployCommand)
+                .subcommand(dev::ExecuteCommand)
+                .subcommand(dev::DryRunCommand)
+                .subcommand(dev::DeriveAddressCommand)
+                .subcommand(dev::GenerateMultisigTxnCommand)
+                .subcommand(dev::ExecuteMultiSignedTxnCommand)
+                .subcommand(dev::UpgradeStdlibCommand)
+                .subcommand(
+                    Command::with_name("subscribe")
+                        .subcommand(dev::SubscribeBlockCommand)
+                        .subcommand(dev::SubscribeEventCommand)
+                        .subcommand(dev::SubscribeNewTxnCommand),
+                ),
+        )
+        .command(
+            Command::with_name("debug")
+                .subcommand(
+                    Command::with_name("log")
+                        .subcommand(debug::LogLevelCommand)
+                        .subcommand(debug::LogPatternCommand),
+                )
+                .subcommand(debug::GenTxnCommand)
+                .subcommand(debug::PanicCommand),
+        )
+}

--- a/cmd/starcoin/src/main.rs
+++ b/cmd/starcoin/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 use anyhow::Result;
-use scmd::{CmdContext, Command};
+use scmd::CmdContext;
 use starcoin_cmd::*;
 use starcoin_cmd::{CliState, StarcoinOpt};
 use starcoin_config::Connect;
@@ -77,73 +77,7 @@ fn run() -> Result<()> {
             }
         },
     );
-    context
-        .command(
-            Command::with_name("wallet")
-                .subcommand(wallet::CreateCommand)
-                .subcommand(wallet::ShowCommand)
-                .subcommand(wallet::TransferCommand)
-                .subcommand(wallet::AcceptCoinCommand)
-                .subcommand(wallet::ListCommand)
-                .subcommand(wallet::PartialSignTxnCommand)
-                .subcommand(wallet::UnlockCommand)
-                .subcommand(wallet::ExportCommand)
-                .subcommand(wallet::ImportCommand)
-                .subcommand(wallet::ExecuteBuildInCommand),
-        )
-        .command(
-            Command::with_name("state")
-                .subcommand(state::GetCommand)
-                .subcommand(state::GetAccountCommand)
-                .subcommand(state::GetProofCommand)
-                .subcommand(state::GetRootCommand),
-        )
-        .command(
-            Command::with_name("node")
-                .subcommand(node::InfoCommand)
-                .subcommand(node::PeersCommand)
-                .subcommand(node::MetricsCommand),
-        )
-        .command(
-            Command::with_name("chain")
-                .subcommand(chain::ShowCommand)
-                .subcommand(chain::GetBlockByNumberCommand)
-                .subcommand(chain::ListBlockCommand)
-                .subcommand(chain::GetTransactionCommand)
-                .subcommand(chain::GetTxnByBlockCommand)
-                .subcommand(chain::GetTransactionInfoCommand)
-                .subcommand(chain::GetBlockCommand)
-                .subcommand(chain::BranchesCommand),
-        )
-        .command(
-            Command::with_name("dev")
-                .subcommand(dev::GetCoinCommand)
-                .subcommand(dev::CompileCommand)
-                .subcommand(dev::DeployCommand)
-                .subcommand(dev::ExecuteCommand)
-                .subcommand(dev::DryRunCommand)
-                .subcommand(dev::DeriveAddressCommand)
-                .subcommand(dev::GenerateMultisigTxnCommand)
-                .subcommand(dev::ExecuteMultiSignedTxnCommand)
-                .subcommand(dev::UpgradeStdlibCommand)
-                .subcommand(
-                    Command::with_name("subscribe")
-                        .subcommand(dev::SubscribeBlockCommand)
-                        .subcommand(dev::SubscribeEventCommand)
-                        .subcommand(dev::SubscribeNewTxnCommand),
-                ),
-        )
-        .command(
-            Command::with_name("debug")
-                .subcommand(
-                    Command::with_name("log")
-                        .subcommand(debug::LogLevelCommand)
-                        .subcommand(debug::LogPatternCommand),
-                )
-                .subcommand(debug::GenTxnCommand)
-                .subcommand(debug::PanicCommand),
-        )
-        .exec();
+    add_command(context).exec();
     Ok(())
 }
 

--- a/testsuite/Cargo.toml
+++ b/testsuite/Cargo.toml
@@ -47,6 +47,7 @@ starcoin-wallet-api= {path ="../wallet/api"}
 starcoin-state-api = {path = "../state/api"}
 cucumber = { package = "cucumber_rust", version = "^0.6.0" }
 gherkin_rust ="0.8.0"
+jsonpath = "0.1.1"
 
 [dev-dependencies]
 

--- a/testsuite/features/cmd.feature
+++ b/testsuite/features/cmd.feature
@@ -53,4 +53,27 @@ Feature: cmd integration test
       | wallet create -p dssss |
       | wallet show |
 
+  Scenario Outline: [cmd]  cli continuous 1
+    Then cmd: "wallet create -p dssss $.address"
+    Then cmd: "wallet show $.account.address"
+    Then cmd: "wallet unlock -p dssss $.account.address"
+
+    Examples:
+      |  |
+
+  Scenario Outline: [cmd]  cli continuous 2
+    Then cmd: "chain show $.head_block"
+    Then cmd: "chain get_block $.author"
+    Then cmd: "wallet show $.account.address"
+
+    Examples:
+      |  |
+
+  Scenario Outline: [cmd]  cli continuous 3
+    Then cmd: "chain show $.head_block"
+    Then cmd: "chain get_block $.author"
+    Then cmd: "wallet show $.account.address"
+
+    Examples:
+      |  |
 

--- a/testsuite/tests/integration.rs
+++ b/testsuite/tests/integration.rs
@@ -29,6 +29,7 @@ pub struct MyWorld {
     txn_account: Option<WalletAccount>,
     node_handle: Option<NodeHandle>,
     default_address: Option<AccountAddress>,
+    cmd_value: Option<Vec<String>>,
 }
 impl MyWorld {
     pub fn storage(&self) -> Option<&Storage> {


### PR DESCRIPTION
通过 cargo test --test integration -e cmd 命令单独执行，目前加了三个回环用例：
参考 Scenario Outline: [cmd]  cli continuous 1-3
以后添加需要注意修改 jsonpath的解析参数，例如：$.account.address
