### PR TITLE
downgrade es version to use same tokio as jsonrpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,11 +384,11 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b72c1f1154e234325b50864a349b9c8e56939e266a4c307c0f159812df2f9537"
 dependencies = [
+ "bytes 0.5.6",
  "flate2",
  "futures-core",
  "memchr",
  "pin-project-lite 0.2.6",
- "tokio 1.3.0",
 ]
 
 [[package]]
@@ -2067,7 +2067,7 @@ dependencies = [
  "rand 0.8.3",
  "regex",
  "regex-syntax",
- "reqwest",
+ "reqwest 0.11.2",
  "rusty-fork",
  "serde",
  "serde_json",
@@ -2245,15 +2245,15 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elasticsearch"
-version = "7.11.0-alpha.1"
+version = "7.10.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56ed5adbc4f665685356405132107c35f905b02f3d429814c680f134f8e8edd"
+checksum = "178d260175cbe5578029036dad1a7411eb5c669dcf12e9c3f50e699e6ca3ef7b"
 dependencies = [
  "base64 0.11.0",
- "bytes 1.0.1",
+ "bytes 0.5.6",
  "dyn-clone",
  "percent-encoding 2.1.0",
- "reqwest",
+ "reqwest 0.10.10",
  "rustc_version",
  "serde",
  "serde_json",
@@ -5628,7 +5628,7 @@ dependencies = [
  "memchr",
  "parking_lot 0.11.1",
  "protobuf",
- "reqwest",
+ "reqwest 0.11.2",
  "thiserror",
 ]
 
@@ -6189,11 +6189,47 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
+version = "0.10.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
+dependencies = [
+ "async-compression",
+ "base64 0.13.0",
+ "bytes 0.5.6",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body 0.3.1",
+ "hyper 0.13.10",
+ "hyper-tls 0.4.3",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log 0.4.14",
+ "mime 0.3.16",
+ "mime_guess",
+ "native-tls",
+ "percent-encoding 2.1.0",
+ "pin-project-lite 0.2.6",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio 0.2.25",
+ "tokio-tls 0.3.1",
+ "url 2.2.1",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.7.0",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf12057f289428dbf5c591c74bf10392e4a8003f993405a902f20117019022d4"
 dependencies = [
- "async-compression",
  "base64 0.13.0",
  "bytes 1.0.1",
  "encoding_rs",
@@ -6216,7 +6252,6 @@ dependencies = [
  "serde_urlencoded",
  "tokio 1.3.0",
  "tokio-native-tls",
- "tokio-util 0.6.4",
  "url 2.2.1",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/cmd/indexer/Cargo.toml
+++ b/cmd/indexer/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.1.0"
 anyhow = "~1"
 async-trait = "~0.1"
 clap = "3.0.0-beta.2"
-elasticsearch = "7.11.0-alpha.1"
+elasticsearch = "7.10.0-alpha.1"
 serde = "1.0.125"
 serde_json = "~1"
 starcoin-crypto = {path = "../../commons/crypto" }

--- a/cmd/indexer/mappings/block.mapping.json
+++ b/cmd/indexer/mappings/block.mapping.json
@@ -110,7 +110,7 @@
       },
       "header": {
         "properties": {
-          "accumulator_root": {
+          "txn_accumulator_root": {
             "type": "text",
             "fields": {
               "keyword": {
@@ -176,7 +176,7 @@
           "number": {
             "type": "long"
           },
-          "parent_block_accumulator_root": {
+          "block_accumulator_root": {
             "type": "text",
             "fields": {
               "keyword": {
@@ -261,7 +261,7 @@
       "uncles": {
         "type": "nested",
         "properties": {
-          "accumulator_root": {
+          "txn_accumulator_root": {
             "type": "text",
             "fields": {
               "keyword": {
@@ -327,7 +327,7 @@
           "number": {
             "type": "long"
           },
-          "parent_block_accumulator_root": {
+          "block_accumulator_root": {
             "type": "text",
             "fields": {
               "keyword": {


### PR DESCRIPTION
es 升级后，依赖tokio 1.x，但jsonrpc 依赖 tokio 0.x ，不兼容。
先回退 es 版本。