### PR TITLE
[stdlib] Fix typo in PackageTxnManager.move and the corresponding PackageTxnManager.md

### DIFF
--- a/vm/stdlib/modules/PackageTxnManager.move
+++ b/vm/stdlib/modules/PackageTxnManager.move
@@ -232,7 +232,7 @@ address 0x1 {
             aborts_if false;
         }
 
-        spec define sepc_get_module_upgrade_strategy(module_address: address): u8 {
+        spec define spec_get_module_upgrade_strategy(module_address: address): u8 {
             if (exists<ModuleUpgradeStrategy>(module_address)) {
                 global<ModuleUpgradeStrategy>(module_address).strategy
             }else{
@@ -252,7 +252,7 @@ address 0x1 {
             aborts_if false;
         }
 
-        spec define sepc_get_upgrade_plan(module_address: address): Option<UpgradePlan> {
+        spec define spec_get_upgrade_plan(module_address: address): Option<UpgradePlan> {
             if (exists<TwoPhaseUpgrade>(module_address)) {
                 global<TwoPhaseUpgrade>(module_address).plan
             }else{
@@ -288,11 +288,11 @@ address 0x1 {
             package_address: address;
             package_hash: vector<u8>;
             aborts_if spec_get_module_maintainer(package_address) != sender;
-            aborts_if sepc_get_module_upgrade_strategy(package_address) == 3;
-            aborts_if sepc_get_module_upgrade_strategy(package_address) == 1 && Option::spec_is_none(sepc_get_upgrade_plan(package_address));
-            aborts_if sepc_get_module_upgrade_strategy(package_address) == 1 && Option::spec_get(sepc_get_upgrade_plan(package_address)).package_hash != package_hash;
-            aborts_if sepc_get_module_upgrade_strategy(package_address) == 1 && !exists<Block::BlockMetadata>(CoreAddresses::GENESIS_ADDRESS());
-            aborts_if sepc_get_module_upgrade_strategy(package_address) == 1 && Option::spec_get(sepc_get_upgrade_plan(package_address)).active_after_number > global<Block::BlockMetadata>(CoreAddresses::GENESIS_ADDRESS()).number;
+            aborts_if spec_get_module_upgrade_strategy(package_address) == 3;
+            aborts_if spec_get_module_upgrade_strategy(package_address) == 1 && Option::spec_is_none(spec_get_upgrade_plan(package_address));
+            aborts_if spec_get_module_upgrade_strategy(package_address) == 1 && Option::spec_get(spec_get_upgrade_plan(package_address)).package_hash != package_hash;
+            aborts_if spec_get_module_upgrade_strategy(package_address) == 1 && !exists<Block::BlockMetadata>(CoreAddresses::GENESIS_ADDRESS());
+            aborts_if spec_get_module_upgrade_strategy(package_address) == 1 && Option::spec_get(spec_get_upgrade_plan(package_address)).active_after_number > global<Block::BlockMetadata>(CoreAddresses::GENESIS_ADDRESS()).number;
         }
 
         fun finish_upgrade_plan(package_address: address) acquires TwoPhaseUpgrade {
@@ -330,7 +330,7 @@ address 0x1 {
 
         spec fun package_txn_epilogue {
             aborts_if Signer::address_of(account) != CoreAddresses::SPEC_GENESIS_ADDRESS();
-            aborts_if sepc_get_module_upgrade_strategy(package_address) == 1
+            aborts_if spec_get_module_upgrade_strategy(package_address) == 1
                     && success && !exists<TwoPhaseUpgrade>(package_address);
     }
 

--- a/vm/stdlib/modules/doc/PackageTxnManager.md
+++ b/vm/stdlib/modules/doc/PackageTxnManager.md
@@ -1071,10 +1071,10 @@ Package txn finished, and clean UpgradePlan
 
 
 
-<a name="0x1_PackageTxnManager_sepc_get_module_upgrade_strategy"></a>
+<a name="0x1_PackageTxnManager_spec_get_module_upgrade_strategy"></a>
 
 
-<pre><code><b>define</b> <a href="PackageTxnManager.md#0x1_PackageTxnManager_sepc_get_module_upgrade_strategy">sepc_get_module_upgrade_strategy</a>(module_address: address): u8 {
+<pre><code><b>define</b> <a href="PackageTxnManager.md#0x1_PackageTxnManager_spec_get_module_upgrade_strategy">spec_get_module_upgrade_strategy</a>(module_address: address): u8 {
    <b>if</b> (<b>exists</b>&lt;<a href="PackageTxnManager.md#0x1_PackageTxnManager_ModuleUpgradeStrategy">ModuleUpgradeStrategy</a>&gt;(module_address)) {
        <b>global</b>&lt;<a href="PackageTxnManager.md#0x1_PackageTxnManager_ModuleUpgradeStrategy">ModuleUpgradeStrategy</a>&gt;(module_address).strategy
    }<b>else</b>{
@@ -1102,10 +1102,10 @@ Package txn finished, and clean UpgradePlan
 
 
 
-<a name="0x1_PackageTxnManager_sepc_get_upgrade_plan"></a>
+<a name="0x1_PackageTxnManager_spec_get_upgrade_plan"></a>
 
 
-<pre><code><b>define</b> <a href="PackageTxnManager.md#0x1_PackageTxnManager_sepc_get_upgrade_plan">sepc_get_upgrade_plan</a>(module_address: address): <a href="Option.md#0x1_Option">Option</a>&lt;<a href="PackageTxnManager.md#0x1_PackageTxnManager_UpgradePlan">UpgradePlan</a>&gt; {
+<pre><code><b>define</b> <a href="PackageTxnManager.md#0x1_PackageTxnManager_spec_get_upgrade_plan">spec_get_upgrade_plan</a>(module_address: address): <a href="Option.md#0x1_Option">Option</a>&lt;<a href="PackageTxnManager.md#0x1_PackageTxnManager_UpgradePlan">UpgradePlan</a>&gt; {
    <b>if</b> (<b>exists</b>&lt;<a href="PackageTxnManager.md#0x1_PackageTxnManager_TwoPhaseUpgrade">TwoPhaseUpgrade</a>&gt;(module_address)) {
        <b>global</b>&lt;<a href="PackageTxnManager.md#0x1_PackageTxnManager_TwoPhaseUpgrade">TwoPhaseUpgrade</a>&gt;(module_address).plan
    }<b>else</b>{
@@ -1141,11 +1141,11 @@ Package txn finished, and clean UpgradePlan
     package_address: address;
     package_hash: vector&lt;u8&gt;;
     <b>aborts_if</b> <a href="PackageTxnManager.md#0x1_PackageTxnManager_spec_get_module_maintainer">spec_get_module_maintainer</a>(package_address) != sender;
-    <b>aborts_if</b> <a href="PackageTxnManager.md#0x1_PackageTxnManager_sepc_get_module_upgrade_strategy">sepc_get_module_upgrade_strategy</a>(package_address) == 3;
-    <b>aborts_if</b> <a href="PackageTxnManager.md#0x1_PackageTxnManager_sepc_get_module_upgrade_strategy">sepc_get_module_upgrade_strategy</a>(package_address) == 1 && <a href="Option.md#0x1_Option_spec_is_none">Option::spec_is_none</a>(<a href="PackageTxnManager.md#0x1_PackageTxnManager_sepc_get_upgrade_plan">sepc_get_upgrade_plan</a>(package_address));
-    <b>aborts_if</b> <a href="PackageTxnManager.md#0x1_PackageTxnManager_sepc_get_module_upgrade_strategy">sepc_get_module_upgrade_strategy</a>(package_address) == 1 && <a href="Option.md#0x1_Option_spec_get">Option::spec_get</a>(<a href="PackageTxnManager.md#0x1_PackageTxnManager_sepc_get_upgrade_plan">sepc_get_upgrade_plan</a>(package_address)).package_hash != package_hash;
-    <b>aborts_if</b> <a href="PackageTxnManager.md#0x1_PackageTxnManager_sepc_get_module_upgrade_strategy">sepc_get_module_upgrade_strategy</a>(package_address) == 1 && !<b>exists</b>&lt;<a href="Block.md#0x1_Block_BlockMetadata">Block::BlockMetadata</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_GENESIS_ADDRESS">CoreAddresses::GENESIS_ADDRESS</a>());
-    <b>aborts_if</b> <a href="PackageTxnManager.md#0x1_PackageTxnManager_sepc_get_module_upgrade_strategy">sepc_get_module_upgrade_strategy</a>(package_address) == 1 && <a href="Option.md#0x1_Option_spec_get">Option::spec_get</a>(<a href="PackageTxnManager.md#0x1_PackageTxnManager_sepc_get_upgrade_plan">sepc_get_upgrade_plan</a>(package_address)).active_after_number &gt; <b>global</b>&lt;<a href="Block.md#0x1_Block_BlockMetadata">Block::BlockMetadata</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_GENESIS_ADDRESS">CoreAddresses::GENESIS_ADDRESS</a>()).number;
+    <b>aborts_if</b> <a href="PackageTxnManager.md#0x1_PackageTxnManager_spec_get_module_upgrade_strategy">spec_get_module_upgrade_strategy</a>(package_address) == 3;
+    <b>aborts_if</b> <a href="PackageTxnManager.md#0x1_PackageTxnManager_spec_get_module_upgrade_strategy">spec_get_module_upgrade_strategy</a>(package_address) == 1 && <a href="Option.md#0x1_Option_spec_is_none">Option::spec_is_none</a>(<a href="PackageTxnManager.md#0x1_PackageTxnManager_spec_get_upgrade_plan">spec_get_upgrade_plan</a>(package_address));
+    <b>aborts_if</b> <a href="PackageTxnManager.md#0x1_PackageTxnManager_spec_get_module_upgrade_strategy">spec_get_module_upgrade_strategy</a>(package_address) == 1 && <a href="Option.md#0x1_Option_spec_get">Option::spec_get</a>(<a href="PackageTxnManager.md#0x1_PackageTxnManager_spec_get_upgrade_plan">spec_get_upgrade_plan</a>(package_address)).package_hash != package_hash;
+    <b>aborts_if</b> <a href="PackageTxnManager.md#0x1_PackageTxnManager_spec_get_module_upgrade_strategy">spec_get_module_upgrade_strategy</a>(package_address) == 1 && !<b>exists</b>&lt;<a href="Block.md#0x1_Block_BlockMetadata">Block::BlockMetadata</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_GENESIS_ADDRESS">CoreAddresses::GENESIS_ADDRESS</a>());
+    <b>aborts_if</b> <a href="PackageTxnManager.md#0x1_PackageTxnManager_spec_get_module_upgrade_strategy">spec_get_module_upgrade_strategy</a>(package_address) == 1 && <a href="Option.md#0x1_Option_spec_get">Option::spec_get</a>(<a href="PackageTxnManager.md#0x1_PackageTxnManager_spec_get_upgrade_plan">spec_get_upgrade_plan</a>(package_address)).active_after_number &gt; <b>global</b>&lt;<a href="Block.md#0x1_Block_BlockMetadata">Block::BlockMetadata</a>&gt;(<a href="CoreAddresses.md#0x1_CoreAddresses_GENESIS_ADDRESS">CoreAddresses::GENESIS_ADDRESS</a>()).number;
 }
 </code></pre>
 
@@ -1196,6 +1196,6 @@ Package txn finished, and clean UpgradePlan
 
 
 <pre><code><b>aborts_if</b> <a href="Signer.md#0x1_Signer_address_of">Signer::address_of</a>(account) != <a href="CoreAddresses.md#0x1_CoreAddresses_SPEC_GENESIS_ADDRESS">CoreAddresses::SPEC_GENESIS_ADDRESS</a>();
-<b>aborts_if</b> <a href="PackageTxnManager.md#0x1_PackageTxnManager_sepc_get_module_upgrade_strategy">sepc_get_module_upgrade_strategy</a>(package_address) == 1
+<b>aborts_if</b> <a href="PackageTxnManager.md#0x1_PackageTxnManager_spec_get_module_upgrade_strategy">spec_get_module_upgrade_strategy</a>(package_address) == 1
         && success && !<b>exists</b>&lt;<a href="PackageTxnManager.md#0x1_PackageTxnManager_TwoPhaseUpgrade">TwoPhaseUpgrade</a>&gt;(package_address);
 </code></pre>


### PR DESCRIPTION
[stdlib] Fix typo:
sepc_get_upgrade_plan -> spec_get_upgrade_plan
sepc_get_module_upgrade_strategy -> spec_get_module_upgrade_strategy