### PR TITLE
network: Unify peer_id

### DIFF
--- a/network-rpc/src/tests.rs
+++ b/network-rpc/src/tests.rs
@@ -35,7 +35,7 @@ fn test_network_rpc() {
 
     let network_2 = handle2.start_handle().network.clone();
     // network rpc client for chain 1
-    let peer_id_2 = network_2.identify().clone();
+    let peer_id_2 = network_2.identify();
     let client = starcoin_gen_client::NetworkRpcClient::new(network_1);
 
     let access_path =
@@ -44,7 +44,7 @@ fn test_network_rpc() {
     let req = GetBlockHeadersByNumber::new(1, 1, 1);
     let resp: Vec<BlockHeader> = block_on(async {
         client
-            .get_headers_by_number(peer_id_2.clone().into(), req)
+            .get_headers_by_number(peer_id_2.clone(), req)
             .await
             .unwrap()
     });
@@ -57,7 +57,7 @@ fn test_network_rpc() {
     };
     let state_with_proof: StateWithProof = block_on(async {
         client
-            .get_state_with_proof(peer_id_2.clone().into(), state_req)
+            .get_state_with_proof(peer_id_2.clone(), state_req)
             .await
             .unwrap()
     });
@@ -72,11 +72,7 @@ fn test_network_rpc() {
     let rpc_info = starcoin_gen_client::get_rpc_info();
     debug!("{:?}", rpc_info);
 
-    let ping = block_on(async {
-        client
-            .ping(peer_id_2.clone().into(), "hello".to_string())
-            .await
-    });
+    let ping = block_on(async { client.ping(peer_id_2.clone(), "hello".to_string()).await });
     match ping {
         Err(e) => debug!("{}", e),
         Ok(_) => panic!(""),

--- a/network/api/src/lib.rs
+++ b/network/api/src/lib.rs
@@ -1,12 +1,12 @@
 use crate::messages::PeerMessage;
 use anyhow::*;
-pub use libp2p::{multiaddr::Multiaddr, PeerId};
+pub use libp2p::multiaddr::Multiaddr;
 use starcoin_types::system_events::NewHeadBlock;
 use std::time::Duration;
 
 pub mod messages;
-
 use async_trait::async_trait;
+pub use starcoin_types::peer_info::PeerId;
 use starcoin_types::peer_info::{PeerInfo, RpcInfo};
 use std::borrow::Cow;
 
@@ -24,7 +24,7 @@ pub trait NetworkService: Send + Sync + Clone + Sized + std::marker::Unpin {
         event: NewHeadBlock,
     ) -> Result<()>;
 
-    fn identify(&self) -> &PeerId;
+    fn identify(&self) -> PeerId;
 
     async fn send_request_bytes(
         &self,

--- a/sync/src/block_connector/mod.rs
+++ b/sync/src/block_connector/mod.rs
@@ -223,7 +223,7 @@ where
                             if block_id == current_block_id {
                                 self.chain_reader
                                     .clone()
-                                    .try_connect_without_execute(block.clone(), peer_id.into())
+                                    .try_connect_without_execute(block.clone(), peer_id)
                                     .await
                             } else {
                                 Err(ConnectBlockError::VerifyBlockFailed(
@@ -259,7 +259,7 @@ where
                     if pivot_id == &parent_id {
                         self.chain_reader
                             .clone()
-                            .try_connect_without_execute(block.clone(), peer_id.into())
+                            .try_connect_without_execute(block.clone(), peer_id)
                             .await
                     } else {
                         Err(ConnectBlockError::VerifyBlockFailed(

--- a/sync/src/block_sync/mod.rs
+++ b/sync/src/block_sync/mod.rs
@@ -217,9 +217,7 @@ where
 
                 let event =
                     match get_headers(&network, &rpc_client, get_headers_req, next_number).await {
-                        Ok((headers, peer_id)) => {
-                            SyncDataEvent::new_header_event(headers, peer_id.into())
-                        }
+                        Ok((headers, peer_id)) => SyncDataEvent::new_header_event(headers, peer_id),
                         Err(e) => {
                             error!("Sync headers err: {:?}", e);
                             Delay::new(Duration::from_secs(1)).await;
@@ -248,7 +246,7 @@ where
                 let event =
                     match get_body_by_hash(&rpc_client, &network, block_idlist, max_height).await {
                         Ok((bodies, peer_id)) => {
-                            SyncDataEvent::new_body_event(bodies, Vec::new(), peer_id.into())
+                            SyncDataEvent::new_body_event(bodies, Vec::new(), peer_id)
                         }
                         Err(e) => {
                             error!("Sync bodies err: {:?}", e);
@@ -324,9 +322,7 @@ where
             loop {
                 let block = blocks.pop();
                 if let Some(b) = block {
-                    downloader
-                        .connect_block_and_child(b, peer_id.clone().into())
-                        .await;
+                    downloader.connect_block_and_child(b, peer_id.clone()).await;
                 } else {
                     break;
                 }

--- a/sync/src/download.rs
+++ b/sync/src/download.rs
@@ -540,7 +540,7 @@ where
     ) -> Result<Option<BlockHeader>> {
         let mut ancestor_header = None;
         let peer_info = network
-            .get_peer(&peer_id.clone().into())
+            .get_peer(&peer_id.clone())
             .await?
             .ok_or_else(|| format_err!("get peer {:?} not exist.", peer_id))?;
 
@@ -687,7 +687,7 @@ where
 
     pub async fn connect_block_and_child(&self, block: Block, peer_id: PeerId) {
         self.block_connector
-            .do_block_and_child(block, peer_id.into())
+            .do_block_and_child(block, peer_id)
             .await;
     }
 

--- a/test-helper/src/dummy_network_service.rs
+++ b/test-helper/src/dummy_network_service.rs
@@ -1,7 +1,6 @@
 use accumulator::AccumulatorNode;
 use anyhow::*;
-use libp2p::PeerId;
-use network_api::{messages::PeerMessage, NetworkService};
+use network_api::{messages::PeerMessage, NetworkService, PeerId};
 use starcoin_chain::BlockChain;
 use starcoin_crypto::HashValue;
 use starcoin_network_rpc_api::{
@@ -154,8 +153,8 @@ impl NetworkService for DummyNetworkService {
         Ok(())
     }
 
-    fn identify(&self) -> &PeerId {
-        &self.peer_id
+    fn identify(&self) -> PeerId {
+        self.peer_id.clone()
     }
 
     async fn send_request_bytes(


### PR DESCRIPTION
The external interface of Network uniformly uses the PeerId which implements serialization.