### PR TITLE
a build crate to gen starcoin_types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6836,6 +6836,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "starcoin-dataformat-generator"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde-generate",
+ "serde-reflection",
+ "serde_yaml",
+ "starcoin-crypto",
+ "starcoin-rpc-api",
+ "starcoin-types",
+]
+
+[[package]]
 name = "starcoin-decrypt"
 version = "0.5.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ members = [
     "cmd/tx-factory",
     "cmd/miner_client",
     "cmd/generator",
+    "dataformat-generator",
 ]
 
 [profile.dev]

--- a/dataformat-generator/Cargo.toml
+++ b/dataformat-generator/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "starcoin-dataformat-generator"
+version = "0.1.0"
+authors = ["Starcoin Core Dev <dev@starcoin.org>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+build = "build.rs"
+
+[dependencies]
+
+[build-dependencies]
+
+serde-generate = {git="https://github.com/starcoinorg/serde-reflection" , rev="128903725d0e057f1c8675b413995cf2e4bdf26d"}
+serde-reflection = {git="https://github.com/starcoinorg/serde-reflection" , rev="128903725d0e057f1c8675b413995cf2e4bdf26d"}
+
+starcoin-types = { path = "../types" }
+starcoin-crypto = {path = "../commons/crypto" }
+starcoin-rpc-api = {path = "../rpc/api" }
+anyhow = "1.0"
+serde = "1.0"
+serde_yaml = "0.8"

--- a/dataformat-generator/build.rs
+++ b/dataformat-generator/build.rs
@@ -1,0 +1,75 @@
+use anyhow::Result;
+use serde_reflection::{Error, Samples, Tracer, TracerConfig};
+use starcoin_crypto::ed25519::Ed25519PrivateKey;
+use starcoin_crypto::multi_ed25519::MultiEd25519PrivateKey;
+use starcoin_crypto::{HashValue, PrivateKey, SigningKey, Uniform};
+use starcoin_rpc_api::types::pubsub::Kind;
+use starcoin_types::access_path::{AccessPath, DataType};
+use starcoin_types::account_address::AccountAddress;
+use starcoin_types::account_config::AccountResource;
+use starcoin_types::block_metadata::BlockMetadata;
+use starcoin_types::contract_event::{ContractEvent, ContractEventV0};
+use starcoin_types::event::EventKey;
+use starcoin_types::language_storage::TypeTag;
+use starcoin_types::transaction::authenticator::TransactionAuthenticator;
+use starcoin_types::transaction::{
+    Module, Package, Script, ScriptABI, SignedUserTransaction, Transaction, TransactionArgument,
+    TransactionPayload,
+};
+use starcoin_types::write_set::{WriteOp, WriteSet};
+
+fn main() {
+    generate().unwrap();
+}
+
+fn generate() -> Result<(), Error> {
+    let mut tracer = Tracer::new(TracerConfig::default());
+    let mut samples = Samples::new();
+    tracer.trace_type::<AccessPath>(&samples)?;
+    tracer.trace_value(&mut samples, &HashValue::zero())?;
+    {
+        let pri_key = Ed25519PrivateKey::generate_for_testing();
+        tracer.trace_value(&mut samples, &pri_key)?;
+        tracer.trace_value(&mut samples, &pri_key.public_key())?;
+        tracer.trace_value(&mut samples, &pri_key.sign(&AccountAddress::random()))?;
+    }
+    {
+        let pri_key = MultiEd25519PrivateKey::generate_for_testing();
+        tracer.trace_value(&mut samples, &pri_key)?;
+        tracer.trace_value(&mut samples, &pri_key.public_key())?;
+        tracer.trace_value(&mut samples, &pri_key.sign(&AccountAddress::random()))?;
+    }
+
+    tracer.trace_type::<BlockMetadata>(&samples)?;
+
+    tracer.trace_value(&mut samples, &EventKey::random())?;
+    tracer.trace_type::<ContractEventV0>(&samples)?;
+    tracer.trace_type::<ContractEvent>(&samples)?;
+    tracer.trace_type::<WriteSet>(&samples)?;
+
+    tracer.trace_type::<TransactionArgument>(&samples)?;
+    tracer.trace_type::<TransactionAuthenticator>(&samples)?;
+    tracer.trace_type::<TransactionPayload>(&samples)?;
+    tracer.trace_type::<TypeTag>(&samples)?;
+    tracer.trace_type::<WriteOp>(&samples)?;
+    tracer.trace_type::<Script>(&samples)?;
+    tracer.trace_type::<Module>(&samples)?;
+    tracer.trace_type::<Package>(&samples)?;
+    tracer.trace_type::<SignedUserTransaction>(&samples)?;
+    tracer.trace_type::<Transaction>(&samples)?;
+
+    tracer.trace_type::<AccountResource>(&samples)?;
+
+    {
+        tracer.trace_type::<Kind>(&samples)?;
+    }
+
+    tracer.trace_type::<AccessPath>(&samples)?;
+    tracer.trace_type::<DataType>(&samples)?;
+    tracer.trace_type::<ScriptABI>(&samples)?;
+    let registry = tracer.registry()?;
+    let data = serde_yaml::to_string(&registry).unwrap();
+    std::fs::write("../etc/starcoin_types.yml", &data).unwrap();
+    // println!("{}", data);
+    Ok(())
+}

--- a/dataformat-generator/src/lib.rs
+++ b/dataformat-generator/src/lib.rs
@@ -1,0 +1,2 @@
+// Copyright (c) The Starcoin Core Contributors
+// SPDX-License-Identifier: Apache-2.0

--- a/etc/starcoin_types.yml
+++ b/etc/starcoin_types.yml
@@ -1,0 +1,273 @@
+---
+AccessPath:
+  STRUCT:
+    - address:
+        TYPENAME: AccountAddress
+    - path: BYTES
+AccountAddress:
+  NEWTYPESTRUCT:
+    TUPLEARRAY:
+      CONTENT: U8
+      SIZE: 16
+AccountResource:
+  STRUCT:
+    - authentication_key:
+        SEQ: U8
+    - withdrawal_capability:
+        OPTION:
+          TYPENAME: WithdrawCapabilityResource
+    - key_rotation_capability:
+        OPTION:
+          TYPENAME: KeyRotationCapabilityResource
+    - received_events:
+        TYPENAME: EventHandle
+    - sent_events:
+        TYPENAME: EventHandle
+    - accept_token_events:
+        TYPENAME: EventHandle
+    - sequence_number: U64
+ArgumentABI:
+  STRUCT:
+    - name: STR
+    - type_tag:
+        TYPENAME: TypeTag
+BlockMetadata:
+  STRUCT:
+    - parent_hash:
+        TYPENAME: HashValue
+    - timestamp: U64
+    - author:
+        TYPENAME: AccountAddress
+    - author_public_key:
+        OPTION:
+          TYPENAME: Ed25519PublicKey
+    - uncles: U64
+    - number: U64
+    - chain_id:
+        TYPENAME: ChainId
+ChainId:
+  STRUCT:
+    - id: U8
+ContractEvent:
+  ENUM:
+    0:
+      V0:
+        NEWTYPE:
+          TYPENAME: ContractEventV0
+ContractEventV0:
+  STRUCT:
+    - key:
+        TYPENAME: EventKey
+    - sequence_number: U64
+    - type_tag:
+        TYPENAME: TypeTag
+    - event_data: BYTES
+DataType:
+  ENUM:
+    0:
+      CODE: UNIT
+    1:
+      RESOURCE: UNIT
+Ed25519PrivateKey:
+  NEWTYPESTRUCT: BYTES
+Ed25519PublicKey:
+  NEWTYPESTRUCT: BYTES
+Ed25519Signature:
+  NEWTYPESTRUCT: BYTES
+EventHandle:
+  STRUCT:
+    - count: U64
+    - key:
+        TYPENAME: EventKey
+EventKey:
+  NEWTYPESTRUCT: BYTES
+HashValue:
+  NEWTYPESTRUCT: BYTES
+Identifier:
+  NEWTYPESTRUCT: STR
+KeyRotationCapabilityResource:
+  STRUCT:
+    - account_address:
+        TYPENAME: AccountAddress
+Kind:
+  ENUM:
+    0:
+      newHeads: UNIT
+    1:
+      events: UNIT
+    2:
+      newPendingTransactions: UNIT
+    3:
+      newMintBlock: UNIT
+Module:
+  STRUCT:
+    - code: BYTES
+MultiEd25519PrivateKey:
+  NEWTYPESTRUCT: BYTES
+MultiEd25519PublicKey:
+  NEWTYPESTRUCT: BYTES
+MultiEd25519Signature:
+  NEWTYPESTRUCT: BYTES
+Package:
+  STRUCT:
+    - package_address:
+        TYPENAME: AccountAddress
+    - modules:
+        SEQ:
+          TYPENAME: Module
+    - init_script:
+        OPTION:
+          TYPENAME: Script
+RawUserTransaction:
+  STRUCT:
+    - sender:
+        TYPENAME: AccountAddress
+    - sequence_number: U64
+    - payload:
+        TYPENAME: TransactionPayload
+    - max_gas_amount: U64
+    - gas_unit_price: U64
+    - gas_token_code: STR
+    - expiration_timestamp_secs: U64
+    - chain_id:
+        TYPENAME: ChainId
+Script:
+  STRUCT:
+    - code: BYTES
+    - ty_args:
+        SEQ:
+          TYPENAME: TypeTag
+    - args:
+        SEQ:
+          TYPENAME: TransactionArgument
+ScriptABI:
+  STRUCT:
+    - name: STR
+    - doc: STR
+    - code: BYTES
+    - ty_args:
+        SEQ:
+          TYPENAME: TypeArgumentABI
+    - args:
+        SEQ:
+          TYPENAME: ArgumentABI
+SignedUserTransaction:
+  STRUCT:
+    - raw_txn:
+        TYPENAME: RawUserTransaction
+    - authenticator:
+        TYPENAME: TransactionAuthenticator
+StructTag:
+  STRUCT:
+    - address:
+        TYPENAME: AccountAddress
+    - module:
+        TYPENAME: Identifier
+    - name:
+        TYPENAME: Identifier
+    - type_params:
+        SEQ:
+          TYPENAME: TypeTag
+Transaction:
+  ENUM:
+    0:
+      UserTransaction:
+        NEWTYPE:
+          TYPENAME: SignedUserTransaction
+    1:
+      BlockMetadata:
+        NEWTYPE:
+          TYPENAME: BlockMetadata
+TransactionArgument:
+  ENUM:
+    0:
+      U8:
+        NEWTYPE: U8
+    1:
+      U64:
+        NEWTYPE: U64
+    2:
+      U128:
+        NEWTYPE: U128
+    3:
+      Address:
+        NEWTYPE:
+          TYPENAME: AccountAddress
+    4:
+      U8Vector:
+        NEWTYPE: BYTES
+    5:
+      Bool:
+        NEWTYPE: BOOL
+TransactionAuthenticator:
+  ENUM:
+    0:
+      Ed25519:
+        STRUCT:
+          - public_key:
+              TYPENAME: Ed25519PublicKey
+          - signature:
+              TYPENAME: Ed25519Signature
+    1:
+      MultiEd25519:
+        STRUCT:
+          - public_key:
+              TYPENAME: MultiEd25519PublicKey
+          - signature:
+              TYPENAME: MultiEd25519Signature
+TransactionPayload:
+  ENUM:
+    0:
+      Script:
+        NEWTYPE:
+          TYPENAME: Script
+    1:
+      Package:
+        NEWTYPE:
+          TYPENAME: Package
+TypeArgumentABI:
+  STRUCT:
+    - name: STR
+TypeTag:
+  ENUM:
+    0:
+      Bool: UNIT
+    1:
+      U8: UNIT
+    2:
+      U64: UNIT
+    3:
+      U128: UNIT
+    4:
+      Address: UNIT
+    5:
+      Signer: UNIT
+    6:
+      Vector:
+        NEWTYPE:
+          TYPENAME: TypeTag
+    7:
+      Struct:
+        NEWTYPE:
+          TYPENAME: StructTag
+WithdrawCapabilityResource:
+  STRUCT:
+    - account_address:
+        TYPENAME: AccountAddress
+WriteOp:
+  ENUM:
+    0:
+      Deletion: UNIT
+    1:
+      Value:
+        NEWTYPE: BYTES
+WriteSet:
+  NEWTYPESTRUCT:
+    TYPENAME: WriteSetMut
+WriteSetMut:
+  STRUCT:
+    - write_set:
+        SEQ:
+          TUPLE:
+            - TYPENAME: AccessPath
+            - TYPENAME: WriteOp

--- a/vm/types/src/transaction/mod.rs
+++ b/vm/types/src/transaction/mod.rs
@@ -38,7 +38,9 @@ pub mod authenticator {
 use crate::account_config::STC_TOKEN_CODE_STR;
 pub use error::CallError;
 pub use error::Error as TransactionError;
-pub use libra_types::transaction::{Module, Script};
+pub use libra_types::transaction::{
+    ArgumentABI, Module, Script, ScriptABI, TypeArgumentABI, SCRIPT_HASH_LENGTH,
+};
 pub use package::Package;
 pub use pending_transaction::{Condition, PendingTransaction};
 pub use transaction_argument::{


### PR DESCRIPTION
Use serde-reflection to generate starcoin_types.yml.
meant to replace the handwriting located in testsuite.