### PR TITLE
[cmd & scmd] Pass version/long version by args and fix git version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6315,7 +6315,6 @@ dependencies = [
  "clap 2.33.3",
  "cli-table",
  "ctrlc",
- "git-version",
  "once_cell",
  "rand 0.7.3",
  "rust-flatten-json",

--- a/cmd/generator/src/main.rs
+++ b/cmd/generator/src/main.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Result;
 use scmd::CmdContext;
-use starcoin_config::StarcoinOpt;
+use starcoin_config::{StarcoinOpt, APP_VERSION, CRATE_VERSION};
 use starcoin_generator::cli_state::CliState;
 use starcoin_generator::gen_data::GenDataCommand;
 use starcoin_generator::gen_genesis::GenGenesisCommand;
@@ -11,7 +11,11 @@ use starcoin_generator::gen_genesis_config::GenGenesisConfigCommand;
 use starcoin_logger::prelude::*;
 
 fn run() -> Result<()> {
-    let context = CmdContext::<CliState, StarcoinOpt>::with_state(CliState);
+    let context = CmdContext::<CliState, StarcoinOpt>::with_state(
+        CRATE_VERSION,
+        Some(APP_VERSION.as_str()),
+        CliState,
+    );
     context
         .command(GenGenesisConfigCommand)
         .command(GenGenesisCommand)

--- a/cmd/starcoin/src/main.rs
+++ b/cmd/starcoin/src/main.rs
@@ -5,7 +5,7 @@ use scmd::error::CmdError;
 use scmd::CmdContext;
 use starcoin_cmd::*;
 use starcoin_cmd::{CliState, StarcoinOpt};
-use starcoin_config::Connect;
+use starcoin_config::{Connect, APP_VERSION, CRATE_VERSION};
 use starcoin_logger::prelude::*;
 use starcoin_node::crash_handler;
 use starcoin_node_api::errors::NodeStartError;
@@ -20,6 +20,8 @@ static EXIT_CODE_NEED_HELP: i32 = 120;
 fn run() -> Result<()> {
     let logger_handle = starcoin_logger::init();
     let context = CmdContext::<CliState, StarcoinOpt>::with_default_action(
+        CRATE_VERSION,
+        Some(APP_VERSION.as_str()),
         |opt| -> Result<CliState> {
             info!("Starcoin opts: {:?}", opt);
             let connect = opt.connect.as_ref().unwrap_or(&Connect::IPC(None));

--- a/commons/scmd/Cargo.toml
+++ b/commons/scmd/Cargo.toml
@@ -13,7 +13,6 @@ serde = { version = "1.0", features = ["derive"] }
 rustyline = "7.1.0"
 structopt = "0.3.21"
 clap = "2.33.3"
-git-version = "0.3.4"
 serde_json = { version="1.0", features = ["arbitrary_precision"]}
 rust-flatten-json = "0.2.0"
 cli-table = "0.3.2"

--- a/commons/scmd/examples/hello_main.rs
+++ b/commons/scmd/examples/hello_main.rs
@@ -193,6 +193,8 @@ struct TestOpts {
 
 pub(crate) fn init_context() -> CmdContext<Counter, GlobalOpts> {
     let context = CmdContext::<Counter, GlobalOpts>::with_default_action(
+        "0.1",
+        None,
         |global_opt| -> Result<Counter> { Ok(Counter::new(global_opt.counter)) },
         |_app, _opt, _state| {
             let running = Arc::new(AtomicBool::new(true));

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -63,8 +63,11 @@ pub use storage_config::{RocksdbConfig, StorageConfig};
 pub use sync_config::SyncMode;
 pub use txpool_config::TxPoolConfig;
 
-static CRATE_VERSION: &str = crate_version!();
-static GIT_VERSION: &str = git_version!(fallback = "unknown");
+pub static CRATE_VERSION: &str = crate_version!();
+pub static GIT_VERSION: &str = git_version!(
+    args = ["--tags", "--dirty", "--always"],
+    fallback = "unknown"
+);
 
 pub static APP_NAME: &str = "starcoin";
 pub static APP_VERSION: Lazy<String> = Lazy::new(|| {

--- a/testsuite/tests/steps/cmd.rs
+++ b/testsuite/tests/steps/cmd.rs
@@ -10,6 +10,7 @@ use scmd::CmdContext;
 use serde_json::Value;
 use starcoin_cmd::add_command;
 use starcoin_cmd::{CliState, StarcoinOpt};
+use starcoin_config::{APP_VERSION, CRATE_VERSION};
 use starcoin_logger::prelude::*;
 use static_assertions::_core::time::Duration;
 use std::collections::{HashMap, HashSet};
@@ -37,7 +38,11 @@ pub fn steps() -> Steps<MyWorld> {
                 Some(Duration::from_secs(5)),
                 None,
             );
-            let context = CmdContext::<CliState, StarcoinOpt>::with_state(state);
+            let context = CmdContext::<CliState, StarcoinOpt>::with_state(
+                CRATE_VERSION,
+                Some(APP_VERSION.as_str()),
+                state,
+            );
             // get last cmd result as current parameter
             let mut vec = vec!["starcoin"];
             let parameters = get_command_args(world, (*args[1]).parse().unwrap());


### PR DESCRIPTION
1. Version 作为参数传递，scmd 不在自动生成 version。
2. 增加参数，让 git_version 可以正确获取到最新的 git tag。