### PR TITLE
[test] txn gas must below max gas bound and above min gas unit

### DIFF
--- a/vm/functional-tests/tests/testsuite/check/gas_check.move
+++ b/vm/functional-tests/tests/testsuite/check/gas_check.move
@@ -1,5 +1,5 @@
 // Test the gas check flow
-//! account: alice, 1000 0x1::STC::STC
+//! account: alice, 50000000 0x1::STC::STC
 
 //! sender: alice
 //! gas-price: 1
@@ -15,4 +15,30 @@ fun main() {
 // check: gas_used
 // check: 1000
 
+//! new-transaction
+//! sender: alice
+//! gas-price: 1
+//! max-gas: 599
 
+script {
+    fun main() {
+        while (true) {}
+    }
+}
+
+// check: Discard
+// check: MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS
+
+//! new-transaction
+//! sender: alice
+//! gas-price: 1
+//! max-gas: 40000001
+
+script {
+    fun main() {
+        while (true) {}
+    }
+}
+
+// check: Discard
+// check: MAX_GAS_UNITS_EXCEEDS_MAX_GAS_UNITS_BOUND


### PR DESCRIPTION
this pr add two tests:
1. txn gas must below max gas bound (40_000_000)
2. txn gas must above min gas unit (600)

when check scaling factor correctness, I found this two tests missing.
https://github.com/starcoinorg/starcoin/issues/2213