### PR TITLE
[chain] Refactor chain and verify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7180,6 +7180,7 @@ dependencies = [
  "starcoin-types",
  "starcoin-vm-types",
  "stest",
+ "thiserror",
 ]
 
 [[package]]

--- a/block-relayer/src/block_relayer.rs
+++ b/block-relayer/src/block_relayer.rs
@@ -185,7 +185,7 @@ impl EventHandler<Self, NewHeadBlock> for BlockRelayer {
     fn handle_event(&mut self, event: NewHeadBlock, ctx: &mut ServiceContext<BlockRelayer>) {
         debug!(
             "[block-relay] Handle new head block event, block_id: {:?}",
-            event.0.get_block().id()
+            event.0.block().id()
         );
         if !self.is_synced() {
             debug!("[block-relay] Ignore NewHeadBlock event because the node has not been synchronized yet.");
@@ -198,8 +198,8 @@ impl EventHandler<Self, NewHeadBlock> for BlockRelayer {
                 return;
             }
         };
-        let compact_block = event.0.get_block().clone().into();
-        let total_difficulty = event.0.get_total_difficulty();
+        let compact_block = event.0.block().clone().into();
+        let total_difficulty = event.0.total_difficulty();
         let compact_block_msg = CompactBlockMessage {
             compact_block,
             total_difficulty,

--- a/chain/api/src/chain.rs
+++ b/chain/api/src/chain.rs
@@ -18,10 +18,7 @@ use std::collections::HashSet;
 
 pub struct VerifiedBlock(pub Block);
 
-pub struct ExecutedBlock {
-    pub block: Block,
-    pub block_info: BlockInfo,
-}
+pub use starcoin_types::block::ExecutedBlock;
 
 pub trait ChainReader {
     fn info(&self) -> ChainInfo;
@@ -77,11 +74,12 @@ pub trait ChainReader {
 }
 
 pub trait ChainWriter {
+    fn can_connect(&self, executed_block: &ExecutedBlock) -> bool;
     /// Connect a executed block to current chain.
-    fn connect(&mut self, block: ExecutedBlock) -> Result<()>;
+    fn connect(&mut self, executed_block: ExecutedBlock) -> Result<ExecutedBlock>;
 
     /// Verify, Execute and Connect block to current chain.
-    fn apply(&mut self, block: Block) -> Result<()>;
+    fn apply(&mut self, block: Block) -> Result<ExecutedBlock>;
 
     fn chain_state(&mut self) -> &dyn ChainState;
 }

--- a/chain/api/src/errors.rs
+++ b/chain/api/src/errors.rs
@@ -37,6 +37,8 @@ pub enum VerifyBlockField {
     Body,
     Uncle,
     Consensus,
+    // block field verified base on block executed result.
+    State,
 }
 
 impl Display for VerifyBlockField {
@@ -46,6 +48,7 @@ impl Display for VerifyBlockField {
             VerifyBlockField::Header => write!(f, "header"),
             VerifyBlockField::Uncle => write!(f, "uncle"),
             VerifyBlockField::Consensus => write!(f, "consensus"),
+            VerifyBlockField::State => write!(f, "state"),
         }
     }
 }

--- a/chain/api/src/lib.rs
+++ b/chain/api/src/lib.rs
@@ -14,6 +14,6 @@ pub struct ExcludedTxns {
     pub untouched_txns: Vec<SignedUserTransaction>,
 }
 
-pub use chain::{Chain, ChainReader, ChainWriter};
+pub use chain::{Chain, ChainReader, ChainWriter, ExecutedBlock, VerifiedBlock};
 pub use errors::*;
 pub use service::{ChainAsyncService, ReadableChainService, WriteableChainService};

--- a/chain/chain-notify/src/lib.rs
+++ b/chain/chain-notify/src/lib.rs
@@ -75,7 +75,7 @@ impl EventHandler<Self, NewHeadBlock> for ChainNotifyHandlerService {
     ) {
         if self.is_synced() {
             let NewHeadBlock(block_detail) = item;
-            let block = block_detail.get_block();
+            let block = block_detail.block();
             // notify header.
             self.notify_new_block(block, ctx);
 

--- a/chain/mock/src/mock_chain.rs
+++ b/chain/mock/src/mock_chain.rs
@@ -62,7 +62,7 @@ impl MockChain {
             Some(id) => id,
             None => self.head.current_header().id(),
         };
-        assert!(self.head.exist_block(block_id));
+        assert!(self.head.exist_block(block_id)?);
         BlockChain::new(self.head.time_service(), block_id, self.head.get_storage())
     }
 

--- a/chain/mock/src/mock_chain.rs
+++ b/chain/mock/src/mock_chain.rs
@@ -116,7 +116,8 @@ impl MockChain {
     }
 
     pub fn apply(&mut self, block: Block) -> Result<()> {
-        self.head.apply(block)
+        self.head.apply(block)?;
+        Ok(())
     }
 
     pub fn produce_and_apply(&mut self) -> Result<BlockHeader> {

--- a/chain/service/src/chain_service.rs
+++ b/chain/service/src/chain_service.rs
@@ -133,7 +133,7 @@ impl ServiceHandler<Self, ChainRequest> for ChainReaderService {
                 self.inner.main_startup_info(),
             ))),
             ChainRequest::GetHeadChainStatus() => Ok(ChainResponse::ChainStatus(Box::new(
-                self.inner.main.get_chain_status()?,
+                self.inner.main.status(),
             ))),
             ChainRequest::GetTransaction(hash) => Ok(ChainResponse::Transaction(Box::new(
                 self.inner

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -13,7 +13,6 @@ use starcoin_chain_api::{
     verify_block, ChainReader, ChainWriter, ConnectBlockError, ExcludedTxns, ExecutedBlock,
     VerifiedBlock, VerifyBlockField,
 };
-use starcoin_executor::BlockExecutedData;
 use starcoin_open_block::OpenedBlock;
 use starcoin_state_api::{AccountStateReader, ChainState, ChainStateReader, ChainStateWriter};
 use starcoin_statedb::ChainStateDB;
@@ -32,9 +31,7 @@ use starcoin_types::{
 };
 use starcoin_vm_types::account_config::genesis_address;
 use starcoin_vm_types::genesis_config::ConsensusStrategy;
-use starcoin_vm_types::on_chain_resource::{
-    BlockMetadata, Epoch, EpochData, EpochInfo, GlobalTimeOnChain,
-};
+use starcoin_vm_types::on_chain_resource::{Epoch, EpochData, EpochInfo, GlobalTimeOnChain};
 use starcoin_vm_types::time::TimeService;
 use starcoin_vm_types::transaction::authenticator::AuthenticationKey;
 use std::cmp::min;
@@ -152,6 +149,7 @@ impl BlockChain {
         self.time_service.clone()
     }
 
+    //TODO lazy init uncles cache.
     pub fn update_uncle_cache(&mut self) -> Result<()> {
         self.uncles = self.epoch_uncles()?.iter().cloned().collect();
         Ok(())
@@ -322,6 +320,31 @@ impl BlockChain {
         FullVerifier::can_be_uncle(self, block_header)
     }
 
+    pub fn verify_with_verifier<V>(&mut self, block: Block) -> Result<VerifiedBlock>
+    where
+        V: BlockVerifier,
+    {
+        V::verify_block(self, block)
+    }
+
+    pub fn apply_with_verifier<V>(&mut self, block: Block) -> Result<ExecutedBlock>
+    where
+        V: BlockVerifier,
+    {
+        let verified_block = self.verify_with_verifier::<V>(block)?;
+        let executed_block = self.execute(verified_block)?;
+        self.connect(executed_block)
+    }
+
+    //TODO remove this function.
+    pub fn update_chain_head(&mut self, block: Block) -> Result<ExecutedBlock> {
+        let block_info = self
+            .storage
+            .get_block_info(block.id())?
+            .ok_or_else(|| format_err!("Can not find block info by hash {:?}", block.id()))?;
+        self.connect(ExecutedBlock { block, block_info })
+    }
+
     //TODO consider move this logic to BlockExecutor
     fn execute_block_and_save(
         storage: &dyn Store,
@@ -466,7 +489,7 @@ impl BlockChain {
         storage.save_transaction_batch(transactions)?;
         //TODO rework on blockstate
         let block_state = BlockState::Executed;
-        storage.commit_block(block.clone(), block_state)?;
+        storage.commit_block(block, block_state)?;
         storage.save_block_info(block_info)?;
         Ok(())
     }
@@ -727,9 +750,8 @@ impl ChainReader for BlockChain {
         let other_header_number = another.current_header().number();
         let self_header_number = self.current_header().number();
         let min_number = std::cmp::min(other_header_number, self_header_number);
-        let max_number = std::cmp::max(other_header_number, self_header_number);
         let mut ancestor = None;
-        for block_number in min_number..max_number {
+        for block_number in (0..min_number).rev() {
             let block_id_1 = another.get_hash_by_number(block_number)?;
             let block_id_2 = self.get_hash_by_number(block_number)?;
             match (block_id_1, block_id_2) {
@@ -740,7 +762,7 @@ impl ChainReader for BlockChain {
                     }
                 }
                 (_, _) => {
-                    break;
+                    continue;
                 }
             }
         }
@@ -868,37 +890,13 @@ impl BlockChain {
     }
 }
 
-impl BlockChain {
-    pub fn verify_with_verifier<V>(&mut self, block: Block) -> Result<VerifiedBlock>
-    where
-        V: BlockVerifier,
-    {
-        V::verify_block(self, block)
+impl ChainWriter for BlockChain {
+    fn can_connect(&self, executed_block: &ExecutedBlock) -> bool {
+        executed_block.block.header().parent_hash == self.status.status.head().id()
     }
 
-    pub fn apply_with_verifier<V>(&mut self, block: Block) -> Result<()>
-    where
-        V: BlockVerifier,
-    {
-        let verified_block = self.verify_with_verifier::<V>(block)?;
-        let executed_block = self.execute(verified_block)?;
-        self.connect(executed_block)
-    }
-
-    pub fn update_chain_head(&mut self, block: Block) -> Result<()> {
-        let block_info = self
-            .storage
-            .get_block_info(block.id())?
-            .ok_or_else(|| format_err!("Can not find block info by hash {:?}", block.id()))?;
-        self.update_chain_head_with_info(block, block_info)
-    }
-
-    //TODO refactor update_chain_head and update_chain_head_with_info
-    pub fn update_chain_head_with_info(
-        &mut self,
-        block: Block,
-        block_info: BlockInfo,
-    ) -> Result<()> {
+    fn connect(&mut self, executed_block: ExecutedBlock) -> Result<ExecutedBlock> {
+        let (block, block_info) = (executed_block.block(), executed_block.block_info());
         debug_assert!(block.header().parent_hash == self.status.status.head().id());
         //TODO try reuse accumulator and state db.
         let txn_accumulator_info = block_info.get_txn_accumulator_info();
@@ -920,28 +918,20 @@ impl BlockChain {
         if self.epoch.end_block_number() == block.header().number() {
             self.epoch = get_epoch_from_statedb(&self.statedb)?;
             self.update_uncle_cache()?;
-        } else {
-            if let Some(block_uncles) = block.uncles() {
-                block_uncles.iter().for_each(|header| {
-                    self.uncles.insert(header.id());
-                });
-            }
+        } else if let Some(block_uncles) = block.uncles() {
+            block_uncles.iter().for_each(|header| {
+                self.uncles.insert(header.id());
+            });
         }
         self.status = ChainStatusWithInfo {
             status: ChainStatus::new(block.header().clone(), block_info.total_difficulty),
-            info: block_info,
-            head: block,
+            info: block_info.clone(),
+            head: block.clone(),
         };
-        Ok(())
-    }
-}
-
-impl ChainWriter for BlockChain {
-    fn connect(&mut self, executed_block: ExecutedBlock) -> Result<()> {
-        self.update_chain_head_with_info(executed_block.block, executed_block.block_info)
+        Ok(executed_block)
     }
 
-    fn apply(&mut self, block: Block) -> Result<()> {
+    fn apply(&mut self, block: Block) -> Result<ExecutedBlock> {
         self.apply_with_verifier::<FullVerifier>(block)
     }
 

--- a/chain/src/lib.rs
+++ b/chain/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod chain;
+pub mod verifier;
 
 pub use chain::BlockChain;
 

--- a/chain/src/verifier/mod.rs
+++ b/chain/src/verifier/mod.rs
@@ -1,18 +1,16 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::BlockChain;
 use anyhow::Result;
 use consensus::{Consensus, ConsensusVerifyError};
 use starcoin_chain_api::{
-    verify_block, ChainReader, ChainWriter, ConnectBlockError, ExcludedTxns, VerifiedBlock,
-    VerifyBlockField,
+    verify_block, ChainReader, ConnectBlockError, VerifiedBlock, VerifyBlockField,
 };
 use starcoin_types::block::{Block, BlockHeader, ALLOWED_FUTURE_BLOCKTIME};
 use std::collections::HashSet;
 
 const MAX_UNCLE_COUNT_PER_BLOCK: usize = 2;
-
+//TODO this trait should move to consensus?
 pub trait BlockVerifier {
     fn verify_header<R>(current_chain: &R, new_block_header: &BlockHeader) -> Result<()>
     where

--- a/chain/src/verifier/mod.rs
+++ b/chain/src/verifier/mod.rs
@@ -1,0 +1,266 @@
+// Copyright (c) The Starcoin Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::BlockChain;
+use anyhow::Result;
+use consensus::{Consensus, ConsensusVerifyError};
+use starcoin_chain_api::{
+    verify_block, ChainReader, ChainWriter, ConnectBlockError, ExcludedTxns, VerifyBlockField,
+};
+use starcoin_types::block::{Block, BlockHeader, ALLOWED_FUTURE_BLOCKTIME};
+use std::collections::HashSet;
+
+const MAX_UNCLE_COUNT_PER_BLOCK: usize = 2;
+
+pub trait BlockVerifier {
+    fn verify_header<R>(current_chain: &R, new_block_header: &BlockHeader) -> Result<()>
+    where
+        R: ChainReader;
+    fn verify_block<R>(current_chain: &R, new_block: &Block) -> Result<()>
+    where
+        R: ChainReader,
+    {
+        //verify header
+        let new_block_header = new_block.header();
+        Self::verify_header(current_chain, new_block_header)?;
+
+        //verify body
+        let body_hash = new_block.body.hash();
+        verify_block!(
+            VerifyBlockField::Body,
+            body_hash == new_block_header.body_hash(),
+            "verify block body hash mismatch, expect: {}, got: {}",
+            new_block_header.body_hash(),
+            body_hash,
+        );
+        //verify uncles
+        Self::verify_uncles(
+            current_chain,
+            new_block.uncles().unwrap_or_default(),
+            new_block_header,
+        )?;
+        Ok(())
+    }
+
+    fn verify_uncles<R>(
+        current_chain: &R,
+        uncles: &[BlockHeader],
+        header: &BlockHeader,
+    ) -> Result<()>
+    where
+        R: ChainReader,
+    {
+        let epoch = current_chain.epoch();
+
+        let switch_epoch = header.number() == epoch.end_block_number();
+        // epoch first block's uncles should empty.
+        if switch_epoch {
+            verify_block!(
+                VerifyBlockField::Uncle,
+                uncles.is_empty(),
+                "Invalid block: first block of epoch's uncles must be empty."
+            );
+        }
+
+        if uncles.is_empty() {
+            return Ok(());
+        }
+        verify_block!(
+            VerifyBlockField::Uncle,
+            uncles.len() <= MAX_UNCLE_COUNT_PER_BLOCK,
+            "too many uncles {} in block {}",
+            uncles.len(),
+            header.id()
+        );
+
+        let mut uncle_ids = HashSet::new();
+        for uncle in uncles {
+            let uncle_id = uncle.id();
+            verify_block!(
+                VerifyBlockField::Uncle,
+                !uncle_ids.contains(&uncle.id()),
+                "repeat uncle {:?} in current block {:?}",
+                uncle_id,
+                header.id()
+            );
+
+            verify_block!(
+                VerifyBlockField::Uncle,
+                uncle.number < header.number ,
+               "uncle block number bigger than or equal to current block ,uncle block number is {} , current block number is {}", uncle.number, header.number
+            );
+
+            verify_block!(
+                VerifyBlockField::Uncle,
+                current_chain.can_be_uncle(uncle),
+                "invalid block: block {} can not be uncle.",
+                uncle_id
+            );
+            // uncle's parent exist in current chain is check in can_be_uncle, so this fork should bean success.
+            let uncle_branch = current_chain.fork(uncle.parent_hash())?;
+            Self::verify_header(&uncle_branch, uncle)?;
+            uncle_ids.insert(uncle_id);
+        }
+        Ok(())
+    }
+}
+
+pub struct BasicVerifier;
+
+impl BlockVerifier for BasicVerifier {
+    fn verify_header<R>(current_chain: &R, new_block_header: &BlockHeader) -> Result<()>
+    where
+        R: ChainReader,
+    {
+        let new_block_parent = new_block_header.parent_hash();
+        let chain_status = current_chain.status();
+        let current = chain_status.head();
+        let current_id = current.id();
+        let expect_number = current.number() + 1;
+
+        verify_block!(
+            VerifyBlockField::Header,
+            expect_number == new_block_header.number,
+            "Invalid block: Unexpect block number, expect:{}, got: {}.",
+            expect_number,
+            new_block_header.number
+        );
+
+        verify_block!(
+            VerifyBlockField::Header,
+            current_id == new_block_parent,
+            "Invalid block: Parent id mismatch, expect:{}, got: {}, number:{}.",
+            current_id,
+            new_block_parent,
+            new_block_header.number
+        );
+
+        verify_block!(
+            VerifyBlockField::Header,
+            current_id == new_block_parent,
+            "Invalid block: Parent id mismatch, expect:{}, got: {}, number:{}.",
+            current_id,
+            new_block_parent,
+            new_block_header.number
+        );
+
+        verify_block!(
+            VerifyBlockField::Header,
+            new_block_header.timestamp() > current.timestamp(),
+            "Invalid block: block timestamp too old, parent time:{}, block time: {}, number:{}.",
+            current.timestamp(),
+            new_block_header.timestamp(),
+            new_block_header.number
+        );
+
+        let now = current_chain.time_service().now_millis();
+        verify_block!(
+            VerifyBlockField::Header,
+            new_block_header.timestamp() <= ALLOWED_FUTURE_BLOCKTIME + now,
+            "Invalid block: block timestamp too new, now:{}, block time:{}",
+            now,
+            new_block_header.timestamp()
+        );
+
+        let epoch = current_chain.epoch();
+
+        verify_block!(
+            VerifyBlockField::Header,
+            new_block_header.number() > epoch.start_block_number()
+                && new_block_header.number() <= epoch.end_block_number(),
+            "block number is {:?}, epoch start number is {:?}, epoch end number is {:?}",
+            new_block_header.number(),
+            epoch.start_block_number(),
+            epoch.end_block_number(),
+        );
+
+        let block_gas_limit = epoch.block_gas_limit();
+
+        verify_block!(
+            VerifyBlockField::Header,
+            new_block_header.gas_used() <= block_gas_limit,
+            "invalid block: gas_used should not greater than block_gas_limit"
+        );
+
+        let current_block_info = current_chain
+            .get_block_info(Some(current_id))?
+            .expect("head block's block info should exist.");
+        verify_block!(
+            VerifyBlockField::Header,
+            current_block_info
+                .get_block_accumulator_info()
+                .get_accumulator_root()
+                == &new_block_header.parent_block_accumulator_root(),
+            "Block accumulator root miss match {:?} : {:?}",
+            current_block_info
+                .get_block_accumulator_info()
+                .get_accumulator_root(),
+            new_block_header.parent_block_accumulator_root(),
+        );
+        Ok(())
+    }
+}
+
+pub struct ConsensusVerifier;
+
+impl BlockVerifier for ConsensusVerifier {
+    fn verify_header<R>(current_chain: &R, new_block_header: &BlockHeader) -> Result<()>
+    where
+        R: ChainReader,
+    {
+        let epoch = current_chain.epoch();
+        let consensus = epoch.strategy();
+        if let Err(e) = consensus.verify(current_chain, new_block_header) {
+            return match e.downcast::<ConsensusVerifyError>() {
+                Ok(e) => Err(ConnectBlockError::VerifyBlockFailed(
+                    VerifyBlockField::Consensus,
+                    e.into(),
+                )
+                .into()),
+                Err(e) => Err(e),
+            };
+        }
+        Ok(())
+    }
+}
+
+pub struct FullVerifier;
+
+impl BlockVerifier for FullVerifier {
+    fn verify_header<R>(current_chain: &R, new_block_header: &BlockHeader) -> Result<()>
+    where
+        R: ChainReader,
+    {
+        BasicVerifier::verify_header(current_chain, new_block_header)?;
+        ConsensusVerifier::verify_header(current_chain, new_block_header)
+    }
+}
+
+pub struct NoneVerifier;
+
+impl BlockVerifier for NoneVerifier {
+    fn verify_header<R>(_current_chain: &R, _new_block_header: &BlockHeader) -> Result<()>
+    where
+        R: ChainReader,
+    {
+        Ok(())
+    }
+
+    fn verify_block<R>(_current_chain: &R, _new_block: &Block) -> Result<()>
+    where
+        R: ChainReader,
+    {
+        Ok(())
+    }
+
+    fn verify_uncles<R>(
+        _current_chain: &R,
+        _uncles: &[BlockHeader],
+        _header: &BlockHeader,
+    ) -> Result<()>
+    where
+        R: ChainReader,
+    {
+        Ok(())
+    }
+}

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.35"
+thiserror = "1.0"
 futures = { version = "0.3" }
 once_cell = "1.5.2"
 starcoin-types = { path = "../types" }

--- a/consensus/src/argon.rs
+++ b/consensus/src/argon.rs
@@ -21,23 +21,9 @@ impl ArgonConsensus {
 }
 
 impl Consensus for ArgonConsensus {
-    fn calculate_next_difficulty(
-        &self,
-        reader: &dyn ChainReader,
-        epoch: &EpochInfo,
-    ) -> Result<U256> {
-        let target = difficulty::get_next_work_required(reader, epoch)?;
+    fn calculate_next_difficulty(&self, reader: &dyn ChainReader) -> Result<U256> {
+        let target = difficulty::get_next_work_required(reader)?;
         Ok(target_to_difficulty(target))
-    }
-
-    fn verify(
-        &self,
-        reader: &dyn ChainReader,
-        epoch: &EpochInfo,
-        header: &BlockHeader,
-    ) -> Result<()> {
-        let difficulty = self.calculate_next_difficulty(reader, epoch)?;
-        self.verify_header_difficulty(difficulty, header)
     }
 
     fn calculate_pow_hash(&self, mining_hash: &[u8], nonce: u32) -> Result<HashValue> {

--- a/consensus/src/argon.rs
+++ b/consensus/src/argon.rs
@@ -7,9 +7,7 @@ use anyhow::Result;
 use argon2::{self, Config};
 use starcoin_crypto::HashValue;
 use starcoin_traits::ChainReader;
-use starcoin_types::block::BlockHeader;
 use starcoin_types::U256;
-use starcoin_vm_types::on_chain_resource::EpochInfo;
 
 #[derive(Default)]
 pub struct ArgonConsensus {}

--- a/consensus/src/cn.rs
+++ b/consensus/src/cn.rs
@@ -21,23 +21,9 @@ impl CryptoNightConsensus {
 }
 
 impl Consensus for CryptoNightConsensus {
-    fn calculate_next_difficulty(
-        &self,
-        reader: &dyn ChainReader,
-        epoch: &EpochInfo,
-    ) -> Result<U256> {
-        let target = difficulty::get_next_work_required(reader, epoch)?;
+    fn calculate_next_difficulty(&self, reader: &dyn ChainReader) -> Result<U256> {
+        let target = difficulty::get_next_work_required(reader)?;
         Ok(target_to_difficulty(target))
-    }
-
-    fn verify(
-        &self,
-        reader: &dyn ChainReader,
-        epoch: &EpochInfo,
-        header: &BlockHeader,
-    ) -> Result<()> {
-        let difficulty = self.calculate_next_difficulty(reader, epoch)?;
-        self.verify_header_difficulty(difficulty, header)
     }
 
     /// CryptoNight-R

--- a/consensus/src/cn.rs
+++ b/consensus/src/cn.rs
@@ -7,9 +7,7 @@ use anyhow::Result;
 use cryptonight::cryptonight_r;
 use starcoin_crypto::HashValue;
 use starcoin_traits::ChainReader;
-use starcoin_types::block::BlockHeader;
 use starcoin_types::U256;
-use starcoin_vm_types::on_chain_resource::EpochInfo;
 
 #[derive(Default)]
 pub struct CryptoNightConsensus {}

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -10,13 +10,22 @@ use starcoin_types::{
 };
 use starcoin_vm_types::on_chain_resource::EpochInfo;
 use starcoin_vm_types::time::TimeService;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ConsensusVerifyError {
+    #[error("Verify Difficulty Error, expect: {expect}, got: {real}")]
+    VerifyDifficultyError { expect: U256, real: U256 },
+    #[error("Verify Nonce Error, expect target: {target}, got: {real}, nonce: {}")]
+    VerifyNonceError {
+        target: U256,
+        real: U256,
+        nonce: u32,
+    },
+}
 
 pub trait Consensus {
-    fn calculate_next_difficulty(
-        &self,
-        reader: &dyn ChainReader,
-        epoch: &EpochInfo,
-    ) -> Result<U256>;
+    fn calculate_next_difficulty(&self, reader: &dyn ChainReader) -> Result<U256>;
 
     /// Calculate new block consensus header
     fn solve_consensus_nonce(
@@ -41,12 +50,10 @@ pub trait Consensus {
         nonce
     }
 
-    fn verify(
-        &self,
-        reader: &dyn ChainReader,
-        epoch: &EpochInfo,
-        header: &BlockHeader,
-    ) -> Result<()>;
+    fn verify(&self, reader: &dyn ChainReader, header: &BlockHeader) -> Result<()> {
+        let difficulty = self.calculate_next_difficulty(reader)?;
+        self.verify_header_difficulty(difficulty, header)
+    }
 
     /// Calculate the Pow hash for header
     fn calculate_pow_hash(&self, pow_header_blob: &[u8], nonce: u32) -> Result<HashValue>;
@@ -65,18 +72,23 @@ pub trait Consensus {
     /// Inner helper for verify and unit testing
     fn verify_header_difficulty(&self, difficulty: U256, header: &BlockHeader) -> Result<()> {
         if header.difficulty() != difficulty {
-            return Err(anyhow!(
-                "Difficulty mismatch: {:?}, header: {:?}",
-                difficulty,
-                header
-            ));
+            return Err(ConsensusVerifyError::VerifyDifficultyError {
+                expect: difficulty,
+                real: header.difficulty(),
+            }
+            .into());
         }
         let nonce = header.nonce;
         let pow_header_blob = header.as_pow_header_blob();
         let pow_hash: U256 = self.calculate_pow_hash(&pow_header_blob, nonce)?.into();
         let target = difficult_to_target(difficulty);
         if pow_hash > target {
-            anyhow::bail!("Invalid header:{:?}", header);
+            return Err(ConsensusVerifyError::VerifyNonceError {
+                target,
+                real: pow_hash,
+                nonce,
+            }
+            .into());
         }
         Ok(())
     }

--- a/consensus/src/consensus.rs
+++ b/consensus/src/consensus.rs
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{difficult_to_target, generate_nonce, ChainReader};
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use starcoin_crypto::HashValue;
 use starcoin_types::{
     block::{Block, BlockHeader, BlockTemplate},
     U256,
 };
-use starcoin_vm_types::on_chain_resource::EpochInfo;
 use starcoin_vm_types::time::TimeService;
 use thiserror::Error;
 

--- a/consensus/src/difficulty.rs
+++ b/consensus/src/difficulty.rs
@@ -12,7 +12,8 @@ use starcoin_vm_types::on_chain_resource::EpochInfo;
 use std::convert::TryInto;
 
 /// Get the target of next pow work
-pub fn get_next_work_required(chain: &dyn ChainReader, epoch: &EpochInfo) -> Result<U256> {
+pub fn get_next_work_required(chain: &dyn ChainReader) -> Result<U256> {
+    let epoch = chain.epoch();
     let current_header = chain.current_header();
     if current_header.number <= 1 {
         return Ok(difficult_to_target(current_header.difficulty));

--- a/consensus/src/difficulty.rs
+++ b/consensus/src/difficulty.rs
@@ -8,7 +8,6 @@ use anyhow::{bail, format_err, Result};
 use logger::prelude::*;
 use starcoin_traits::ChainReader;
 use starcoin_types::block::BlockHeader;
-use starcoin_vm_types::on_chain_resource::EpochInfo;
 use std::convert::TryInto;
 
 /// Get the target of next pow work

--- a/consensus/src/dummy.rs
+++ b/consensus/src/dummy.rs
@@ -9,7 +9,6 @@ use starcoin_crypto::HashValue;
 use starcoin_traits::ChainReader;
 use starcoin_types::block::BlockHeader;
 use starcoin_types::U256;
-use starcoin_vm_types::on_chain_resource::EpochInfo;
 use starcoin_vm_types::time::TimeService;
 
 #[derive(Default)]

--- a/consensus/src/dummy.rs
+++ b/consensus/src/dummy.rs
@@ -22,11 +22,8 @@ impl DummyConsensus {
 }
 
 impl Consensus for DummyConsensus {
-    fn calculate_next_difficulty(
-        &self,
-        _chain: &dyn ChainReader,
-        epoch: &EpochInfo,
-    ) -> Result<U256> {
+    fn calculate_next_difficulty(&self, chain: &dyn ChainReader) -> Result<U256> {
+        let epoch = chain.epoch();
         info!("epoch: {:?}", epoch);
         let target = epoch.block_time_target();
         Ok(target.into())
@@ -51,12 +48,7 @@ impl Consensus for DummyConsensus {
         time
     }
 
-    fn verify(
-        &self,
-        _reader: &dyn ChainReader,
-        _epoch: &EpochInfo,
-        _header: &BlockHeader,
-    ) -> Result<()> {
+    fn verify(&self, _reader: &dyn ChainReader, _header: &BlockHeader) -> Result<()> {
         Ok(())
     }
 

--- a/consensus/src/keccak.rs
+++ b/consensus/src/keccak.rs
@@ -21,23 +21,9 @@ impl KeccakConsensus {
 }
 
 impl Consensus for KeccakConsensus {
-    fn calculate_next_difficulty(
-        &self,
-        reader: &dyn ChainReader,
-        epoch: &EpochInfo,
-    ) -> Result<U256> {
-        let target = difficulty::get_next_work_required(reader, epoch)?;
+    fn calculate_next_difficulty(&self, reader: &dyn ChainReader) -> Result<U256> {
+        let target = difficulty::get_next_work_required(reader)?;
         Ok(target_to_difficulty(target))
-    }
-
-    fn verify(
-        &self,
-        reader: &dyn ChainReader,
-        epoch: &EpochInfo,
-        header: &BlockHeader,
-    ) -> Result<()> {
-        let difficulty = self.calculate_next_difficulty(reader, epoch)?;
-        self.verify_header_difficulty(difficulty, header)
     }
 
     /// Double keccak256 for pow hash

--- a/consensus/src/keccak.rs
+++ b/consensus/src/keccak.rs
@@ -7,9 +7,7 @@ use anyhow::Result;
 use sha3::{Digest, Keccak256};
 use starcoin_crypto::HashValue;
 use starcoin_traits::ChainReader;
-use starcoin_types::block::BlockHeader;
 use starcoin_types::U256;
-use starcoin_vm_types::on_chain_resource::EpochInfo;
 
 #[derive(Default)]
 pub struct KeccakConsensus {}

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -1,18 +1,6 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod argon;
-pub mod cn;
-mod consensus;
-#[cfg(test)]
-mod consensus_test;
-pub mod difficulty;
-pub mod dummy;
-pub mod keccak;
-
-pub use consensus::Consensus;
-pub use starcoin_vm_types::time::duration_since_epoch;
-
 use crate::argon::ArgonConsensus;
 use crate::cn::CryptoNightConsensus;
 use crate::dummy::DummyConsensus;
@@ -28,6 +16,18 @@ use starcoin_types::U256;
 use starcoin_vm_types::genesis_config::ConsensusStrategy;
 use starcoin_vm_types::on_chain_resource::EpochInfo;
 use starcoin_vm_types::time::TimeService;
+
+pub mod argon;
+pub mod cn;
+mod consensus;
+#[cfg(test)]
+mod consensus_test;
+pub mod difficulty;
+pub mod dummy;
+pub mod keccak;
+
+pub use consensus::{Consensus, ConsensusVerifyError};
+pub use starcoin_vm_types::time::duration_since_epoch;
 
 pub fn target_to_difficulty(target: U256) -> U256 {
     U256::max_value() / target
@@ -54,16 +54,12 @@ static KECCAK: Lazy<KeccakConsensus> = Lazy::new(KeccakConsensus::new);
 pub static CRYPTONIGHT: Lazy<CryptoNightConsensus> = Lazy::new(CryptoNightConsensus::new);
 
 impl Consensus for ConsensusStrategy {
-    fn calculate_next_difficulty(
-        &self,
-        reader: &dyn ChainReader,
-        epoch: &EpochInfo,
-    ) -> Result<U256> {
+    fn calculate_next_difficulty(&self, reader: &dyn ChainReader) -> Result<U256> {
         match self {
-            ConsensusStrategy::Dummy => DUMMY.calculate_next_difficulty(reader, epoch),
-            ConsensusStrategy::Argon => ARGON.calculate_next_difficulty(reader, epoch),
-            ConsensusStrategy::Keccak => KECCAK.calculate_next_difficulty(reader, epoch),
-            ConsensusStrategy::CryptoNight => CRYPTONIGHT.calculate_next_difficulty(reader, epoch),
+            ConsensusStrategy::Dummy => DUMMY.calculate_next_difficulty(reader),
+            ConsensusStrategy::Argon => ARGON.calculate_next_difficulty(reader),
+            ConsensusStrategy::Keccak => KECCAK.calculate_next_difficulty(reader),
+            ConsensusStrategy::CryptoNight => CRYPTONIGHT.calculate_next_difficulty(reader),
         }
     }
 
@@ -89,17 +85,12 @@ impl Consensus for ConsensusStrategy {
         }
     }
 
-    fn verify(
-        &self,
-        reader: &dyn ChainReader,
-        epoch: &EpochInfo,
-        header: &BlockHeader,
-    ) -> Result<()> {
+    fn verify(&self, reader: &dyn ChainReader, header: &BlockHeader) -> Result<()> {
         match self {
-            ConsensusStrategy::Dummy => DUMMY.verify(reader, epoch, header),
-            ConsensusStrategy::Argon => ARGON.verify(reader, epoch, header),
-            ConsensusStrategy::Keccak => KECCAK.verify(reader, epoch, header),
-            ConsensusStrategy::CryptoNight => CRYPTONIGHT.verify(reader, epoch, header),
+            ConsensusStrategy::Dummy => DUMMY.verify(reader, header),
+            ConsensusStrategy::Argon => ARGON.verify(reader, header),
+            ConsensusStrategy::Keccak => KECCAK.verify(reader, header),
+            ConsensusStrategy::CryptoNight => CRYPTONIGHT.verify(reader, header),
         }
     }
 

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -14,7 +14,6 @@ use starcoin_traits::ChainReader;
 use starcoin_types::block::BlockHeader;
 use starcoin_types::U256;
 use starcoin_vm_types::genesis_config::ConsensusStrategy;
-use starcoin_vm_types::on_chain_resource::EpochInfo;
 use starcoin_vm_types::time::TimeService;
 
 pub mod argon;

--- a/core/accumulator/src/lib.rs
+++ b/core/accumulator/src/lib.rs
@@ -101,6 +101,11 @@ impl MerkleAccumulator {
             tree: Mutex::new(AccumulatorTree::new_empty(node_store)),
         }
     }
+
+    /// Fork a new accumulator base on current accumulator
+    pub fn fork(&self) -> MerkleAccumulator {
+        Self::new_with_info(self.get_info(), self.tree.lock().store.clone())
+    }
 }
 
 impl Accumulator for MerkleAccumulator {

--- a/core/accumulator/src/tree.rs
+++ b/core/accumulator/src/tree.rs
@@ -26,7 +26,7 @@ pub struct AccumulatorTree {
     /// The index cache
     index_cache: LruCache<NodeCacheKey, HashValue>,
     /// The storage of accumulator.
-    store: Arc<dyn AccumulatorTreeStore>,
+    pub(crate) store: Arc<dyn AccumulatorTreeStore>,
     /// The temp update nodes
     update_nodes: HashMap<HashValue, AccumulatorNode>,
 }

--- a/core/genesis/src/lib.rs
+++ b/core/genesis/src/lib.rs
@@ -27,13 +27,12 @@ use std::fs::{create_dir_all, File};
 use std::io::{Read, Write};
 use std::path::Path;
 use std::sync::Arc;
-use traits::{ChainReader, ChainWriter};
+use traits::ChainReader;
 
 mod errors;
 
 pub use errors::GenesisError;
 use starcoin_accumulator::accumulator_info::AccumulatorInfo;
-use starcoin_chain::verifier::NoneVerifier;
 use starcoin_vm_types::genesis_config::{BuiltinNetworkID, ChainNetworkID};
 
 pub static GENESIS_GENERATED_DIR: &str = "generated";

--- a/core/genesis/src/lib.rs
+++ b/core/genesis/src/lib.rs
@@ -259,12 +259,12 @@ impl Genesis {
         net: &ChainNetwork,
         storage: Arc<dyn Store>,
     ) -> Result<StartupInfo> {
-        let mut genesis_chain = BlockChain::init_empty_chain(
+        let genesis_chain = BlockChain::new_with_genesis(
             net.time_service(),
-            net.genesis_config().genesis_epoch(),
             storage.clone(),
-        );
-        genesis_chain.apply_with_verifier::<NoneVerifier>(self.block.clone())?;
+            net.genesis_config().genesis_epoch(),
+            self.block.clone(),
+        )?;
         let startup_info = StartupInfo::new(genesis_chain.current_header().id());
         storage.save_startup_info(startup_info.clone())?;
         Ok(startup_info)

--- a/miner/src/create_block_template/mod.rs
+++ b/miner/src/create_block_template/mod.rs
@@ -224,7 +224,7 @@ impl Inner {
     }
 
     pub fn create_block_template(&self) -> Result<BlockTemplate> {
-        let on_chain_block_gas_limit = self.chain.get_on_chain_block_gas_limit()?;
+        let on_chain_block_gas_limit = self.chain.epoch().block_gas_limit();
         let block_gas_limit = self
             .local_block_gas_limit
             .map(|block_gas_limit| min(block_gas_limit, on_chain_block_gas_limit))

--- a/miner/src/create_block_template/mod.rs
+++ b/miner/src/create_block_template/mod.rs
@@ -201,7 +201,7 @@ impl Inner {
                     if new_uncle.len() >= MAX_UNCLE_COUNT_PER_BLOCK {
                         break;
                     }
-                    if self.chain.can_be_uncle(maybe_uncle) {
+                    if self.chain.can_be_uncle(maybe_uncle).unwrap_or_default() {
                         new_uncle.push(maybe_uncle.clone())
                     }
                 }

--- a/miner/src/create_block_template/mod.rs
+++ b/miner/src/create_block_template/mod.rs
@@ -255,9 +255,9 @@ impl Inner {
             txns.len()
         );
 
-        let epoch = self.chain.epoch_info()?;
-        let strategy = epoch.epoch().strategy();
-        let difficulty = strategy.calculate_next_difficulty(&self.chain, &epoch)?;
+        let epoch = self.chain.epoch();
+        let strategy = epoch.strategy();
+        let difficulty = strategy.calculate_next_difficulty(&self.chain)?;
 
         let mut opened_block = OpenedBlock::new(
             self.storage.clone(),

--- a/miner/src/create_block_template/test_create_block_template.rs
+++ b/miner/src/create_block_template/test_create_block_template.rs
@@ -102,8 +102,8 @@ fn test_switch_main() {
             .unwrap();
 
         let block_header = block.header().clone();
-        main.apply(block.clone()).unwrap();
-        tmp_inner.update_chain(block).unwrap();
+        let executed_block = main.apply(block.clone()).unwrap();
+        tmp_inner.update_chain(executed_block).unwrap();
         main_inner = Some(tmp_inner);
 
         if i != (times - 1) {
@@ -144,19 +144,27 @@ fn test_switch_main() {
             .create_block(block_template, node_config.net().time_service().as_ref())
             .unwrap();
 
-        new_main.apply(block.clone()).unwrap();
+        let executed_block = new_main.apply(block.clone()).unwrap();
 
         head_id = block.id();
         if i == 0 {
             let block_header = block.header().clone();
             assert_eq!(main_inner.as_ref().unwrap().uncles.len(), 1);
-            main_inner.as_mut().unwrap().update_chain(block).unwrap();
+            main_inner
+                .as_mut()
+                .unwrap()
+                .update_chain(executed_block)
+                .unwrap();
             main_inner.as_mut().unwrap().insert_uncle(block_header);
         } else if i == 1 {
             assert_eq!(main_inner.as_ref().unwrap().uncles.len(), 2);
             assert!(block.body.uncles.is_some());
             assert_eq!(block.body.uncles.as_ref().unwrap().len(), 1);
-            main_inner.as_mut().unwrap().update_chain(block).unwrap();
+            main_inner
+                .as_mut()
+                .unwrap()
+                .update_chain(executed_block)
+                .unwrap();
         } else if i == 2 {
             assert_eq!(main_inner.as_ref().unwrap().uncles.len(), 2);
             assert!(block.body.uncles.is_none());
@@ -204,8 +212,8 @@ fn test_do_uncles() {
             .create_block(block_template, node_config.net().time_service().as_ref())
             .unwrap();
         head_id = block.id();
-        main.apply(block.clone()).unwrap();
-        tmp_inner.update_chain(block).unwrap();
+        let executed_block = main.apply(block.clone()).unwrap();
+        tmp_inner.update_chain(executed_block).unwrap();
         main_inner = Some(tmp_inner);
     }
 
@@ -255,8 +263,12 @@ fn test_do_uncles() {
             assert!(block.uncles().is_none());
         }
         head_id = block.id();
-        main.apply(block.clone()).unwrap();
-        main_inner.as_mut().unwrap().update_chain(block).unwrap();
+        let executed_block = main.apply(block.clone()).unwrap();
+        main_inner
+            .as_mut()
+            .unwrap()
+            .update_chain(executed_block)
+            .unwrap();
     }
 }
 
@@ -293,9 +305,9 @@ fn test_new_head() {
             .consensus()
             .create_block(block_template, node_config.net().time_service().as_ref())
             .unwrap();
-        (&mut main_inner.chain).apply(block.clone()).unwrap();
+        let executed_block = (&mut main_inner.chain).apply(block.clone()).unwrap();
         if i % 2 == 0 {
-            main_inner.update_chain(block).unwrap();
+            main_inner.update_chain(executed_block).unwrap();
         }
         assert_eq!(main_inner.chain.current_header().number(), i + 1);
     }
@@ -358,10 +370,10 @@ fn test_new_branch() {
             .create_block(block_template, node_config.net().time_service().as_ref())
             .unwrap();
         new_head_id = new_block.id();
-        branch.apply(new_block.clone()).unwrap();
+        let executed_block = branch.apply(new_block.clone()).unwrap();
 
         if i > times {
-            main_inner.update_chain(new_block).unwrap();
+            main_inner.update_chain(executed_block).unwrap();
             assert_eq!(main_inner.chain.current_header().number(), i + 1);
         }
     }

--- a/miner/tests/miner_test.rs
+++ b/miner/tests/miner_test.rs
@@ -48,7 +48,7 @@ fn test_miner() {
             minting_blob: mint_block_event.minting_blob.clone(),
         })
         .unwrap();
-        let mined_block = new_block_receiver.await.unwrap().0.get_block().clone();
+        let mined_block = new_block_receiver.await.unwrap().0.block().clone();
         assert_eq!(mined_block.header.nonce, nonce);
         let minting_blob = mined_block.header.as_pow_header_blob();
         assert_eq!(mint_block_event.minting_blob, minting_blob);

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -179,7 +179,7 @@ impl NodeHandle {
             {
                 //wait for new block event to been processed.
                 Delay::new(Duration::from_millis(100)).await;
-                event.0.get_block().clone()
+                event.0.block().clone()
             } else {
                 let latest_head = chain_service.main_head_block().await?;
                 debug!("generate_block: latest block: {:?}", latest_head.header);

--- a/state/api/src/chain_state.rs
+++ b/state/api/src/chain_state.rs
@@ -209,6 +209,7 @@ impl<'a, T: 'a + StateView> IntoSuper<dyn StateView + 'a> for T {
     }
 }
 
+///TODO change AccountStateReader to a trait, and auto implements to ChainStateReader
 /// `AccountStateReader` is a helper struct for read account state.
 pub struct AccountStateReader<'a> {
     //TODO add a cache.

--- a/state/statedb/src/lib.rs
+++ b/state/statedb/src/lib.rs
@@ -220,6 +220,11 @@ impl ChainStateDB {
         }
     }
 
+    /// Fork a new statedb base current statedb
+    pub fn fork(&self) -> Self {
+        Self::new(self.store.clone(), Some(self.state_root()))
+    }
+
     //TODO implements a change_root ChainStateReader
     pub fn change_root(&self, root_hash: HashValue) -> Self {
         Self {

--- a/sync/src/block_connector/test_illegal_block.rs
+++ b/sync/src/block_connector/test_illegal_block.rs
@@ -176,7 +176,8 @@ async fn test_verify_gas_limit(succ: bool) -> Result<()> {
     if !succ {
         new_block.header.gas_used = u64::MAX;
     }
-    main.apply(new_block)
+    main.apply(new_block)?;
+    Ok(())
 }
 
 #[stest::test(timeout = 120)]
@@ -194,7 +195,8 @@ async fn test_verify_body_hash(succ: bool) -> Result<()> {
     if !succ {
         new_block.header.body_hash = HashValue::random();
     }
-    main.apply(new_block)
+    main.apply(new_block)?;
+    Ok(())
 }
 
 #[stest::test(timeout = 120)]
@@ -212,7 +214,8 @@ async fn test_verify_parent_id(succ: bool) -> Result<()> {
     if !succ {
         new_block.header.parent_hash = HashValue::random();
     }
-    main.apply(new_block)
+    main.apply(new_block)?;
+    Ok(())
 }
 
 #[stest::test(timeout = 120)]
@@ -235,7 +238,8 @@ async fn test_verify_timestamp(succ: bool) -> Result<()> {
     if !succ {
         new_block.header.timestamp = main.current_header().timestamp();
     }
-    main.apply(new_block)
+    main.apply(new_block)?;
+    Ok(())
 }
 
 #[stest::test(timeout = 120)]
@@ -257,7 +261,8 @@ async fn test_verify_future_timestamp(succ: bool) -> Result<()> {
             .as_secs()
             + 1000;
     }
-    main.apply(new_block)
+    main.apply(new_block)?;
+    Ok(())
 }
 
 #[stest::test(timeout = 120)]
@@ -275,7 +280,8 @@ async fn test_verify_consensus(succ: bool) -> Result<()> {
     if !succ {
         new_block.header.difficulty = U256::from(1024u64);
     }
-    main.apply(new_block)
+    main.apply(new_block)?;
+    Ok(())
 }
 
 #[stest::test(timeout = 120)]
@@ -467,7 +473,8 @@ async fn test_verify_illegal_uncle_consensus(succ: bool) -> Result<()> {
         .create_block(block_template, net.time_service().as_ref())
         .unwrap();
 
-    main_block_chain.apply(new_block)
+    main_block_chain.apply(new_block)?;
+    Ok(())
 }
 
 #[stest::test(timeout = 120)]
@@ -485,7 +492,8 @@ async fn test_verify_state_root(succ: bool) -> Result<()> {
     if !succ {
         new_block.header.state_root = HashValue::random();
     }
-    main.apply(new_block)
+    main.apply(new_block)?;
+    Ok(())
 }
 
 #[stest::test(timeout = 120)]
@@ -503,7 +511,8 @@ async fn test_verify_block_used_gas(succ: bool) -> Result<()> {
     if !succ {
         new_block.header.gas_used = 1;
     }
-    main.apply(new_block)
+    main.apply(new_block)?;
+    Ok(())
 }
 
 #[stest::test(timeout = 360)]
@@ -537,7 +546,8 @@ async fn test_verify_accumulator_root(succ: bool) -> Result<()> {
     if !succ {
         new_block.header.accumulator_root = HashValue::random();
     }
-    main.apply(new_block)
+    main.apply(new_block)?;
+    Ok(())
 }
 
 #[stest::test(timeout = 120)]
@@ -555,7 +565,8 @@ async fn test_verify_block_accumulator_root(succ: bool) -> Result<()> {
     if !succ {
         new_block.header.parent_block_accumulator_root = HashValue::random();
     }
-    main.apply(new_block)
+    main.apply(new_block)?;
+    Ok(())
 }
 
 #[stest::test(timeout = 120)]

--- a/sync/src/sync2.rs
+++ b/sync/src/sync2.rs
@@ -315,7 +315,7 @@ impl EventHandler<Self, NewHeadBlock> for SyncService2 {
         let NewHeadBlock(block) = msg;
         if self.sync_status.update_chain_status(ChainStatus::new(
             block.header().clone(),
-            block.get_total_difficulty(),
+            block.total_difficulty(),
         )) {
             ctx.broadcast(SyncStatusChangeEvent(self.sync_status.clone()));
         }

--- a/sync/src/tasks/block_sync_task.rs
+++ b/sync/src/tasks/block_sync_task.rs
@@ -11,7 +11,7 @@ use futures::FutureExt;
 use logger::prelude::*;
 use network_api::NetworkService;
 use starcoin_accumulator::{Accumulator, MerkleAccumulator};
-use starcoin_chain_api::{ChainReader, ChainWriter, ConnectBlockError};
+use starcoin_chain_api::{ChainReader, ChainWriter, ConnectBlockError, ExecutedBlock};
 use starcoin_types::block::{Block, BlockInfo, BlockNumber};
 use starcoin_types::peer_info::PeerId;
 use starcoin_vm_types::on_chain_config::GlobalTimeOnChain;
@@ -252,7 +252,7 @@ where
             Some(block_info) => {
                 //If block_info exists, it means that this block was already executed and try connect in the previous sync, but the sync task was interrupted.
                 //So, we just need to update chain and continue
-                self.chain.update_chain_head_with_info(block, block_info)?;
+                self.chain.connect(ExecutedBlock { block, block_info })?;
             }
             None => {
                 self.apply_block(block.clone(), peer_id)?;

--- a/types/src/block.rs
+++ b/types/src/block.rs
@@ -685,25 +685,26 @@ impl BlockTemplate {
 }
 
 #[derive(Clone, Debug, Hash, Serialize, Deserialize, CryptoHasher, CryptoHash)]
-pub struct BlockDetail {
-    block: Block,
-    total_difficulty: U256,
+pub struct ExecutedBlock {
+    pub block: Block,
+    pub block_info: BlockInfo,
 }
 
-impl BlockDetail {
-    pub fn new(block: Block, total_difficulty: U256) -> Self {
-        BlockDetail {
-            block,
-            total_difficulty,
-        }
+impl ExecutedBlock {
+    pub fn new(block: Block, block_info: BlockInfo) -> Self {
+        ExecutedBlock { block, block_info }
     }
 
-    pub fn get_total_difficulty(&self) -> U256 {
-        self.total_difficulty
+    pub fn total_difficulty(&self) -> U256 {
+        self.block_info.total_difficulty
     }
 
-    pub fn get_block(&self) -> &Block {
+    pub fn block(&self) -> &Block {
         &self.block
+    }
+
+    pub fn block_info(&self) -> &BlockInfo {
+        &self.block_info
     }
 
     pub fn header(&self) -> &BlockHeader {

--- a/types/src/system_events.rs
+++ b/types/src/system_events.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::block::{Block, BlockDetail, BlockHeader};
+use crate::block::{Block, BlockHeader, ExecutedBlock};
 use crate::sync_status::SyncStatus;
 use crate::U256;
 use actix::prelude::*;
@@ -12,7 +12,7 @@ use std::sync::Arc;
 //TODO this type should at another crate and avoid starcoin-types dependency actix ?.
 #[derive(Clone, Debug, Message)]
 #[rtype(result = "()")]
-pub struct NewHeadBlock(pub Arc<BlockDetail>);
+pub struct NewHeadBlock(pub Arc<ExecutedBlock>);
 
 /// may be uncle block
 #[derive(Clone, Debug, Message)]

--- a/vm/types/src/genesis_config.rs
+++ b/vm/types/src/genesis_config.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::account_config::genesis_address;
-use crate::event::{EventHandle, EventKey};
+use crate::event::EventHandle;
 use crate::gas_schedule::{
     AbstractMemorySize, GasAlgebra, GasCarrier, GasConstants, GasPrice, GasUnits,
 };

--- a/vm/types/src/genesis_config.rs
+++ b/vm/types/src/genesis_config.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::account_config::genesis_address;
+use crate::event::{EventHandle, EventKey};
 use crate::gas_schedule::{
     AbstractMemorySize, GasAlgebra, GasCarrier, GasConstants, GasPrice, GasUnits,
 };
@@ -8,6 +10,7 @@ use crate::on_chain_config::DaoConfig;
 use crate::on_chain_config::{
     ConsensusConfig, VMConfig, VMPublishingOption, Version, INITIAL_GAS_SCHEDULE,
 };
+use crate::on_chain_resource::Epoch;
 use crate::time::{TimeService, TimeServiceType};
 use crate::token::stc::STCUnit;
 use crate::token::token_value::TokenValue;
@@ -748,6 +751,24 @@ impl GenesisConfig {
     pub fn consensus(&self) -> ConsensusStrategy {
         ConsensusStrategy::try_from(self.consensus_config.strategy)
             .expect("consensus strategy config error.")
+    }
+
+    pub fn genesis_epoch(&self) -> Epoch {
+        Epoch::new(
+            0,
+            self.timestamp,
+            0,
+            self.consensus_config.epoch_block_count,
+            self.consensus_config.base_block_time_target,
+            self.consensus_config.base_reward_per_block,
+            self.consensus_config.base_reward_per_uncle_percent,
+            self.consensus_config.base_block_difficulty_window,
+            self.consensus_config.base_max_uncles_per_block,
+            self.consensus_config.base_block_gas_limit,
+            self.consensus_config.strategy,
+            //TODO conform new Epoch events salt value.
+            EventHandle::new_from_address(&genesis_address(), 0),
+        )
     }
 }
 

--- a/vm/types/src/on_chain_resource/block_metadata.rs
+++ b/vm/types/src/on_chain_resource/block_metadata.rs
@@ -1,0 +1,27 @@
+// Copyright (c) The Starcoin Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::event::EventHandle;
+use move_core_types::account_address::AccountAddress;
+use move_core_types::move_resource::MoveResource;
+use serde::{Deserialize, Serialize};
+use starcoin_crypto::HashValue;
+
+/// On chain resource BlockMetadata mapping
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BlockMetadata {
+    // number of the current block
+    pub number: u64,
+    // Hash of the parent block.
+    pub parent_hash: HashValue,
+    // Author of the current block.
+    pub author: AccountAddress,
+    pub uncles: u64,
+    // Handle where events with the time of new blocks are emitted
+    pub new_block_events: EventHandle,
+}
+
+impl MoveResource for BlockMetadata {
+    const MODULE_NAME: &'static str = "Block";
+    const STRUCT_NAME: &'static str = "BlockMetadata";
+}

--- a/vm/types/src/on_chain_resource/epoch.rs
+++ b/vm/types/src/on_chain_resource/epoch.rs
@@ -9,7 +9,7 @@ use serde::export::TryFrom;
 use serde::{Deserialize, Serialize};
 
 /// The Epoch resource held under an account.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Epoch {
     number: u64,
     //milli_seconds

--- a/vm/types/src/on_chain_resource/mod.rs
+++ b/vm/types/src/on_chain_resource/mod.rs
@@ -1,8 +1,10 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+mod block_metadata;
 mod epoch;
 mod global_time;
 
+pub use block_metadata::BlockMetadata;
 pub use epoch::{Epoch, EpochData, EpochInfo};
 pub use global_time::GlobalTimeOnChain;

--- a/vm/vm-runtime/src/errors.rs
+++ b/vm/vm-runtime/src/errors.rs
@@ -68,25 +68,37 @@ pub fn convert_prologue_runtime_error(error: VMError) -> Result<(), VMStatus> {
                 (INVALID_ARGUMENT, PROLOGUE_SCRIPT_NOT_ALLOWED) => StatusCode::UNKNOWN_SCRIPT,
                 (REQUIRES_ADDRESS, ENOT_GENESIS_ACCOUNT) => StatusCode::NO_ACCOUNT_ROLE,
                 (INVALID_STATE, ENOT_GENESIS) => {
+                    warn!("prologue runtime : INVALID_STATE, ENOT_GENESIS");
                     StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION
                 }
                 (INVALID_STATE, ECONFIG_VALUE_DOES_NOT_EXIST) => {
+                    warn!("prologue runtime : INVALID_STATE, ECONFIG_VALUE_DOES_NOT_EXIST");
                     StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION
                 }
                 (INVALID_ARGUMENT, EINVALID_TIMESTAMP) => {
+                    warn!("prologue runtime : INVALID_ARGUMENT, EINVALID_TIMESTAMP");
                     StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION
                 }
                 (INVALID_ARGUMENT, ECOIN_DEPOSIT_IS_ZERO) => {
+                    warn!("prologue runtime : INVALID_ARGUMENT, ECOIN_DEPOSIT_IS_ZERO");
                     StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION
                 }
                 (INVALID_STATE, EDESTROY_TOKEN_NON_ZERO) => {
+                    warn!("prologue runtime : INVALID_STATE, EDESTROY_TOKEN_NON_ZERO");
                     StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION
                 }
                 (INVALID_ARGUMENT, EBLOCK_NUMBER_MISMATCH) => {
+                    warn!("prologue runtime : INVALID_ARGUMENT, EBLOCK_NUMBER_MISMATCH");
                     StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION
                 }
                 // ToDo add corresponding error code into StatusCode
-                (_, _) => StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION,
+                (category, reason) => {
+                    warn!(
+                        "prologue runtime unknown: category({}), reason:({})",
+                        category, reason
+                    );
+                    StatusCode::UNEXPECTED_ERROR_FROM_KNOWN_MOVE_FUNCTION
+                }
             };
             VMStatus::Error(new_major_status)
         }


### PR DESCRIPTION
1. 重构以及清理了 Chain 的 verify 逻辑，将 verify 逻辑尽量放在一起，同时支持不同的 verify 策略： None, Basic, Consensus, Full.
2. 重构了 Chain 的 apply 逻辑，apply = verify + execute + connect.
3. 将 BlockDetail 重名名为 ExecutedBlock, 包含 BlockInfo，execute 和 apply 后返回 ExecutedBlock。
4. 定义了 ConsensusVerifyError，避免把其他错误误认为是 Verify 失败。
4. 重新梳理了 chain 的实现，做了一些清理。