### PR TITLE
[types]Reuse Transaction's id

### DIFF
--- a/account/lib/src/account_test.rs
+++ b/account/lib/src/account_test.rs
@@ -116,10 +116,7 @@ pub fn test_wallet_account() -> Result<()> {
     use core::convert::{From, TryFrom};
     use scs::SCSCodec;
     use starcoin_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature};
-    use starcoin_crypto::{
-        hash::{CryptoHash, PlainCryptoHash},
-        HashValue,
-    };
+    use starcoin_crypto::{hash::CryptoHash, HashValue};
     use starcoin_types::transaction::authenticator::AuthenticationKey;
 
     let bytes = hex::decode("2c78c6fd8829de80451cda02310250b27307360ddc972d614fa0c8462ae41b3e")?;
@@ -211,6 +208,6 @@ pub fn test_wallet_account() -> Result<()> {
         211, 150, 199, 7, 37, 161, 6, 202, 7,
     ];
     let stxn = SignedUserTransaction::decode(&stxn_bytes)?;
-    println!("txn hash is {:?}", stxn.crypto_hash());
+    println!("txn hash is {:?}", stxn.id());
     Ok(())
 }

--- a/block-relayer/src/block_relayer.rs
+++ b/block-relayer/src/block_relayer.rs
@@ -23,7 +23,7 @@ use starcoin_types::{
     cmpact_block::{CompactBlock, ShortId},
     peer_info::PeerId,
     system_events::NewHeadBlock,
-    transaction::{SignedUserTransaction, Transaction},
+    transaction::SignedUserTransaction,
 };
 use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
@@ -80,11 +80,10 @@ impl BlockRelayer {
                 if prefilled_txn.index as usize >= txns.len() {
                     continue;
                 }
-                txns[prefilled_txn.index as usize] = Some(prefilled_txn.clone().tx);
+                let id = prefilled_txn.tx.id();
+                txns[prefilled_txn.index as usize] = Some(prefilled_txn.tx);
                 BLOCK_RELAYER_METRICS.txns_filled_from_prefill.inc();
-                missing_txn_short_ids.remove(&ShortId(
-                    Transaction::UserTransaction(prefilled_txn.tx).id(),
-                ));
+                missing_txn_short_ids.remove(&ShortId(id));
             }
             // Fetch the missing txns from peer
             let missing_txn_ids: Vec<HashValue> = missing_txn_short_ids

--- a/chain/chain-notify/src/lib.rs
+++ b/chain/chain-notify/src/lib.rs
@@ -5,7 +5,6 @@ pub mod message;
 
 use crate::message::{ContractEventNotification, Event, Notification, ThinBlock};
 use anyhow::{format_err, Result};
-use starcoin_crypto::hash::PlainCryptoHash;
 use starcoin_logger::prelude::*;
 use starcoin_service_registry::{ActorService, EventHandler, ServiceContext, ServiceFactory};
 use starcoin_storage::{Storage, Store};
@@ -93,11 +92,7 @@ impl ChainNotifyHandlerService {
     pub fn notify_new_block(&self, block: &Block, ctx: &mut ServiceContext<Self>) {
         let thin_block = ThinBlock::new(
             block.header().clone(),
-            block
-                .transactions()
-                .iter()
-                .map(|t| t.crypto_hash())
-                .collect(),
+            block.transactions().iter().map(|t| t.id()).collect(),
         );
         ctx.broadcast(Notification(thin_block));
     }

--- a/chain/src/tests/test_block_chain.rs
+++ b/chain/src/tests/test_block_chain.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Result;
 use consensus::Consensus;
-use crypto::{ed25519::Ed25519PrivateKey, hash::PlainCryptoHash, Genesis, PrivateKey};
+use crypto::{ed25519::Ed25519PrivateKey, Genesis, PrivateKey};
 use starcoin_account_api::AccountInfo;
 use starcoin_chain_mock::{BlockChain, MockChain};
 use starcoin_config::NodeConfig;
@@ -386,7 +386,7 @@ async fn test_block_chain_txn_info_fork_mapping() -> Result<()> {
         );
         txn.as_signed_user_txn()?.clone()
     };
