### PR TITLE
[sync & network] Config refactor and cleanup

### DIFF
--- a/cmd/starcoin/src/node/sync/start_cmd.rs
+++ b/cmd/starcoin/src/node/sync/start_cmd.rs
@@ -15,6 +15,11 @@ pub struct StartOpt {
     /// if force is set, will cancel current sync task.
     force: bool,
 
+    #[structopt(long = "skip-pow-verify-when-sync")]
+    /// Don't verify pwd nonce and difficulty when sync, if you trust the peers.
+    /// Note: This flag may speed up the sync process, but may introduce security risks.
+    skip_pow_verify: bool,
+
     /// if peers is not empty, will try sync with the special peers.
     #[structopt(short = "p", long = "peer")]
     peers: Option<Vec<PeerId>>,
@@ -36,6 +41,7 @@ impl CommandAction for StartCommand {
         client.sync_start(
             ctx.opt().force,
             ctx.opt().peers.as_ref().cloned().unwrap_or_default(),
+            ctx.opt().skip_pow_verify,
         )
     }
 }

--- a/cmd/starcoin/src/node/sync/start_cmd.rs
+++ b/cmd/starcoin/src/node/sync/start_cmd.rs
@@ -15,7 +15,7 @@ pub struct StartOpt {
     /// if force is set, will cancel current sync task.
     force: bool,
 
-    #[structopt(long = "skip-pow-verify-when-sync")]
+    #[structopt(long = "skip-pow-verify")]
     /// Don't verify pwd nonce and difficulty when sync, if you trust the peers.
     /// Note: This flag may speed up the sync process, but may introduce security risks.
     skip_pow_verify: bool,

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -216,8 +216,12 @@ pub struct StarcoinOpt {
     pub disable_miner_client: bool,
 
     #[structopt(long = "disable-seed")]
-    /// Disable seed for seed node.
+    /// Do not connect to seed node, include builtin and config seed.
     pub disable_seed: bool,
+
+    #[structopt(long = "enable-mdns")]
+    /// Enable p2p mdns discovery, for automatically discover the peer from the local network.
+    pub enable_mdns: bool,
 
     #[structopt(long = "disable-mint-empty-block")]
     /// Do not mint empty block, default is true in Dev network.

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -219,11 +219,6 @@ pub struct StarcoinOpt {
     /// Disable seed for seed node.
     pub disable_seed: bool,
 
-    #[structopt(long = "skip-pow-verify-when-sync")]
-    /// Don't verify pwd nonce and difficulty when sync, if you trust the peers.
-    /// Note: This flag may speed up the sync process, but may introduce security risks.
-    pub skip_pow_verify_when_sync: bool,
-
     #[structopt(long = "disable-mint-empty-block")]
     /// Do not mint empty block, default is true in Dev network.
     pub disable_mint_empty_block: Option<bool>,

--- a/config/src/network_config.rs
+++ b/config/src/network_config.rs
@@ -89,8 +89,7 @@ pub struct NetworkConfig {
     pub listen: Multiaddr,
     pub seeds: Vec<MultiaddrWithPeerId>,
     pub enable_mdns: bool,
-    // Do not persistence this flag to config.
-    #[serde(skip)]
+    //TODO skip this field, do not persistence this flag to config. this change will break network config.
     pub disable_seed: bool,
     #[serde(skip)]
     network_keypair: Option<Arc<KeyPair<Ed25519PrivateKey, Ed25519PublicKey>>>,

--- a/config/src/network_config.rs
+++ b/config/src/network_config.rs
@@ -5,7 +5,7 @@ use crate::{
     decode_key, get_available_port_from, get_random_available_port, load_key, parse_key_val,
     ApiQuotaConfig, BaseConfig, ConfigModule, QuotaDuration, StarcoinOpt,
 };
-use anyhow::{bail, format_err, Result};
+use anyhow::{bail, Result};
 use network_p2p_types::{
     is_memory_addr, memory_addr,
     multiaddr::{Multiaddr, Protocol},
@@ -88,33 +88,31 @@ pub struct NetworkConfig {
     // The address that this node is listening on for new connections.
     pub listen: Multiaddr,
     pub seeds: Vec<MultiaddrWithPeerId>,
+    pub enable_mdns: bool,
+    // Do not persistence this flag to config.
+    #[serde(skip)]
     pub disable_seed: bool,
     #[serde(skip)]
-    pub network_keypair: Option<Arc<KeyPair<Ed25519PrivateKey, Ed25519PublicKey>>>,
+    network_keypair: Option<Arc<KeyPair<Ed25519PrivateKey, Ed25519PublicKey>>>,
     #[serde(skip)]
-    pub self_peer_id: Option<PeerId>,
+    self_peer_id: Option<PeerId>,
     #[serde(skip)]
-    pub self_address: Option<MultiaddrWithPeerId>,
+    self_address: Option<MultiaddrWithPeerId>,
     #[serde(default)]
     pub network_rpc_quotas: NetworkRpcQuotaConfiguration,
 }
 
 impl NetworkConfig {
     pub fn network_keypair(&self) -> Arc<KeyPair<Ed25519PrivateKey, Ed25519PublicKey>> {
-        self.network_keypair.clone().unwrap()
+        self.network_keypair.clone().expect("Config should init.")
     }
 
-    pub fn self_address(&self) -> Result<MultiaddrWithPeerId> {
-        self.self_address
-            .as_ref()
-            .cloned()
-            .ok_or_else(|| format_err!("Config not init."))
+    pub fn self_address(&self) -> MultiaddrWithPeerId {
+        self.self_address.clone().expect("Config should init.")
     }
 
-    pub fn self_peer_id(&self) -> Result<PeerId> {
-        self.self_peer_id
-            .clone()
-            .ok_or_else(|| format_err!("Self peer_id has not init."))
+    pub fn self_peer_id(&self) -> PeerId {
+        self.self_peer_id.clone().expect("Config should init.")
     }
 
     fn prepare_peer_id(&mut self) {
@@ -178,10 +176,11 @@ impl ConfigModule for NetworkConfig {
         Ok(Self {
             listen,
             seeds,
+            enable_mdns: opt.enable_mdns,
+            disable_seed: opt.disable_seed,
             network_keypair: Some(Arc::new(Self::load_or_generate_keypair(opt, base)?)),
             self_peer_id: None,
             self_address: None,
-            disable_seed: opt.disable_seed,
             network_rpc_quotas: opt.network_rpc_quotas.clone(),
         })
     }

--- a/config/src/sync_config.rs
+++ b/config/src/sync_config.rs
@@ -12,17 +12,11 @@ use std::str::FromStr;
 #[serde(deny_unknown_fields)]
 pub struct SyncConfig {
     sync_mode: SyncMode,
-    //Do not persistence this flag to config file.
-    #[serde(skip)]
-    pub skip_pow_verify_when_sync: bool,
 }
 
 impl SyncConfig {
     pub fn new(sync_mode: SyncMode) -> Self {
-        Self {
-            sync_mode,
-            skip_pow_verify_when_sync: false,
-        }
+        Self { sync_mode }
     }
 
     pub fn set_mode(&mut self, sync_mode: SyncMode) {
@@ -41,10 +35,7 @@ impl SyncConfig {
 impl ConfigModule for SyncConfig {
     fn default_with_opt(opt: &StarcoinOpt, _base: &BaseConfig) -> Result<Self> {
         let sync_mode = opt.sync_mode.unwrap_or_else(|| SyncMode::FULL);
-        Ok(SyncConfig {
-            sync_mode,
-            skip_pow_verify_when_sync: opt.skip_pow_verify_when_sync,
-        })
+        Ok(SyncConfig { sync_mode })
     }
 
     fn after_load(&mut self, opt: &StarcoinOpt, _base: &BaseConfig) -> Result<()> {
@@ -54,11 +45,7 @@ impl ConfigModule for SyncConfig {
         if self.sync_mode == SyncMode::LIGHT || self.sync_mode == SyncMode::FAST {
             bail!("{} is not supported yet.", self.sync_mode);
         }
-        self.skip_pow_verify_when_sync = opt.skip_pow_verify_when_sync;
-        info!(
-            "Sync mode : {:?} : {:?}, skip_pow_verify_when_sync: {}",
-            opt.sync_mode, self.sync_mode, self.skip_pow_verify_when_sync
-        );
+        info!("Sync mode : {:?} : {:?}", opt.sync_mode, self.sync_mode);
         Ok(())
     }
 }

--- a/network-p2p/src/config.rs
+++ b/network-p2p/src/config.rs
@@ -104,10 +104,7 @@ pub struct NetworkConfiguration {
 
     pub transport: TransportConfig,
 
-    pub disable_seed: bool,
-
-    pub protocols: Vec<Cow<'static, str>>,
-
+    pub notifications_protocols: Vec<Cow<'static, str>>,
     pub request_response_protocols: Vec<RequestResponseConfig>,
     /// Should we insert non-global addresses into the DHT?
     pub allow_non_globals_in_dht: bool,
@@ -162,8 +159,7 @@ impl Default for NetworkConfiguration {
                 allow_private_ipv4: false,
                 wasm_external_transport: None,
             },
-            disable_seed: false,
-            protocols: vec![],
+            notifications_protocols: vec![],
             request_response_protocols: vec![],
             allow_non_globals_in_dht: false,
             kademlia_disjoint_query_paths: false,
@@ -183,8 +179,6 @@ impl NetworkConfiguration {
             public_addresses: Vec::new(),
             boot_nodes: Vec::new(),
             node_key,
-            //notifications_protocols: Vec::new(),
-            //request_response_protocols: Vec::new(),
             in_peers: 25,
             out_peers: 75,
             reserved_nodes: Vec::new(),
@@ -196,8 +190,7 @@ impl NetworkConfiguration {
                 allow_private_ipv4: true,
                 wasm_external_transport: None,
             },
-            disable_seed: false,
-            protocols: vec![],
+            notifications_protocols: vec![],
             request_response_protocols: vec![],
             allow_non_globals_in_dht: false,
             kademlia_disjoint_query_paths: false,

--- a/network-p2p/src/service.rs
+++ b/network-p2p/src/service.rs
@@ -214,7 +214,7 @@ impl NetworkWorker {
         let num_connected = Arc::new(AtomicUsize::new(0));
         let is_major_syncing = Arc::new(AtomicBool::new(false));
 
-        let notif_protocols = params.network_config.protocols.clone();
+        let notif_protocols = params.network_config.notifications_protocols.clone();
 
         let (protocol, peerset_handle) = Protocol::new(
             peerset_config,

--- a/network-p2p/src/service_test.rs
+++ b/network-p2p/src/service_test.rs
@@ -59,7 +59,7 @@ fn build_nodes_one_proto() -> (
 
     let (node1, events_stream1) = build_test_full_node(config::NetworkConfiguration {
         //notifications_protocols: vec![(ENGINE_ID, From::from("/foo"))],
-        protocols: vec![From::from(PROTOCOL_NAME)],
+        notifications_protocols: vec![From::from(PROTOCOL_NAME)],
         listen_addresses: vec![listen_addr.clone()],
         transport: config::TransportConfig::MemoryOnly,
         ..config::NetworkConfiguration::new_local()
@@ -67,7 +67,7 @@ fn build_nodes_one_proto() -> (
 
     let (node2, events_stream2) = build_test_full_node(config::NetworkConfiguration {
         //notifications_protocols: vec![(ENGINE_ID, From::from("/foo"))],
-        protocols: vec![From::from(PROTOCOL_NAME)],
+        notifications_protocols: vec![From::from(PROTOCOL_NAME)],
         listen_addresses: vec![],
         reserved_nodes: vec![config::MultiaddrWithPeerId {
             multiaddr: listen_addr,
@@ -85,7 +85,7 @@ fn lots_of_incoming_peers_works() {
     let listen_addr = config::build_multiaddr![Memory(rand::random::<u64>())];
 
     let (main_node, _) = build_test_full_node(config::NetworkConfiguration {
-        protocols: vec![From::from(PROTOCOL_NAME)],
+        notifications_protocols: vec![From::from(PROTOCOL_NAME)],
         listen_addresses: vec![listen_addr.clone()],
         in_peers: u32::max_value(),
         transport: config::TransportConfig::MemoryOnly,
@@ -102,7 +102,7 @@ fn lots_of_incoming_peers_works() {
         let main_node_peer_id = main_node_peer_id.clone();
 
         let (_dialing_node, event_stream) = build_test_full_node(config::NetworkConfiguration {
-            protocols: vec![From::from(PROTOCOL_NAME)],
+            notifications_protocols: vec![From::from(PROTOCOL_NAME)],
             listen_addresses: vec![],
             reserved_nodes: vec![config::MultiaddrWithPeerId {
                 multiaddr: listen_addr.clone(),
@@ -471,7 +471,7 @@ fn generate_config(boot_nodes: Vec<MultiaddrWithPeerId>) -> NetworkConfiguration
 
     config::NetworkConfiguration {
         //notifications_protocols: vec![(ENGINE_ID, From::from("/foo"))],
-        protocols: vec![From::from(PROTOCOL_NAME)],
+        notifications_protocols: vec![From::from(PROTOCOL_NAME)],
         listen_addresses: vec![listen_addr],
         transport: config::TransportConfig::MemoryOnly,
         boot_nodes,

--- a/network-rpc/src/tests.rs
+++ b/network-rpc/src/tests.rs
@@ -20,7 +20,7 @@ use vm_types::on_chain_resource::Epoch;
 fn test_network_rpc() {
     let (handle1, net_addr_1) = {
         let config_1 = NodeConfig::random_for_test();
-        let net_addr = config_1.network.self_address().unwrap();
+        let net_addr = config_1.network.self_address();
         debug!("First node address: {:?}", net_addr);
         (gen_chain_env(config_1).unwrap(), net_addr)
     };
@@ -29,7 +29,7 @@ fn test_network_rpc() {
     let (handle2, peer_id_2) = {
         let mut config_2 = NodeConfig::random_for_test();
         config_2.network.seeds = vec![net_addr_1];
-        let peer_id_2 = config_2.network.self_peer_id().unwrap();
+        let peer_id_2 = config_2.network.self_peer_id();
         (gen_chain_env(config_2).unwrap(), peer_id_2)
     };
     handle2.generate_block().unwrap();

--- a/network/src/service.rs
+++ b/network/src/service.rs
@@ -55,7 +55,7 @@ impl NetworkActorService {
             rpc,
         )?;
         let service = worker.service().clone();
-        let self_info = PeerInfo::new(config.network.self_peer_id()?, chain_info);
+        let self_info = PeerInfo::new(config.network.self_peer_id(), chain_info);
         let inner = Inner::new(self_info, service, peer_message_handler)?;
         Ok(Self {
             worker: Some(worker),

--- a/network/src/worker.rs
+++ b/network/src/worker.rs
@@ -34,9 +34,8 @@ pub fn build_network_worker(
         TransportConfig::MemoryOnly
     } else {
         TransportConfig::Normal {
-            //TODO support enable mdns by config.
-            enable_mdns: false,
-            allow_private_ipv4: false,
+            enable_mdns: node_config.network.enable_mdns,
+            allow_private_ipv4: true,
             wasm_external_transport: None,
         }
     };
@@ -71,7 +70,7 @@ pub fn build_network_worker(
             .collect::<Vec<_>>(),
         None => vec![],
     };
-    let self_peer_id = node_config.network.self_peer_id()?;
+    let self_peer_id = node_config.network.self_peer_id();
     let boot_nodes = if node_config.network.disable_seed {
         vec![]
     } else {
@@ -97,7 +96,7 @@ pub fn build_network_worker(
             .expect("decode network node key should success.");
             NodeKeyConfig::Ed25519(Secret::Input(secret))
         },
-        protocols,
+        notifications_protocols: protocols,
         request_response_protocols: rpc_protocols,
         transport: transport_config,
         node_name: node_name.to_string(),

--- a/network/tests/network_node_test.rs
+++ b/network/tests/network_node_test.rs
@@ -21,7 +21,7 @@ fn test_reconnected_peers() -> anyhow::Result<()> {
     assert_eq!(peers.len(), 0);
 
     let mut node_config2 = NodeConfig::random_for_test();
-    node_config2.network.seeds = vec![node_config1.network.self_address()?];
+    node_config2.network.seeds = vec![node_config1.network.self_address()];
     let node_config2 = Arc::new(node_config2);
     let node2 = test_helper::run_node_by_config(node_config2.clone())?;
 

--- a/network/tests/network_rpc_test.rs
+++ b/network/tests/network_rpc_test.rs
@@ -28,13 +28,13 @@ async fn test_network_raw_rpc() {
     let service1 = build_network(None, Some((rpc_info.clone(), MockRpcHandler::echo())))
         .await
         .unwrap();
-    let peer_id_1 = service1.config.network.self_peer_id().unwrap();
-    let seed = service1.config.network.self_address().unwrap();
+    let peer_id_1 = service1.config.network.self_peer_id();
+    let seed = service1.config.network.self_address();
 
     let service2 = build_network(Some(seed), Some((rpc_info, MockRpcHandler::echo())))
         .await
         .unwrap();
-    let peer_id_2 = service2.config.network.self_peer_id().unwrap();
+    let peer_id_2 = service2.config.network.self_peer_id();
     Delay::new(Duration::from_secs(1)).await;
     let request = TestRequest {
         data: HashValue::random(),

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -236,17 +236,10 @@ impl NodeService {
 
         registry.register::<TxnSyncService>().await?;
 
-        let peer_id = config.network.self_peer_id()?;
+        let peer_id = config.network.self_peer_id();
 
         info!("Self peer_id is: {}", peer_id.to_base58());
-        info!(
-            "Self address is: {}",
-            config
-                .network
-                .self_address
-                .as_ref()
-                .expect("Self connect address must has been set.")
-        );
+        info!("Self address is: {}", config.network.self_address());
 
         registry.register::<CreateBlockTemplateService>().await?;
         registry.register::<MinerService>().await?;

--- a/rpc/api/src/sync_manager.rs
+++ b/rpc/api/src/sync_manager.rs
@@ -19,7 +19,7 @@ pub trait SyncManagerApi {
     #[rpc(name = "sync.start")]
     /// if `force` is true, will cancel current task and start a new task.
     /// if peers is not empty, will try sync with the special peers.
-    fn start(&self, force: bool, peers: Vec<PeerId>) -> FutureResult<()>;
+    fn start(&self, force: bool, peers: Vec<PeerId>, skip_pow_verify: bool) -> FutureResult<()>;
 
     #[rpc(name = "sync.progress")]
     fn progress(&self) -> FutureResult<Option<SyncProgressReport>>;

--- a/rpc/client/src/lib.rs
+++ b/rpc/client/src/lib.rs
@@ -838,9 +838,18 @@ impl RpcClient {
             .map_err(map_err)
     }
 
-    pub fn sync_start(&self, force: bool, peers: Vec<PeerId>) -> anyhow::Result<()> {
+    pub fn sync_start(
+        &self,
+        force: bool,
+        peers: Vec<PeerId>,
+        skip_pow_verify: bool,
+    ) -> anyhow::Result<()> {
         self.call_rpc_blocking(|inner| async move {
-            inner.sync_client.start(force, peers).compat().await
+            inner
+                .sync_client
+                .start(force, peers, skip_pow_verify)
+                .compat()
+                .await
         })
         .map_err(map_err)
     }

--- a/rpc/server/src/module/node_rpc.rs
+++ b/rpc/server/src/module/node_rpc.rs
@@ -33,13 +33,7 @@ impl NodeApi for NodeRpcImpl {
 
     fn info(&self) -> FutureResult<NodeInfo> {
         let service = self.service.clone().unwrap();
-        let self_address = self
-            .config
-            .network
-            .self_address
-            .as_ref()
-            .expect("self address must exist in runtime.")
-            .to_string();
+        let self_address = self.config.network.self_address().to_string();
         let net = self.config.net().clone();
         let fut = async move {
             let peer_info = service.get_self_peer().await?;

--- a/rpc/server/src/module/sync_manager_rpc.rs
+++ b/rpc/server/src/module/sync_manager_rpc.rs
@@ -50,10 +50,10 @@ where
         Box::new(fut.boxed().compat())
     }
 
-    fn start(&self, force: bool, peers: Vec<PeerId>) -> FutureResult<()> {
+    fn start(&self, force: bool, peers: Vec<PeerId>, skip_pow_verify: bool) -> FutureResult<()> {
         let service = self.service.clone();
         let fut = async move {
-            service.start(force, peers).await?;
+            service.start(force, peers, skip_pow_verify).await?;
             Ok(())
         }
         .map_err(map_err);

--- a/sync/api/src/lib.rs
+++ b/sync/api/src/lib.rs
@@ -89,6 +89,7 @@ impl ServiceRequest for SyncCancelRequest {
 pub struct SyncStartRequest {
     pub force: bool,
     pub peers: Vec<PeerId>,
+    pub skip_pow_verify: bool,
 }
 
 impl ServiceRequest for SyncStartRequest {

--- a/sync/api/src/service.rs
+++ b/sync/api/src/service.rs
@@ -16,7 +16,7 @@ pub trait SyncAsyncService: Clone + std::marker::Unpin + Send + Sync {
     async fn cancel(&self) -> Result<()>;
     /// if `force` is true, will cancel current task and start a new task.
     /// if peers is not empty, will try sync with the special peers.
-    async fn start(&self, force: bool, peers: Vec<PeerId>) -> Result<()>;
+    async fn start(&self, force: bool, peers: Vec<PeerId>, skip_pow_verify: bool) -> Result<()>;
 }
 
 pub trait SyncServiceHandler:
@@ -45,7 +45,12 @@ where
         self.send(SyncCancelRequest).await
     }
 
-    async fn start(&self, force: bool, peers: Vec<PeerId>) -> Result<()> {
-        self.send(SyncStartRequest { force, peers }).await?
+    async fn start(&self, force: bool, peers: Vec<PeerId>, skip_pow_verify: bool) -> Result<()> {
+        self.send(SyncStartRequest {
+            force,
+            peers,
+            skip_pow_verify,
+        })
+        .await?
     }
 }

--- a/sync/src/download.rs
+++ b/sync/src/download.rs
@@ -110,7 +110,7 @@ impl ServiceFactory<Self> for DownloadService {
             .get_startup_info()?
             .ok_or_else(|| format_err!("Startup info should exist."))?;
         let network = ctx.get_shared::<NetworkServiceRef>()?;
-        let peer_id = node_config.network.self_peer_id()?;
+        let peer_id = node_config.network.self_peer_id();
         Ok(Self::new(
             node_config,
             peer_id,

--- a/sync/src/tasks/block_sync_task.rs
+++ b/sync/src/tasks/block_sync_task.rs
@@ -177,7 +177,7 @@ where
     chain: BlockChain,
     event_handle: Box<dyn BlockConnectedEventHandle>,
     network: N,
-    skip_pow_verify_when_sync: bool,
+    skip_pow_verify: bool,
 }
 
 impl<N> BlockCollector<N>
@@ -214,7 +214,7 @@ where
             chain,
             event_handle: Box::new(event_handle),
             network,
-            skip_pow_verify_when_sync,
+            skip_pow_verify: skip_pow_verify_when_sync,
         }
     }
 
@@ -224,7 +224,7 @@ where
     }
 
     fn apply_block(&mut self, block: Block, peer_id: Option<PeerId>) -> Result<()> {
-        if let Err(err) = if self.skip_pow_verify_when_sync {
+        if let Err(err) = if self.skip_pow_verify {
             self.chain
                 .apply_with_verifier::<BasicVerifier>(block.clone())
         } else {

--- a/sync/src/tasks/mod.rs
+++ b/sync/src/tasks/mod.rs
@@ -190,7 +190,7 @@ use starcoin_types::peer_info::PeerId;
 pub fn full_sync_task<H, F, N>(
     current_block_id: HashValue,
     target: BlockInfo,
-    skip_pow_verify_when_sync: bool,
+    skip_pow_verify: bool,
     time_service: Arc<dyn TimeService>,
     storage: Arc<dyn Store>,
     block_event_handle: H,
@@ -289,7 +289,7 @@ where
                 1,
             );
             let chain = BlockChain::new(time_service, ancestor.id, chain_storage)?;
-            let block_collector = BlockCollector::new_with_handle(current_block_info, chain, block_event_handle, network, skip_pow_verify_when_sync);
+            let block_collector = BlockCollector::new_with_handle(current_block_info, chain, block_event_handle, network, skip_pow_verify);
             Ok(TaskGenerator::new(
                 block_sync_task,
                 10,

--- a/sync/tests/full_sync_test.rs
+++ b/sync/tests/full_sync_test.rs
@@ -20,10 +20,7 @@ fn test_full_sync() {
 #[stest::test(timeout = 120)]
 fn test_sync_by_notification() {
     let first_config = Arc::new(NodeConfig::random_for_test());
-    info!(
-        "first peer : {:?}",
-        first_config.network.self_peer_id().unwrap()
-    );
+    info!("first peer : {:?}", first_config.network.self_peer_id());
     let first_node = run_node_by_config(first_config.clone()).unwrap();
     let first_chain = first_node.chain_service().unwrap();
 
@@ -31,11 +28,8 @@ fn test_sync_by_notification() {
     sleep(Duration::from_millis(1000));
 
     let mut second_config = NodeConfig::random_for_test();
-    info!(
-        "second peer : {:?}",
-        second_config.network.self_peer_id().unwrap()
-    );
-    second_config.network.seeds = vec![first_config.network.self_address().unwrap()];
+    info!("second peer : {:?}", second_config.network.self_peer_id());
+    second_config.network.seeds = vec![first_config.network.self_address()];
     second_config.miner.enable_miner_client = false;
 
     let second_node = run_node_by_config(Arc::new(second_config)).unwrap();
@@ -79,10 +73,7 @@ fn test_sync_by_notification() {
 #[stest::test(timeout = 120)]
 fn test_broadcast_with_difficulty() {
     let first_config = Arc::new(NodeConfig::random_for_test());
-    info!(
-        "first peer : {:?}",
-        first_config.network.self_peer_id().unwrap()
-    );
+    info!("first peer : {:?}", first_config.network.self_peer_id());
     let first_node = run_node_by_config(first_config.clone()).unwrap();
     let first_chain = first_node.chain_service().unwrap();
     let count = 5;
@@ -94,11 +85,8 @@ fn test_broadcast_with_difficulty() {
     let number_1 = block_1.header().number();
 
     let mut second_config = NodeConfig::random_for_test();
-    info!(
-        "second peer : {:?}",
-        second_config.network.self_peer_id().unwrap()
-    );
-    second_config.network.seeds = vec![first_config.network.self_address().unwrap()];
+    info!("second peer : {:?}", second_config.network.self_peer_id());
+    second_config.network.seeds = vec![first_config.network.self_address()];
     //second_config.miner.enable_miner_client = false;
     second_config.sync.set_mode(SyncMode::FULL);
 

--- a/sync/tests/test_sync/mod.rs
+++ b/sync/tests/test_sync/mod.rs
@@ -8,10 +8,7 @@ use traits::ChainAsyncService;
 
 pub fn test_sync(sync_mode: SyncMode) {
     let first_config = Arc::new(NodeConfig::random_for_test());
-    info!(
-        "first peer : {:?}",
-        first_config.network.self_peer_id().unwrap()
-    );
+    info!("first peer : {:?}", first_config.network.self_peer_id());
     let first_node = run_node_by_config(first_config.clone()).unwrap();
     let first_chain = first_node.chain_service().unwrap();
     let count = 5;
@@ -26,11 +23,8 @@ pub fn test_sync(sync_mode: SyncMode) {
     assert_eq!(number_1, count);
 
     let mut second_config = NodeConfig::random_for_test();
-    info!(
-        "second peer : {:?}",
-        second_config.network.self_peer_id().unwrap()
-    );
-    second_config.network.seeds = vec![first_config.network.self_address().unwrap()];
+    info!("second peer : {:?}", second_config.network.self_peer_id());
+    second_config.network.seeds = vec![first_config.network.self_address()];
     second_config.miner.enable_miner_client = false;
     second_config.sync.set_mode(sync_mode);
 

--- a/sync/tests/txn_sync_test.rs
+++ b/sync/tests/txn_sync_test.rs
@@ -16,7 +16,7 @@ use txpool::TxPoolService;
 fn test_txn_sync_actor() {
     let mut first_config = NodeConfig::random_for_test();
     first_config.miner.enable_miner_client = false;
-    let first_network_address = first_config.network.self_address().unwrap();
+    let first_network_address = first_config.network.self_address();
     let first_config = Arc::new(first_config);
     let first_node = run_node_by_config(first_config.clone()).unwrap();
     let txpool_1 = first_node

--- a/test-helper/src/network.rs
+++ b/test-helper/src/network.rs
@@ -106,7 +106,7 @@ pub struct TestNetworkService {
 
 impl TestNetworkService {
     pub fn peer_id(&self) -> PeerId {
-        self.config.network.self_peer_id().unwrap()
+        self.config.network.self_peer_id()
     }
 }
 
@@ -119,7 +119,7 @@ pub async fn build_network_pair() -> Result<(TestNetworkService, TestNetworkServ
 
 pub async fn build_network_cluster(n: usize) -> Result<Vec<TestNetworkService>> {
     let seed_service = build_network(None, None).await?;
-    let seed = seed_service.config.network.self_address()?;
+    let seed = seed_service.config.network.self_address();
     let mut nodes = vec![seed_service];
     for _i in 1..n {
         let service = build_network(Some(seed.clone()), None).await?;


### PR DESCRIPTION
1.  将 skip-pow-verify 作为 node sync start 的参数，而不是全局参数。
2. 增加了 enable_mdns 参数，开启网络的 mdsn。
3. allow_private_ipv4 默认设置位 true。
4. 清理了一些配置项，self_address/self_peer_id 在 network config 内部 expect，而不是抛出 Error。