### PR TITLE
review txpool&account rpc error code

### DIFF
--- a/cmd/faucet/src/faucet.rs
+++ b/cmd/faucet/src/faucet.rs
@@ -31,7 +31,7 @@ impl Faucet {
         amount: u128,
         receiver: AccountAddress,
         public_key: Vec<u8>,
-    ) -> Result<Result<(), anyhow::Error>> {
+    ) -> Result<()> {
         let chain_state_reader = RemoteStateReader::new(&self.client)?;
         let account_state_reader = AccountStateReader::new(&chain_state_reader);
         let account_resource = account_state_reader
@@ -55,7 +55,7 @@ impl Faucet {
             self.client.node_info()?.net.chain_id(),
         );
         let signed_tx = self.client.account_sign_txn(raw_tx)?;
-        let ret = self.client.submit_transaction(signed_tx)?;
-        Ok(ret)
+        self.client.submit_transaction(signed_tx)?;
+        Ok(())
     }
 }

--- a/cmd/faucet/src/web.rs
+++ b/cmd/faucet/src/web.rs
@@ -31,18 +31,14 @@ async fn handle_fund(faucet: &Faucet, query: &str) -> Response<Cursor<String>> {
     let query_param =
         unwrap_or_return!(parse_query(query), response_custom(400, "Invalid request"));
     info!("Fund query params: {:?}", query_param);
-    let ret = unwrap_or_return!(
-        faucet.transfer(
-            query_param.amount,
-            query_param.address,
-            query_param.public_key
-        ),
-        response_custom(500, "Inner error")
-    );
-    if ret.is_err() {
-        return response_custom(400, "Fund too frequently");
+    match faucet.transfer(
+        query_param.amount,
+        query_param.address,
+        query_param.public_key,
+    ) {
+        Ok(_) => response_custom(200, "Success"),
+        Err(e) => response_custom(400, &e.to_string()),
     }
-    response_custom(200, "Success")
 }
 
 pub async fn run(server: Server, faucet: Faucet) {

--- a/cmd/starcoin/src/account/accept_token_cmd.rs
+++ b/cmd/starcoin/src/account/accept_token_cmd.rs
@@ -92,10 +92,7 @@ impl CommandAction for AcceptTokenCommand {
 
         let signed_txn = client.account_sign_txn(accept_token_txn)?;
         let txn_hash = signed_txn.crypto_hash();
-        let succ = client.submit_transaction(signed_txn)?;
-        if let Err(e) = succ {
-            bail!("execute-txn is reject by node, reason: {}", &e)
-        }
+        client.submit_transaction(signed_txn)?;
         println!("txn {:#x} submitted.", txn_hash);
 
         if opt.blocking {

--- a/cmd/starcoin/src/account/execute_builtin_script_cmd.rs
+++ b/cmd/starcoin/src/account/execute_builtin_script_cmd.rs
@@ -124,10 +124,7 @@ impl CommandAction for ExecuteBuildInCommand {
 
         let signed_txn = client.account_sign_txn(script_txn)?;
         let txn_hash = signed_txn.crypto_hash();
-        let succ = client.submit_transaction(signed_txn)?;
-        if let Err(e) = succ {
-            bail!("execute-txn is reject by node, reason: {}", &e)
-        }
+        client.submit_transaction(signed_txn)?;
         println!("txn {:#x} submitted.", txn_hash);
 
         if opt.blocking {

--- a/cmd/starcoin/src/account/transfer_cmd.rs
+++ b/cmd/starcoin/src/account/transfer_cmd.rs
@@ -4,7 +4,7 @@
 use crate::cli_state::CliState;
 use crate::view::{ExecuteResultView, ExecutionOutputView};
 use crate::StarcoinOpt;
-use anyhow::{bail, format_err, Result};
+use anyhow::{format_err, Result};
 use scmd::{CommandAction, ExecContext};
 use starcoin_crypto::hash::PlainCryptoHash;
 use starcoin_crypto::{ed25519::Ed25519PublicKey, ValidCryptoMaterialStringExt};
@@ -137,10 +137,7 @@ impl CommandAction for TransferCommand {
         );
         let txn = client.account_sign_txn(raw_txn)?;
         let txn_hash = txn.crypto_hash();
-        let succ = client.submit_transaction(txn)?;
-        if let Err(e) = succ {
-            bail!("execute-txn is reject by node, reason: {}", &e)
-        }
+        client.submit_transaction(txn)?;
 
         let mut output_view = ExecutionOutputView::new(txn_hash);
 

--- a/cmd/starcoin/src/dev/deploy_cmd.rs
+++ b/cmd/starcoin/src/dev/deploy_cmd.rs
@@ -107,10 +107,8 @@ impl CommandAction for DeployCommand {
 
         let signed_txn = client.account_sign_txn(deploy_txn)?;
         let txn_hash = signed_txn.crypto_hash();
-        let succ = client.submit_transaction(signed_txn)?;
-        if let Err(e) = succ {
-            bail!("execute-txn is reject by node, reason: {}", &e)
-        }
+        client.submit_transaction(signed_txn)?;
+
         println!("txn {:#x} submitted.", txn_hash);
 
         if opt.blocking {

--- a/cmd/starcoin/src/dev/execute_cmd.rs
+++ b/cmd/starcoin/src/dev/execute_cmd.rs
@@ -229,10 +229,8 @@ impl CommandAction for ExecuteCommand {
             );
         }
         if !opt.dry_run {
-            let success = client.submit_transaction(signed_txn)?;
-            if let Err(e) = success {
-                bail!("execute-txn is reject by node, reason: {}", &e)
-            }
+            client.submit_transaction(signed_txn)?;
+
             println!("txn {:#x} submitted.", txn_hash);
 
             let mut output_view = ExecutionOutputView::new(txn_hash);

--- a/cmd/starcoin/src/dev/get_coin_cmd.rs
+++ b/cmd/starcoin/src/dev/get_coin_cmd.rs
@@ -94,10 +94,7 @@ impl CommandAction for GetCoinCommand {
         )?;
         let txn = client.account_sign_txn(raw_txn)?;
         let id = txn.crypto_hash();
-        let ret = client.submit_transaction(txn.clone())?;
-        if let Err(e) = ret {
-            bail!("execute-txn is reject by node, reason: {}", e)
-        }
+        client.submit_transaction(txn.clone())?;
         if !opt.no_blocking {
             ctx.state().watch_txn(id)?;
         }

--- a/cmd/starcoin/src/dev/sign_txn_helper.rs
+++ b/cmd/starcoin/src/dev/sign_txn_helper.rs
@@ -193,8 +193,8 @@ mod tests {
         cli_state
             .client()
             .submit_transaction(transfer_txn.clone())
-            .unwrap()
             .unwrap();
+
         sleep(Duration::from_millis(500));
         let block = node_handle.generate_block().unwrap();
         assert!(block.transactions().contains(&transfer_txn));
@@ -258,8 +258,8 @@ mod tests {
         cli_state
             .client()
             .submit_transaction(proposal_txn.clone())
-            .unwrap()
             .unwrap();
+
         sleep(Duration::from_millis(500));
         let block = node_handle.generate_block().unwrap();
         assert!(block.transactions().contains(&proposal_txn));
@@ -313,8 +313,8 @@ mod tests {
         cli_state
             .client()
             .submit_transaction(vote_txn.clone())
-            .unwrap()
             .unwrap();
+
         sleep(Duration::from_millis(500));
         let block = node_handle.generate_block().unwrap();
         assert!(block.transactions().contains(&vote_txn));
@@ -345,8 +345,8 @@ mod tests {
         cli_state
             .client()
             .submit_transaction(queue_txn.clone())
-            .unwrap()
             .unwrap();
+
         sleep(Duration::from_millis(500));
         let block = node_handle.generate_block().unwrap();
         assert!(block.transactions().contains(&queue_txn));
@@ -378,8 +378,8 @@ mod tests {
         cli_state
             .client()
             .submit_transaction(plan_txn.clone())
-            .unwrap()
             .unwrap();
+
         sleep(Duration::from_millis(500));
         let block = node_handle.generate_block().unwrap();
         assert!(block.transactions().contains(&plan_txn));
@@ -403,8 +403,8 @@ mod tests {
         cli_state
             .client()
             .submit_transaction(package_txn.clone())
-            .unwrap()
             .unwrap();
+
         sleep(Duration::from_millis(500));
         let block = node_handle.generate_block().unwrap();
         assert!(block.transactions().contains(&package_txn));
@@ -484,8 +484,8 @@ mod tests {
         cli_state
             .client()
             .submit_transaction(only_new_module_strategy_txn.clone())
-            .unwrap()
             .unwrap();
+
         sleep(Duration::from_millis(500));
         let block = node_handle.generate_block().unwrap();
         assert!(block.transactions().contains(&only_new_module_strategy_txn));
@@ -523,8 +523,8 @@ mod tests {
         cli_state
             .client()
             .submit_transaction(package_txn_1.clone())
-            .unwrap()
             .unwrap();
+
         sleep(Duration::from_millis(500));
         let block = node_handle.generate_block().unwrap();
         assert!(block.transactions().contains(&package_txn_1));
@@ -559,10 +559,8 @@ mod tests {
             TransactionPayload::Package(test_upgrade_module_package_2),
         )
         .unwrap();
-        let result = cli_state
-            .client()
-            .submit_transaction(package_txn_2)
-            .unwrap();
+        let result = cli_state.client().submit_transaction(package_txn_2);
+
         assert!(result.is_err());
         info!("error : {:?}", result);
 

--- a/cmd/starcoin/src/dev/submit_multisig_txn_cmd.rs
+++ b/cmd/starcoin/src/dev/submit_multisig_txn_cmd.rs
@@ -44,10 +44,8 @@ impl CommandAction for ExecuteMultiSignedTxnCommand {
         let client = ctx.state().client();
         let signed_txn = assemble_multisig_txn(opt.partial_signed_txns.clone())?;
         let txn_hash = signed_txn.crypto_hash();
-        let succ = client.submit_transaction(signed_txn)?;
-        if let Err(e) = succ {
-            bail!("execute-txn is reject by node, reason: {}", &e)
-        }
+        client.submit_transaction(signed_txn)?;
+
         println!("txn {:#x} submitted.", txn_hash);
 
         if opt.blocking {

--- a/cmd/starcoin/src/dev/upgrade_module_exe_cmd.rs
+++ b/cmd/starcoin/src/dev/upgrade_module_exe_cmd.rs
@@ -95,10 +95,8 @@ impl CommandAction for UpgradeModuleExeCommand {
                 TransactionPayload::Package(upgrade_package),
             )?;
             let txn_hash = signed_txn.crypto_hash();
-            let success = cli_state.client().submit_transaction(signed_txn)?;
-            if let Err(e) = success {
-                bail!("execute-txn is reject by node, reason: {}", &e)
-            }
+            cli_state.client().submit_transaction(signed_txn)?;
+
             println!("txn {:#x} submitted.", txn_hash);
 
             if opt.blocking {

--- a/cmd/starcoin/src/dev/upgrade_module_plan_cmd.rs
+++ b/cmd/starcoin/src/dev/upgrade_module_plan_cmd.rs
@@ -4,7 +4,7 @@
 use crate::cli_state::CliState;
 use crate::dev::sign_txn_helper::sign_txn_with_account_by_rpc_client;
 use crate::StarcoinOpt;
-use anyhow::{bail, Result};
+use anyhow::Result;
 use scmd::{CommandAction, ExecContext};
 use starcoin_crypto::hash::{HashValue, PlainCryptoHash};
 use starcoin_transaction_builder::build_module_upgrade_plan;
@@ -97,10 +97,8 @@ impl CommandAction for UpgradeModulePlanCommand {
             TransactionPayload::Script(module_upgrade_plan),
         )?;
         let txn_hash = signed_txn.crypto_hash();
-        let success = cli_state.client().submit_transaction(signed_txn)?;
-        if let Err(e) = success {
-            bail!("execute-txn is reject by node, reason: {}", &e)
-        }
+        cli_state.client().submit_transaction(signed_txn)?;
+
         println!("txn {:#x} submitted.", txn_hash);
 
         if opt.blocking {

--- a/cmd/starcoin/src/dev/upgrade_module_proposal_cmd.rs
+++ b/cmd/starcoin/src/dev/upgrade_module_proposal_cmd.rs
@@ -115,10 +115,8 @@ impl CommandAction for UpgradeModuleProposalCommand {
                 TransactionPayload::Script(module_upgrade_proposal),
             )?;
             let txn_hash = signed_txn.crypto_hash();
-            let success = cli_state.client().submit_transaction(signed_txn)?;
-            if let Err(e) = success {
-                bail!("execute-txn is reject by node, reason: {}", &e)
-            }
+            cli_state.client().submit_transaction(signed_txn)?;
+
             println!("txn {:#x} submitted.", txn_hash);
 
             if opt.blocking {

--- a/cmd/starcoin/src/dev/upgrade_module_queue_cmd.rs
+++ b/cmd/starcoin/src/dev/upgrade_module_queue_cmd.rs
@@ -4,7 +4,7 @@
 use crate::cli_state::CliState;
 use crate::dev::sign_txn_helper::sign_txn_with_account_by_rpc_client;
 use crate::StarcoinOpt;
-use anyhow::{bail, Result};
+use anyhow::Result;
 use scmd::{CommandAction, ExecContext};
 use starcoin_crypto::hash::{HashValue, PlainCryptoHash};
 use starcoin_transaction_builder::build_module_upgrade_queue;
@@ -97,10 +97,8 @@ impl CommandAction for UpgradeModuleQueueCommand {
             TransactionPayload::Script(module_upgrade_queue),
         )?;
         let txn_hash = signed_txn.crypto_hash();
-        let success = cli_state.client().submit_transaction(signed_txn)?;
-        if let Err(e) = success {
-            bail!("execute-txn is reject by node, reason: {}", &e)
-        }
+        cli_state.client().submit_transaction(signed_txn)?;
+
         println!("txn {:#x} submitted.", txn_hash);
 
         if opt.blocking {

--- a/commons/scs/src/lib.rs
+++ b/commons/scs/src/lib.rs
@@ -47,7 +47,7 @@ where
     }
 }
 
-pub use lcs::{is_human_readable, serialize_into, serialized_size};
+pub use lcs::{is_human_readable, serialize_into, serialized_size, Error};
 
 #[cfg(test)]
 mod tests {

--- a/rpc/api/src/txpool/mod.rs
+++ b/rpc/api/src/txpool/mod.rs
@@ -6,16 +6,17 @@ use jsonrpc_derive::rpc;
 use starcoin_types::transaction::SignedUserTransaction;
 
 pub use self::gen_client::Client as TxPoolClient;
+use starcoin_crypto::HashValue;
 use starcoin_txpool_api::TxPoolStatus;
 use starcoin_types::account_address::AccountAddress;
 
 #[rpc]
 pub trait TxPoolApi {
     #[rpc(name = "txpool.submit_transaction")]
-    fn submit_transaction(&self, tx: SignedUserTransaction) -> FutureResult<Result<(), String>>;
+    fn submit_transaction(&self, tx: SignedUserTransaction) -> FutureResult<HashValue>;
 
     #[rpc(name = "txpool.submit_hex_transaction")]
-    fn submit_hex_transaction(&self, tx: String) -> FutureResult<Result<(), String>>;
+    fn submit_hex_transaction(&self, tx: String) -> FutureResult<HashValue>;
 
     /// Returns next valid sequence number for given sender
     /// or `None` if there are no pending transactions from that sender in txpool.

--- a/rpc/client/src/lib.rs
+++ b/rpc/client/src/lib.rs
@@ -255,14 +255,10 @@ impl RpcClient {
         .map_err(map_err)
     }
 
-    pub fn submit_transaction(
-        &self,
-        txn: SignedUserTransaction,
-    ) -> anyhow::Result<Result<(), anyhow::Error>> {
+    pub fn submit_transaction(&self, txn: SignedUserTransaction) -> anyhow::Result<HashValue> {
         self.call_rpc_blocking(|inner| async move {
             inner.txpool_client.submit_transaction(txn).compat().await
         })
-        .map(|r| r.map_err(|e| anyhow::format_err!("{}", e)))
         .map_err(map_err)
     }
     //TODO should split client for different api ?

--- a/rpc/server/src/module/mod.rs
+++ b/rpc/server/src/module/mod.rs
@@ -76,7 +76,6 @@ impl From<anyhow::Error> for RpcError {
     }
 }
 
-const MAILBOX_ERROR_BASE: i64 = -41000;
 const TXN_ERROR_BASE: i64 = -50000;
 const ACCOUNT_ERROR_BASE: i64 = -60000;
 
@@ -157,7 +156,7 @@ impl From<scs::Error> for RpcError {
 impl From<MailboxError> for RpcError {
     fn from(err: MailboxError) -> Self {
         RpcError(jsonrpc_core::Error {
-            code: ErrorCode::ServerError(MAILBOX_ERROR_BASE),
+            code: ErrorCode::InternalError,
             message: err.to_string(),
             data: None,
         })

--- a/rpc/server/src/module/txpool_rpc.rs
+++ b/rpc/server/src/module/txpool_rpc.rs
@@ -91,6 +91,7 @@ mod tests {
         let txpool_service = MockTxPoolService::new();
         io.extend_with(TxPoolRpcImpl::new(txpool_service).to_delegate());
         let txn = SignedUserTransaction::mock();
+        let txn_hash = txn.id();
         let prefix = r#"{"jsonrpc":"2.0","method":"txpool.submit_transaction","params":["#;
         let suffix = r#"],"id":0}"#;
         let request = format!(
@@ -99,10 +100,11 @@ mod tests {
             serde_json::to_string(&txn).expect("txn to json should success."),
             suffix
         );
-        let response = r#"{"jsonrpc":"2.0","result":{"Ok":null},"id":0}"#;
+        let response = r#"{"jsonrpc":"2.0","result":"$txn_hash","id":0}"#;
+        let response = response.replace("$txn_hash", &txn_hash.to_string());
         assert_eq!(
             io.handle_request(request.as_str()).wait().unwrap(),
-            Some(response.to_string())
+            Some(response)
         );
     }
 }

--- a/testsuite/tests/steps/transaction.rs
+++ b/testsuite/tests/steps/transaction.rs
@@ -5,6 +5,7 @@ use crate::MyWorld;
 use anyhow::Error;
 use cucumber::{Steps, StepsBuilder};
 use starcoin_account_api::AccountInfo;
+use starcoin_crypto::HashValue;
 use starcoin_executor::{DEFAULT_EXPIRATION_TIME, DEFAULT_MAX_GAS_AMOUNT};
 use starcoin_logger::prelude::*;
 use starcoin_rpc_client::{RemoteStateReader, RpcClient};
@@ -49,7 +50,7 @@ fn transfer_txn(
     to: &AccountInfo,
     from: AccountAddress,
     amount: Option<u128>,
-) -> Result<(), Error> {
+) -> Result<HashValue, Error> {
     let chain_state_reader = RemoteStateReader::new(client)?;
     let account_state_reader = AccountStateReader::new(&chain_state_reader);
     let account_resource = account_state_reader
@@ -72,7 +73,7 @@ fn transfer_txn(
     );
 
     let txn = sign_txn(client, raw_txn).unwrap();
-    client.submit_transaction(txn.clone()).and_then(|r| r)
+    client.submit_transaction(txn.clone())
 }
 fn sign_txn(
     client: &RpcClient,

--- a/txpool/src/pool_client.rs
+++ b/txpool/src/pool_client.rs
@@ -146,7 +146,7 @@ impl crate::pool::Client for PoolClient {
             .map_err(|e| TransactionError::InvalidSignature(e.to_string()))?;
         match starcoin_executor::validate_transaction(self.nonce_client.statedb.as_ref(), txn) {
             None => Ok(checked_txn),
-            Some(status) => Err(TransactionError::CallErr(CallError::Execution(status))),
+            Some(status) => Err(TransactionError::CallErr(CallError::ExecutionError(status))),
         }
     }
 }

--- a/vm/types/src/transaction/error.rs
+++ b/vm/types/src/transaction/error.rs
@@ -65,8 +65,6 @@ pub enum Error {
     InvalidSignature(String),
     /// Transaction too big
     TooBig,
-    /// Invalid RLP encoding
-    InvalidRlp(String),
     CallErr(CallError),
 }
 
@@ -104,7 +102,6 @@ impl fmt::Display for Error {
                 "Sender does not have permissions to execute this type of transaction".into()
             }
             TooBig => "Transaction too big".into(),
-            InvalidRlp(err) => format!("Transaction has invalid RLP structure: {}.", err),
             CallErr(call_err) => format!("Call txn err: {}.", call_err),
         };
 
@@ -131,12 +128,12 @@ pub enum CallError {
     /// Corrupt state.
     StateCorrupt,
     /// Error executing.
-    Execution(VMStatus),
+    ExecutionError(VMStatus),
 }
 
 impl From<VMStatus> for CallError {
     fn from(error: VMStatus) -> Self {
-        CallError::Execution(error)
+        CallError::ExecutionError(error)
     }
 }
 
@@ -148,7 +145,7 @@ impl fmt::Display for CallError {
             StatePruned => "Couldn't find the transaction block's state in the chain".into(),
             //            Exceptional(ref e) => format!("An exception ({}) happened in the execution", e),
             StateCorrupt => "Stored state found to be corrupted.".into(),
-            Execution(ref e) => format!("{}", e),
+            ExecutionError(ref e) => format!("Execution error: {}", e),
         };
 
         f.write_fmt(format_args!("Transaction execution error ({}).", msg))


### PR DESCRIPTION
定义了 txpool 和 account 的error code 转换逻辑。

这里给出 error 转换的思路：
- 内部Service 接口中的各种 CustomError，可以直接转换到 JsonRpcError。只需要实现 From trait 即可。转换时对应的是 invalid param 还是 internal error，或者需要自定义的 server error code，都可以无歧义的实现。
- 内部 Service 接口如果返回的是 anyhow::Error，这个时候需要 downcast 到具体的 CustomError，然后再走上面的逻辑，转换到 JsonRpcError。
- 无法 downcast 的，或者要 downcast 的custom error 过于通用，不知道如何映射到 jsonrpc error 的，走 internal error 的 逻辑，返回的message 中包含具体的 error 信息。