-    let tnx_hash = signed_txn_t2.crypto_hash();
+    let tnx_hash = signed_txn_t2.id();
     let (template_b2, excluded) = block_chain.create_block_template(
         *miner_account.address(),
         Some(miner_account.public_key.authentication_key()),

--- a/cmd/starcoin/src/account/accept_token_cmd.rs
+++ b/cmd/starcoin/src/account/accept_token_cmd.rs
@@ -5,7 +5,7 @@ use crate::cli_state::CliState;
 use crate::StarcoinOpt;
 use anyhow::{bail, Result};
 use scmd::{CommandAction, ExecContext};
-use starcoin_crypto::hash::{HashValue, PlainCryptoHash};
+use starcoin_crypto::hash::HashValue;
 use starcoin_executor::DEFAULT_EXPIRATION_TIME;
 use starcoin_rpc_client::RemoteStateReader;
 use starcoin_state_api::AccountStateReader;
@@ -91,7 +91,7 @@ impl CommandAction for AcceptTokenCommand {
         );
 
         let signed_txn = client.account_sign_txn(accept_token_txn)?;
-        let txn_hash = signed_txn.crypto_hash();
+        let txn_hash = signed_txn.id();
         client.submit_transaction(signed_txn)?;
         println!("txn {:#x} submitted.", txn_hash);
 

--- a/cmd/starcoin/src/account/execute_builtin_script_cmd.rs
+++ b/cmd/starcoin/src/account/execute_builtin_script_cmd.rs
@@ -5,7 +5,7 @@ use crate::cli_state::CliState;
 use crate::StarcoinOpt;
 use anyhow::{bail, Result};
 use scmd::{CommandAction, ExecContext};
-use starcoin_crypto::hash::{HashValue, PlainCryptoHash};
+use starcoin_crypto::hash::HashValue;
 use starcoin_rpc_client::RemoteStateReader;
 use starcoin_state_api::AccountStateReader;
 use starcoin_transaction_builder::compiled_transaction_script;
@@ -123,7 +123,7 @@ impl CommandAction for ExecuteBuildInCommand {
         );
 
         let signed_txn = client.account_sign_txn(script_txn)?;
-        let txn_hash = signed_txn.crypto_hash();
+        let txn_hash = signed_txn.id();
         client.submit_transaction(signed_txn)?;
         println!("txn {:#x} submitted.", txn_hash);
 

--- a/cmd/starcoin/src/account/transfer_cmd.rs
+++ b/cmd/starcoin/src/account/transfer_cmd.rs
@@ -6,7 +6,6 @@ use crate::view::{ExecuteResultView, ExecutionOutputView};
 use crate::StarcoinOpt;
 use anyhow::{format_err, Result};
 use scmd::{CommandAction, ExecContext};
-use starcoin_crypto::hash::PlainCryptoHash;
 use starcoin_crypto::{ed25519::Ed25519PublicKey, ValidCryptoMaterialStringExt};
 use starcoin_executor::DEFAULT_EXPIRATION_TIME;
 use starcoin_rpc_client::RemoteStateReader;
@@ -136,7 +135,7 @@ impl CommandAction for TransferCommand {
             ctx.state().net().chain_id(),
         );
         let txn = client.account_sign_txn(raw_txn)?;
-        let txn_hash = txn.crypto_hash();
+        let txn_hash = txn.id();
         client.submit_transaction(txn)?;
 
         let mut output_view = ExecutionOutputView::new(txn_hash);

--- a/cmd/starcoin/src/debug/gen_block_cmd.rs
+++ b/cmd/starcoin/src/debug/gen_block_cmd.rs
@@ -6,7 +6,6 @@ use crate::dev::sign_txn_with_account_by_rpc_client;
 use crate::StarcoinOpt;
 use anyhow::Result;
 use scmd::{CommandAction, ExecContext};
-use starcoin_crypto::hash::PlainCryptoHash;
 use starcoin_transaction_builder::build_empty_script;
 use starcoin_types::transaction::TransactionPayload;
 use structopt::StructOpt;
@@ -40,7 +39,7 @@ impl CommandAction for GenBlockCommand {
             3000,
             TransactionPayload::Script(empty),
         )?;
-        let txn_hash = signed_txn.crypto_hash();
+        let txn_hash = signed_txn.id();
         cli_state.client().submit_transaction(signed_txn)?;
 
         println!("txn {:#x} submitted.", txn_hash);

--- a/cmd/starcoin/src/dev/deploy_cmd.rs
+++ b/cmd/starcoin/src/dev/deploy_cmd.rs
@@ -5,7 +5,7 @@ use crate::cli_state::CliState;
 use crate::StarcoinOpt;
 use anyhow::{bail, Result};
 use scmd::{CommandAction, ExecContext};
-use starcoin_crypto::hash::{HashValue, PlainCryptoHash};
+use starcoin_crypto::hash::HashValue;
 use starcoin_rpc_client::RemoteStateReader;
 use starcoin_state_api::AccountStateReader;
 use starcoin_types::transaction::{Module, RawUserTransaction};
@@ -106,7 +106,7 @@ impl CommandAction for DeployCommand {
         );
 
         let signed_txn = client.account_sign_txn(deploy_txn)?;
-        let txn_hash = signed_txn.crypto_hash();
+        let txn_hash = signed_txn.id();
         client.submit_transaction(signed_txn)?;
 
         println!("txn {:#x} submitted.", txn_hash);

--- a/cmd/starcoin/src/dev/execute_cmd.rs
+++ b/cmd/starcoin/src/dev/execute_cmd.rs
@@ -6,7 +6,6 @@ use crate::view::{ExecuteResultView, ExecutionOutputView};
 use crate::StarcoinOpt;
 use anyhow::{bail, format_err, Result};
 use scmd::{CommandAction, ExecContext};
-use starcoin_crypto::hash::PlainCryptoHash;
 use starcoin_dev::playground;
 use starcoin_move_compiler::{
     compile_source_string_no_report, errors, load_bytecode_file, CompiledUnit, MOVE_EXTENSION,
@@ -208,7 +207,7 @@ impl CommandAction for ExecuteCommand {
         };
 
         let signed_txn = client.account_sign_txn(script_txn)?;
-        let txn_hash = signed_txn.crypto_hash();
+        let txn_hash = signed_txn.id();
         let output = if opt.local_mode {
             let state_view = RemoteStateReader::new(client)?;
             playground::dry_run(

--- a/cmd/starcoin/src/dev/get_coin_cmd.rs
+++ b/cmd/starcoin/src/dev/get_coin_cmd.rs
@@ -6,7 +6,6 @@ use crate::view::TransactionView;
 use crate::StarcoinOpt;
 use anyhow::{bail, format_err, Result};
 use scmd::{CommandAction, ExecContext};
-use starcoin_crypto::hash::PlainCryptoHash;
 use starcoin_executor::{DEFAULT_EXPIRATION_TIME, DEFAULT_MAX_GAS_AMOUNT};
 use starcoin_rpc_client::RemoteStateReader;
 use starcoin_state_api::AccountStateReader;
@@ -93,7 +92,7 @@ impl CommandAction for GetCoinCommand {
             Duration::from_secs(300),
         )?;
         let txn = client.account_sign_txn(raw_txn)?;
-        let id = txn.crypto_hash();
+        let id = txn.id();
         client.submit_transaction(txn.clone())?;
         if !opt.no_blocking {
             ctx.state().watch_txn(id)?;

--- a/cmd/starcoin/src/dev/sign_txn_helper.rs
+++ b/cmd/starcoin/src/dev/sign_txn_helper.rs
@@ -112,7 +112,6 @@ pub fn get_dao_config(cli_state: &CliState) -> Result<DaoConfig> {
 mod tests {
     use super::*;
     use starcoin_config::NodeConfig;
-    use starcoin_crypto::hash::PlainCryptoHash;
     use starcoin_logger::prelude::*;
     use starcoin_node::NodeHandle;
     use starcoin_rpc_api::types::{AnnotatedMoveValueView, ContractCall, TransactionVMStatus};
@@ -189,7 +188,7 @@ mod tests {
             .client()
             .account_sign_txn(transfer_raw_txn)
             .unwrap();
-        let transfer_txn_id = transfer_txn.crypto_hash();
+        let transfer_txn_id = transfer_txn.id();
         cli_state
             .client()
             .submit_transaction(transfer_txn.clone())
@@ -254,7 +253,7 @@ mod tests {
         )
         .unwrap();
 
-        let proposal_txn_id = proposal_txn.crypto_hash();
+        let proposal_txn_id = proposal_txn.id();
         cli_state
             .client()
             .submit_transaction(proposal_txn.clone())
@@ -309,7 +308,7 @@ mod tests {
             cli_state.net().chain_id(),
         );
         let vote_txn = cli_state.client().account_sign_txn(vote_raw_txn).unwrap();
-        let vote_txn_id = vote_txn.crypto_hash();
+        let vote_txn_id = vote_txn.id();
         cli_state
             .client()
             .submit_transaction(vote_txn.clone())
@@ -341,7 +340,7 @@ mod tests {
             TransactionPayload::Script(module_upgrade_queue),
         )
         .unwrap();
-        let queue_txn_id = queue_txn.crypto_hash();
+        let queue_txn_id = queue_txn.id();
         cli_state
             .client()
             .submit_transaction(queue_txn.clone())
@@ -374,7 +373,7 @@ mod tests {
             TransactionPayload::Script(module_upgrade_plan),
         )
         .unwrap();
-        let plan_txn_id = plan_txn.crypto_hash();
+        let plan_txn_id = plan_txn.id();
         cli_state
             .client()
             .submit_transaction(plan_txn.clone())
@@ -399,7 +398,7 @@ mod tests {
             TransactionPayload::Package(test_upgrade_module_package),
         )
         .unwrap();
-        let package_txn_id = package_txn.crypto_hash();
+        let package_txn_id = package_txn.id();
         cli_state
             .client()
             .submit_transaction(package_txn.clone())
@@ -480,7 +479,7 @@ mod tests {
             .client()
             .account_sign_txn(only_new_module_strategy_raw_txn)
             .unwrap();
-        let only_new_module_strategy_txn_id = only_new_module_strategy_txn.crypto_hash();
+        let only_new_module_strategy_txn_id = only_new_module_strategy_txn.id();
         cli_state
             .client()
             .submit_transaction(only_new_module_strategy_txn.clone())
@@ -519,7 +518,7 @@ mod tests {
             TransactionPayload::Package(test_upgrade_module_package_1),
         )
         .unwrap();
-        let package_txn_id_1 = package_txn_1.crypto_hash();
+        let package_txn_id_1 = package_txn_1.id();
         cli_state
             .client()
             .submit_transaction(package_txn_1.clone())

--- a/cmd/starcoin/src/dev/submit_multisig_txn_cmd.rs
+++ b/cmd/starcoin/src/dev/submit_multisig_txn_cmd.rs
@@ -6,7 +6,7 @@ use crate::mutlisig_transaction::MultisigTransaction;
 use crate::StarcoinOpt;
 use anyhow::{bail, ensure, Result};
 use scmd::{CommandAction, ExecContext};
-use starcoin_crypto::hash::{HashValue, PlainCryptoHash};
+use starcoin_crypto::hash::HashValue;
 use starcoin_vm_types::transaction::SignedUserTransaction;
 use std::fs::File;
 use std::io::Read;
@@ -43,7 +43,7 @@ impl CommandAction for ExecuteMultiSignedTxnCommand {
         let opt = ctx.opt();
         let client = ctx.state().client();
         let signed_txn = assemble_multisig_txn(opt.partial_signed_txns.clone())?;
-        let txn_hash = signed_txn.crypto_hash();
+        let txn_hash = signed_txn.id();
         client.submit_transaction(signed_txn)?;
 
         println!("txn {:#x} submitted.", txn_hash);

--- a/cmd/starcoin/src/dev/upgrade_module_exe_cmd.rs
+++ b/cmd/starcoin/src/dev/upgrade_module_exe_cmd.rs
@@ -6,7 +6,7 @@ use crate::dev::sign_txn_helper::sign_txn_with_account_by_rpc_client;
 use crate::StarcoinOpt;
 use anyhow::{bail, Result};
 use scmd::{CommandAction, ExecContext};
-use starcoin_crypto::hash::{HashValue, PlainCryptoHash};
+use starcoin_crypto::hash::HashValue;
 use starcoin_vm_types::account_address::AccountAddress;
 use starcoin_vm_types::transaction::TransactionPayload;
 use std::fs::File;
@@ -94,7 +94,7 @@ impl CommandAction for UpgradeModuleExeCommand {
                 opt.expiration_time,
                 TransactionPayload::Package(upgrade_package),
             )?;
-            let txn_hash = signed_txn.crypto_hash();
+            let txn_hash = signed_txn.id();
             cli_state.client().submit_transaction(signed_txn)?;
 
             println!("txn {:#x} submitted.", txn_hash);

--- a/cmd/starcoin/src/dev/upgrade_module_plan_cmd.rs
+++ b/cmd/starcoin/src/dev/upgrade_module_plan_cmd.rs
@@ -6,7 +6,7 @@ use crate::dev::sign_txn_helper::sign_txn_with_account_by_rpc_client;
 use crate::StarcoinOpt;
 use anyhow::Result;
 use scmd::{CommandAction, ExecContext};
-use starcoin_crypto::hash::{HashValue, PlainCryptoHash};
+use starcoin_crypto::hash::HashValue;
 use starcoin_transaction_builder::build_module_upgrade_plan;
 use starcoin_vm_types::account_address::AccountAddress;
 use starcoin_vm_types::transaction::TransactionPayload;
@@ -96,7 +96,7 @@ impl CommandAction for UpgradeModulePlanCommand {
             opt.expiration_time,
             TransactionPayload::Script(module_upgrade_plan),
         )?;
-        let txn_hash = signed_txn.crypto_hash();
+        let txn_hash = signed_txn.id();
         cli_state.client().submit_transaction(signed_txn)?;
 
         println!("txn {:#x} submitted.", txn_hash);

--- a/cmd/starcoin/src/dev/upgrade_module_queue_cmd.rs
+++ b/cmd/starcoin/src/dev/upgrade_module_queue_cmd.rs
@@ -6,7 +6,7 @@ use crate::dev::sign_txn_helper::sign_txn_with_account_by_rpc_client;
 use crate::StarcoinOpt;
 use anyhow::Result;
 use scmd::{CommandAction, ExecContext};
-use starcoin_crypto::hash::{HashValue, PlainCryptoHash};
+use starcoin_crypto::hash::HashValue;
 use starcoin_transaction_builder::build_module_upgrade_queue;
 use starcoin_vm_types::account_address::AccountAddress;
 use starcoin_vm_types::transaction::TransactionPayload;
@@ -96,7 +96,7 @@ impl CommandAction for UpgradeModuleQueueCommand {
             opt.expiration_time,
             TransactionPayload::Script(module_upgrade_queue),
         )?;
-        let txn_hash = signed_txn.crypto_hash();
+        let txn_hash = signed_txn.id();
         cli_state.client().submit_transaction(signed_txn)?;
 
         println!("txn {:#x} submitted.", txn_hash);

--- a/cmd/starcoin/src/view.rs
+++ b/cmd/starcoin/src/view.rs
@@ -5,7 +5,8 @@ use anyhow::{format_err, Error};
 use forkable_jellyfish_merkle::proof::SparseMerkleProof;
 use serde::{Deserialize, Serialize, Serializer};
 use starcoin_account_api::AccountInfo;
-use starcoin_crypto::{hash::PlainCryptoHash, HashValue};
+use starcoin_crypto::HashValue;
+use starcoin_resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue};
 use starcoin_rpc_api::types::{
     TransactionEventView, TransactionOutputAction, TransactionOutputView, TransactionVMStatus,
 };
@@ -72,7 +73,7 @@ pub struct TransactionView {
 impl From<SignedUserTransaction> for TransactionView {
     fn from(txn: SignedUserTransaction) -> Self {
         Self {
-            id: txn.raw_txn().crypto_hash(),
+            id: txn.id(),
             sender: txn.sender(),
             sequence_number: txn.sequence_number(),
             gas_unit_price: txn.gas_unit_price(),

--- a/cmd/starcoin/src/view.rs
+++ b/cmd/starcoin/src/view.rs
@@ -6,7 +6,6 @@ use forkable_jellyfish_merkle::proof::SparseMerkleProof;
 use serde::{Deserialize, Serialize, Serializer};
 use starcoin_account_api::AccountInfo;
 use starcoin_crypto::HashValue;
-use starcoin_resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue};
 use starcoin_rpc_api::types::{
     TransactionEventView, TransactionOutputAction, TransactionOutputView, TransactionVMStatus,
 };

--- a/cmd/tx-factory/src/main.rs
+++ b/cmd/tx-factory/src/main.rs
@@ -4,7 +4,6 @@
 use anyhow::{bail, Result};
 use starcoin_account_api::AccountInfo;
 use starcoin_crypto::ed25519::Ed25519PublicKey;
-use starcoin_crypto::hash::PlainCryptoHash;
 use starcoin_crypto::{HashValue, ValidCryptoMaterialStringExt};
 use starcoin_executor::DEFAULT_EXPIRATION_TIME;
 use starcoin_logger::prelude::*;
@@ -334,7 +333,7 @@ impl TxnMocker {
             user_txn.sender(),
             user_txn.sequence_number(),
         );
-        let txn_hash = user_txn.crypto_hash();
+        let txn_hash = user_txn.id();
         let result = self.client.submit_transaction(user_txn);
 
         // increase sequence number if added in pool.
@@ -393,7 +392,7 @@ impl TxnMocker {
             user_txn.sender(),
             user_txn.sequence_number(),
         );
-        let txn_hash = user_txn.crypto_hash();
+        let txn_hash = user_txn.id();
         let result = self.client.submit_transaction(user_txn);
 
         if matches!(result, Ok(_)) && blocking {

--- a/commons/crypto/tests/crypto_hash_test.rs
+++ b/commons/crypto/tests/crypto_hash_test.rs
@@ -9,6 +9,11 @@ struct TestStruct {
     str_field: String,
 }
 
+#[derive(Debug, Hash, Serialize, Deserialize, CryptoHasher, CryptoHash)]
+struct TestStruct2 {
+    str_field: String,
+}
+
 #[test]
 fn test_crypto_hash() {
     let o = TestStruct {
@@ -22,4 +27,12 @@ fn test_crypto_hash() {
     let hash1 = o.crypto_hash();
     let hash2 = o2.crypto_hash();
     assert_eq!(hash1, hash2);
+
+    let o3 = TestStruct2 {
+        str_field: "hello".to_string(),
+    };
+
+    assert_eq!(scs::to_bytes(&o).unwrap(), scs::to_bytes(&o3).unwrap());
+    let hash3 = o3.crypto_hash();
+    assert_ne!(hash1, hash3);
 }

--- a/rpc/server/src/module/pubsub/tests.rs
+++ b/rpc/server/src/module/pubsub/tests.rs
@@ -11,7 +11,7 @@ use starcoin_account_api::AccountInfo;
 use starcoin_chain::BlockChain;
 use starcoin_chain_notify::ChainNotifyHandlerService;
 use starcoin_consensus::Consensus;
-use starcoin_crypto::{ed25519::Ed25519PrivateKey, hash::PlainCryptoHash, Genesis, PrivateKey};
+use starcoin_crypto::{ed25519::Ed25519PrivateKey, Genesis, PrivateKey};
 use starcoin_executor::DEFAULT_EXPIRATION_TIME;
 use starcoin_logger::prelude::*;
 use starcoin_rpc_api::metadata::Metadata;
@@ -191,7 +191,7 @@ pub async fn test_subscribe_to_pending_transactions() -> Result<()> {
         );
         txn.as_signed_user_txn()?.clone()
     };
-    let txn_id = txn.crypto_hash();
+    let txn_id = txn.id();
     txpool_service.add_txns(vec![txn]).pop().unwrap().unwrap();
     let mut receiver = receiver.compat();
     let res = receiver.next().await.transpose().unwrap();

--- a/storage/src/transaction_info/mod.rs
+++ b/storage/src/transaction_info/mod.rs
@@ -36,14 +36,14 @@ impl ValueCodec for TransactionInfo {
 
 impl TransactionInfoStore for TransactionInfoHashStorage {
     fn get_transaction_info(&self, _id: HashValue) -> Result<Option<TransactionInfo>, Error> {
-        unimplemented!()
+        unreachable!()
     }
 
     fn get_transaction_info_by_hash(
         &self,
         _txn_hash: HashValue,
     ) -> Result<Vec<TransactionInfo>, Error> {
-        unimplemented!()
+        unreachable!()
     }
 
     fn get_transaction_info_ids_by_hash(
@@ -79,14 +79,14 @@ impl TransactionInfoStore for TransactionInfoStorage {
         &self,
         _txn_hash: HashValue,
     ) -> Result<Vec<TransactionInfo>, Error> {
-        unimplemented!()
+        unreachable!()
     }
 
     fn get_transaction_info_ids_by_hash(
         &self,
         _txn_hash: HashValue,
     ) -> Result<Vec<HashValue>, Error> {
-        unimplemented!()
+        unreachable!()
     }
 
     fn save_transaction_infos(&self, vec_txn_info: Vec<TransactionInfo>) -> Result<(), Error> {

--- a/sync/tests/txn_sync_test.rs
+++ b/sync/tests/txn_sync_test.rs
@@ -1,6 +1,6 @@
 use config::NodeConfig;
 use executor::DEFAULT_EXPIRATION_TIME;
-use starcoin_crypto::{hash::PlainCryptoHash, keygen::KeyGen};
+use starcoin_crypto::keygen::KeyGen;
 use starcoin_service_registry::RegistryAsyncService;
 use starcoin_txpool_api::TxPoolSyncService;
 use starcoin_types::transaction::authenticator::AuthenticationKey;
@@ -47,7 +47,7 @@ fn test_txn_sync_actor() {
     let mut txns = txpool_2.get_pending_txns(None, Some(current_timestamp));
     assert_eq!(txns.len(), 1);
     let txn = txns.pop().unwrap();
-    assert_eq!(user_txn.crypto_hash(), txn.crypto_hash());
+    assert_eq!(user_txn.id(), txn.id());
     second_node.stop().unwrap();
     first_node.stop().unwrap();
 }

--- a/txpool/src/test.rs
+++ b/txpool/src/test.rs
@@ -4,7 +4,7 @@
 use crate::pool::AccountSeqNumberClient;
 use crate::TxStatus;
 use anyhow::Result;
-use crypto::{hash::PlainCryptoHash, keygen::KeyGen};
+use crypto::keygen::KeyGen;
 use network_api::messages::{PeerTransactionsMessage, TransactionsMessage};
 use network_api::PeerId;
 use parking_lot::RwLock;
@@ -83,11 +83,11 @@ async fn test_tx_pool() -> Result<()> {
         config.net(),
     );
     let txn = txn.as_signed_user_txn()?.clone();
-    let txn_hash = txn.crypto_hash();
+    let txn_hash = txn.id();
     let mut result = txpool_service.add_txns(vec![txn]);
     assert!(result.pop().unwrap().is_ok());
     let mut pending_txns = txpool_service.get_pending_txns(Some(10), Some(0));
-    assert_eq!(pending_txns.pop().unwrap().crypto_hash(), txn_hash);
+    assert_eq!(pending_txns.pop().unwrap().id(), txn_hash);
 
     let next_sequence_number =
         txpool_service.next_sequence_number(account_config::association_address());


### PR DESCRIPTION
1. Cache SignedUserTransaction id and BlockMetadata id.
2. Use txn.id() to replace txn.crypto_hash()