### PR TITLE
 [sync] sync start cmd supports sync from specified peers.

### DIFF
--- a/cmd/starcoin/src/node/sync/start_cmd.rs
+++ b/cmd/starcoin/src/node/sync/start_cmd.rs
@@ -35,7 +35,7 @@ impl CommandAction for StartCommand {
         let client = ctx.state().client();
         client.sync_start(
             ctx.opt().force,
-            ctx.opt().peers.as_ref().cloned().unwrap_or(vec![]),
+            ctx.opt().peers.as_ref().cloned().unwrap_or_default(),
         )
     }
 }

--- a/cmd/starcoin/src/node/sync/start_cmd.rs
+++ b/cmd/starcoin/src/node/sync/start_cmd.rs
@@ -5,14 +5,19 @@ use crate::cli_state::CliState;
 use crate::StarcoinOpt;
 use anyhow::Result;
 use scmd::{CommandAction, ExecContext};
+use starcoin_types::peer_info::PeerId;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt, Default)]
 #[structopt(name = "start")]
 pub struct StartOpt {
-    #[structopt(long = "force")]
+    #[structopt(short = "f", long = "force")]
     /// if force is set, will cancel current sync task.
     force: bool,
+
+    /// if peers is not empty, will try sync with the special peers.
+    #[structopt(short = "p", long = "peer")]
+    peers: Option<Vec<PeerId>>,
 }
 
 pub struct StartCommand;
@@ -28,6 +33,9 @@ impl CommandAction for StartCommand {
         ctx: &ExecContext<Self::State, Self::GlobalOpt, Self::Opt>,
     ) -> Result<Self::ReturnItem> {
         let client = ctx.state().client();
-        client.sync_start(ctx.opt().force)
+        client.sync_start(
+            ctx.opt().force,
+            ctx.opt().peers.as_ref().cloned().unwrap_or(vec![]),
+        )
     }
 }

--- a/network/src/net.rs
+++ b/network/src/net.rs
@@ -244,7 +244,7 @@ pub fn build_network_service(
     let transport_config = TransportConfig::Normal {
         //TODO support enable mdns by config.
         enable_mdns: false,
-        allow_private_ipv4: true,
+        allow_private_ipv4: false,
         wasm_external_transport: None,
         use_yamux_flow_control: false,
     };

--- a/rpc/api/src/sync_manager.rs
+++ b/rpc/api/src/sync_manager.rs
@@ -5,6 +5,7 @@ pub use self::gen_client::Client as SyncManagerClient;
 use crate::FutureResult;
 use jsonrpc_derive::rpc;
 use starcoin_sync_api::SyncProgressReport;
+use starcoin_types::peer_info::PeerId;
 use starcoin_types::sync_status::SyncStatus;
 
 #[rpc]
@@ -16,7 +17,9 @@ pub trait SyncManagerApi {
     fn cancel(&self) -> FutureResult<()>;
 
     #[rpc(name = "sync.start")]
-    fn start(&self, force: bool) -> FutureResult<()>;
+    /// if `force` is true, will cancel current task and start a new task.
+    /// if peers is not empty, will try sync with the special peers.
+    fn start(&self, force: bool, peers: Vec<PeerId>) -> FutureResult<()>;
 
     #[rpc(name = "sync.progress")]
     fn progress(&self) -> FutureResult<Option<SyncProgressReport>>;

--- a/rpc/client/src/lib.rs
+++ b/rpc/client/src/lib.rs
@@ -764,9 +764,11 @@ impl RpcClient {
             .map_err(map_err)
     }
 
-    pub fn sync_start(&self, force: bool) -> anyhow::Result<()> {
-        self.call_rpc_blocking(|inner| async move { inner.sync_client.start(force).compat().await })
-            .map_err(map_err)
+    pub fn sync_start(&self, force: bool, peers: Vec<PeerId>) -> anyhow::Result<()> {
+        self.call_rpc_blocking(|inner| async move {
+            inner.sync_client.start(force, peers).compat().await
+        })
+        .map_err(map_err)
     }
 
     pub fn sync_cancel(&self) -> anyhow::Result<()> {

--- a/rpc/server/src/module/sync_manager_rpc.rs
+++ b/rpc/server/src/module/sync_manager_rpc.rs
@@ -7,6 +7,7 @@ use futures::FutureExt;
 use starcoin_rpc_api::sync_manager::SyncManagerApi;
 use starcoin_rpc_api::FutureResult;
 use starcoin_sync_api::{SyncAsyncService, SyncProgressReport};
+use starcoin_types::peer_info::PeerId;
 use starcoin_types::sync_status::SyncStatus;
 
 pub struct SyncManagerRpcImpl<S>
@@ -49,10 +50,10 @@ where
         Box::new(fut.boxed().compat())
     }
 
-    fn start(&self, force: bool) -> FutureResult<()> {
+    fn start(&self, force: bool, peers: Vec<PeerId>) -> FutureResult<()> {
         let service = self.service.clone();
         let fut = async move {
-            service.start(force).await?;
+            service.start(force, peers).await?;
             Ok(())
         }
         .map_err(map_err);

--- a/sync/api/src/lib.rs
+++ b/sync/api/src/lib.rs
@@ -88,6 +88,7 @@ impl ServiceRequest for SyncCancelRequest {
 #[derive(Debug, Clone)]
 pub struct SyncStartRequest {
     pub force: bool,
+    pub peers: Vec<PeerId>,
 }
 
 impl ServiceRequest for SyncStartRequest {

--- a/sync/api/src/service.rs
+++ b/sync/api/src/service.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use anyhow::Result;
 use starcoin_service_registry::{ActorService, ServiceHandler, ServiceRef};
+use starcoin_types::peer_info::PeerId;
 use starcoin_types::sync_status::SyncStatus;
 
 #[async_trait::async_trait]
@@ -13,7 +14,9 @@ pub trait SyncAsyncService: Clone + std::marker::Unpin + Send + Sync {
     async fn status(&self) -> Result<SyncStatus>;
     async fn progress(&self) -> Result<Option<SyncProgressReport>>;
     async fn cancel(&self) -> Result<()>;
-    async fn start(&self, force: bool) -> Result<()>;
+    /// if `force` is true, will cancel current task and start a new task.
+    /// if peers is not empty, will try sync with the special peers.
+    async fn start(&self, force: bool, peers: Vec<PeerId>) -> Result<()>;
 }
 
 pub trait SyncServiceHandler:
@@ -42,7 +45,7 @@ where
         self.send(SyncCancelRequest).await
     }
 
-    async fn start(&self, force: bool) -> Result<()> {
-        self.send(SyncStartRequest { force }).await?
+    async fn start(&self, force: bool, peers: Vec<PeerId>) -> Result<()> {
+        self.send(SyncStartRequest { force, peers }).await?
     }
 }

--- a/sync/src/block_connector/block_connector_service.rs
+++ b/sync/src/block_connector/block_connector_service.rs
@@ -125,7 +125,7 @@ impl EventHandler<Self, PeerNewBlock> for BlockConnectorService {
                                     block.header().number,
                                     peer_id
                                 );
-                                let _ = sync_service.notify(CheckSyncEvent::new());
+                                let _ = sync_service.notify(CheckSyncEvent::default());
                             }
                         }
                         e => warn!("BlockConnector fail: {:?}, peer_id:{:?}", e, peer_id),


### PR DESCRIPTION
1. [sync] sync start cmd supports sync from specified peers.
2. [network] Temporarily disable allow_private_ipv4 in TransportConfig.