### PR TITLE
[network] Exchange supported notif_protocols and rpc_protocols when peer handshake

### DIFF
--- a/network-p2p/src/behaviour.rs
+++ b/network-p2p/src/behaviour.rs
@@ -69,6 +69,8 @@ pub enum BehaviourOut {
         /// Object that permits sending notifications to the peer.
         notifications_sink: NotificationsSink,
         info: Box<ChainInfo>,
+        notif_protocols: Vec<Cow<'static, str>>,
+        rpc_protocols: Vec<Cow<'static, str>>,
     },
 
     /// The [`NotificationsSink`] object used to send notifications with the given peer must be
@@ -256,6 +258,8 @@ impl NetworkBehaviourEventProcess<CustomMessageOutcome> for Behaviour {
                 protocol,
                 notifications_sink,
                 info,
+                notif_protocols,
+                rpc_protocols,
             } => {
                 self.events
                     .push_back(BehaviourOut::NotificationStreamOpened {
@@ -263,6 +267,8 @@ impl NetworkBehaviourEventProcess<CustomMessageOutcome> for Behaviour {
                         protocol,
                         notifications_sink,
                         info,
+                        notif_protocols,
+                        rpc_protocols,
                     });
             }
             CustomMessageOutcome::NotificationStreamClosed { remote, protocol } => {

--- a/network-p2p/src/protocol.rs
+++ b/network-p2p/src/protocol.rs
@@ -64,6 +64,8 @@ pub enum CustomMessageOutcome {
         protocol: Cow<'static, str>,
         notifications_sink: NotificationsSink,
         info: Box<ChainInfo>,
+        notif_protocols: Vec<Cow<'static, str>>,
+        rpc_protocols: Vec<Cow<'static, str>>,
     },
     /// The [`NotificationsSink`] of some notification protocols need an update.
     NotificationStreamReplaced {
@@ -116,6 +118,7 @@ pub struct Protocol {
     /// The `PeerId`'s of all boot nodes.
     boot_node_ids: Arc<HashSet<PeerId>>,
     notif_protocols: Vec<Cow<'static, str>>,
+    rpc_protocols: Vec<Cow<'static, str>>,
     /// If we receive a new "substream open" event that contains an invalid handshake, we ask the
     /// inner layer to force-close the substream. Force-closing the substream will generate a
     /// "substream closed" event. This is a problem: since we can't propagate the "substream open"
@@ -339,17 +342,24 @@ impl Protocol {
         peerset_config: sc_peerset::PeersetConfig,
         chain_info: ChainInfo,
         boot_node_ids: Arc<HashSet<PeerId>>,
-        notif_protocols: impl IntoIterator<Item = Cow<'static, str>>,
+        notif_protocols: Vec<Cow<'static, str>>,
+        rpc_protocols: Vec<Cow<'static, str>>,
     ) -> errors::Result<(Protocol, sc_peerset::PeersetHandle)> {
         let mut important_peers = HashSet::new();
-        for reserved in &peerset_config.sets[0].reserved_nodes {
-            important_peers.insert(*reserved);
+        important_peers.extend(boot_node_ids.iter());
+        for peer_set in peerset_config.sets.iter() {
+            for reserved in &peer_set.reserved_nodes {
+                important_peers.insert(*reserved);
+            }
         }
+
         let (peerset, peerset_handle) = sc_peerset::Peerset::from_config(peerset_config);
-        let notif_protocols: Vec<Cow<'static, str>> = notif_protocols.into_iter().collect();
         let behaviour = {
-            let handshake_message =
-                Self::build_handshake_msg(notif_protocols.clone(), chain_info.clone());
+            let handshake_message = Self::build_handshake_msg(
+                notif_protocols.to_vec(),
+                rpc_protocols.to_vec(),
+                chain_info.clone(),
+            );
 
             let notif_protocol_wth_handshake: Vec<(Cow<'static, str>, Vec<u8>, u64)> =
                 notif_protocols
@@ -378,6 +388,7 @@ impl Protocol {
             chain_info,
             boot_node_ids,
             notif_protocols,
+            rpc_protocols,
             bad_handshake_substreams: Default::default(),
         };
         Ok((protocol, peerset_handle))
@@ -496,21 +507,31 @@ impl Protocol {
             protocol: protocol_name,
             notifications_sink,
             info: Box::new(status.info),
+            notif_protocols: status.notif_protocols.to_vec(),
+            rpc_protocols: status.rpc_protocols.to_vec(),
         }
     }
 
-    fn build_status(notif_protocols: Vec<Cow<'static, str>>, info: ChainInfo) -> Status {
+    fn build_status(
+        notif_protocols: Vec<Cow<'static, str>>,
+        rpc_protocols: Vec<Cow<'static, str>>,
+        info: ChainInfo,
+    ) -> Status {
         message::generic::Status {
             version: CURRENT_VERSION,
             min_supported_version: MIN_VERSION,
             notif_protocols,
-            rpc_protocols: vec![],
+            rpc_protocols,
             info,
         }
     }
 
-    fn build_handshake_msg(notif_protocols: Vec<Cow<'static, str>>, info: ChainInfo) -> Vec<u8> {
-        Self::build_status(notif_protocols, info)
+    fn build_handshake_msg(
+        notif_protocols: Vec<Cow<'static, str>>,
+        rpc_protocols: Vec<Cow<'static, str>>,
+        info: ChainInfo,
+    ) -> Vec<u8> {
+        Self::build_status(notif_protocols, rpc_protocols, info)
             .encode()
             .expect("Status encode should success.")
     }
@@ -563,8 +584,11 @@ impl Protocol {
     }
 
     fn update_handshake(&mut self) {
-        let handshake_msg =
-            Self::build_handshake_msg(self.notif_protocols.to_vec(), self.chain_info.clone());
+        let handshake_msg = Self::build_handshake_msg(
+            self.notif_protocols.to_vec(),
+            self.rpc_protocols.to_vec(),
+            self.chain_info.clone(),
+        );
         self.behaviour
             .set_notif_protocol_handshake(HARD_CORE_PROTOCOL_ID, handshake_msg)
     }

--- a/network-p2p/src/protocol.rs
+++ b/network-p2p/src/protocol.rs
@@ -458,13 +458,6 @@ impl Protocol {
         notifications_sink: NotificationsSink,
     ) -> CustomMessageOutcome {
         debug!(target: "network-p2p", "New peer {} {:?}", who, status);
-        if self.context_data.peers.contains_key(&who) {
-            log!(
-                target: "network-p2p",
-                if self.important_peers.contains(&who) { Level::Warn } else { Level::Debug },
-                "Unexpected status packet from {}", who
-            );
-        }
         if status.info.genesis_hash() != self.chain_info.genesis_hash() {
             if self.boot_node_ids.contains(&who) {
                 error!(
@@ -475,7 +468,9 @@ impl Protocol {
                     status.info.genesis_hash(),
                 );
             } else {
-                info!(
+                log!(
+                    target: "network-p2p",
+                    if self.important_peers.contains(&who) { Level::Warn } else { Level::Debug },
                     "Peer with id `{}` is on different chain (our genesis: {} theirs: {})",
                     who,
                     self.chain_info.genesis_hash(),
@@ -489,7 +484,7 @@ impl Protocol {
         if status.version < MIN_VERSION && CURRENT_VERSION < status.min_supported_version {
             log!(
                 target: "network-p2p",
-                if self.important_peers.contains(&who) { Level::Warn } else { Level::Trace },
+                if self.important_peers.contains(&who) { Level::Warn } else { Level::Debug },
                 "Peer {:?} using unsupported protocol version {}", who, status.version
             );
             self.peerset_handle.report_peer(who, rep::BAD_PROTOCOL);

--- a/network-p2p/src/protocol/event.rs
+++ b/network-p2p/src/protocol/event.rs
@@ -56,6 +56,8 @@ pub enum Event {
         /// The concerned protocol. Each protocol uses a different substream.
         protocol: Cow<'static, str>,
         info: Box<ChainInfo>,
+        notif_protocols: Vec<Cow<'static, str>>,
+        rpc_protocols: Vec<Cow<'static, str>>,
     },
 
     /// Closed a substream with the given node. Always matches a corresponding previous

--- a/network-p2p/src/service.rs
+++ b/network-p2p/src/service.rs
@@ -222,6 +222,12 @@ impl NetworkWorker {
             params.chain_info,
             boot_node_ids.clone(),
             notif_protocols,
+            params
+                .network_config
+                .request_response_protocols
+                .iter()
+                .map(|config| config.name.clone())
+                .collect(),
         )?;
 
         // Build the swarm.
@@ -1139,6 +1145,8 @@ impl Future for NetworkWorker {
                     protocol,
                     notifications_sink,
                     info,
+                    notif_protocols,
+                    rpc_protocols,
                 })) => {
                     if let Some(metrics) = this.metrics.as_ref() {
                         metrics.notifications_streams_opened_total.inc();
@@ -1152,6 +1160,8 @@ impl Future for NetworkWorker {
                         remote,
                         protocol,
                         info,
+                        notif_protocols,
+                        rpc_protocols,
                     });
                 }
                 Poll::Ready(SwarmEvent::Behaviour(BehaviourOut::NotificationStreamReplaced {

--- a/network/api/src/tests.rs
+++ b/network/api/src/tests.rs
@@ -31,18 +31,26 @@ fn test_peer_selector() {
         PeerInfo::new(
             PeerId::random(),
             ChainInfo::new(1.into(), HashValue::zero(), mock_chain_status(100.into())),
+            vec![],
+            vec![],
         ),
         PeerInfo::new(
             PeerId::random(),
             ChainInfo::new(1.into(), HashValue::zero(), mock_chain_status(99.into())),
+            vec![],
+            vec![],
         ),
         PeerInfo::new(
             PeerId::random(),
             ChainInfo::new(1.into(), HashValue::zero(), mock_chain_status(100.into())),
+            vec![],
+            vec![],
         ),
         PeerInfo::new(
             PeerId::random(),
             ChainInfo::new(1.into(), HashValue::zero(), mock_chain_status(1.into())),
+            vec![],
+            vec![],
         ),
     ];
 

--- a/network/src/worker.rs
+++ b/network/src/worker.rs
@@ -6,6 +6,7 @@ use bitflags::_core::time::Duration;
 use futures::channel::mpsc::channel;
 use futures::prelude::*;
 use log::{debug, error, info};
+use network_api::PeerInfo;
 use network_p2p::config::{RequestResponseConfig, TransportConfig};
 use network_p2p::{
     identity, NetworkConfiguration, NetworkWorker, NodeKeyConfig, Params, ProtocolId, Secret,
@@ -29,7 +30,7 @@ pub fn build_network_worker(
     chain_info: ChainInfo,
     protocols: Vec<Cow<'static, str>>,
     rpc_service: Option<(RpcInfo, ServiceRef<NetworkRpcService>)>,
-) -> Result<NetworkWorker> {
+) -> Result<(PeerInfo, NetworkWorker)> {
     let node_name = node_config.node_name();
     let discover_local = node_config.network.discover_local();
     let transport_config = if is_memory_addr(&node_config.network.listen()) {
@@ -76,7 +77,15 @@ pub fn build_network_worker(
     let boot_nodes = node_config.network.seeds();
 
     info!("Final bootstrap seeds: {:?}", boot_nodes);
-
+    let self_info = PeerInfo::new(
+        node_config.network.self_peer_id(),
+        chain_info.clone(),
+        protocols.to_vec(),
+        rpc_protocols
+            .iter()
+            .map(|config| config.name.clone())
+            .collect(),
+    );
     let config = NetworkConfiguration {
         listen_addresses: vec![node_config.network.listen()],
         boot_nodes,
@@ -108,5 +117,6 @@ pub fn build_network_worker(
         //TODO use a custom registry for each instance.
         Some(default_registry().clone()),
     ))?;
-    Ok(worker)
+
+    Ok((self_info, worker))
 }

--- a/network/tests/network_service_test.rs
+++ b/network/tests/network_service_test.rs
@@ -61,7 +61,7 @@ fn build_test_network_services(num: usize) -> Vec<NetworkComponent> {
         }
         let mut protocols = NotificationMessage::protocols();
         protocols.push(TEST_NOTIF_PROTOCOL_NAME.into());
-        let worker =
+        let (_peer_info, worker) =
             build_network_worker(&node_config, chain_info.clone(), protocols, None).unwrap();
         let network_service = worker.service().clone();
         async_std::task::spawn(worker);

--- a/rpc/api/src/types.rs
+++ b/rpc/api/src/types.rs
@@ -943,14 +943,17 @@ impl From<ChainInfo> for ChainInfoView {
 pub struct PeerInfoView {
     pub peer_id: PeerId,
     pub chain_info: ChainInfoView,
+    pub notif_protocols: String,
+    pub rpc_protocols: String,
 }
 
 impl From<PeerInfo> for PeerInfoView {
     fn from(info: PeerInfo) -> Self {
-        let (peer_id, chain_info) = info.into_inner();
         Self {
-            peer_id,
-            chain_info: chain_info.into(),
+            peer_id: info.peer_id,
+            chain_info: info.chain_info.into(),
+            notif_protocols: info.notif_protocols.join(","),
+            rpc_protocols: info.rpc_protocols.join(","),
         }
     }
 }

--- a/sync/src/tasks/mock.rs
+++ b/sync/src/tasks/mock.rs
@@ -144,7 +144,7 @@ impl SyncNodeMocker {
     ) -> Result<Self> {
         let chain = MockChain::new(net)?;
         let peer_id = PeerId::random();
-        let peer_info = PeerInfo::new(peer_id.clone(), chain.chain_info());
+        let peer_info = PeerInfo::new(peer_id.clone(), chain.chain_info(), vec![], vec![]);
         let peer_selector = PeerSelector::new(vec![peer_info], PeerStrategy::default());
         Ok(Self::new_inner(
             peer_id,
@@ -162,7 +162,7 @@ impl SyncNodeMocker {
     ) -> Result<Self> {
         let chain = MockChain::new(net)?;
         let peer_id = PeerId::random();
-        let peer_info = PeerInfo::new(peer_id.clone(), chain.chain_info());
+        let peer_info = PeerInfo::new(peer_id.clone(), chain.chain_info(), vec![], vec![]);
         let peer_selector = PeerSelector::new(vec![peer_info], PeerStrategy::default());
         Ok(Self::new_inner(
             peer_id,
@@ -205,7 +205,12 @@ impl SyncNodeMocker {
     }
 
     pub fn peer_info(&self) -> PeerInfo {
-        PeerInfo::new(self.peer_id.clone(), self.chain_mocker.chain_info())
+        PeerInfo::new(
+            self.peer_id.clone(),
+            self.chain_mocker.chain_info(),
+            vec![],
+            vec![],
+        )
     }
 
     pub fn sync_target(&self) -> SyncTarget {

--- a/sync/src/tasks/mod.rs
+++ b/sync/src/tasks/mod.rs
@@ -556,6 +556,8 @@ where
             for peer in all_peers {
                 fetcher.peer_selector().add_or_update_peer(peer);
             }
+            fetcher.peer_selector().retain_rpc_peers();
+
             let sub_target = fetcher
                 .get_better_target(ancestor_block_info.total_difficulty, target.clone())
                 .await

--- a/sync/src/tasks/tests.rs
+++ b/sync/src/tasks/tests.rs
@@ -914,10 +914,20 @@ async fn test_sync_target() {
     let mut node1 = SyncNodeMocker::new(net1, 1, 0).unwrap();
     node1.produce_block(10).unwrap();
     let low_chain_info = node1.peer_info().chain_info().clone();
-    peer_infos.push(PeerInfo::new(PeerId::random(), low_chain_info.clone()));
+    peer_infos.push(PeerInfo::new(
+        PeerId::random(),
+        low_chain_info.clone(),
+        vec![],
+        vec![],
+    ));
     node1.produce_block(10).unwrap();
     let high_chain_info = node1.peer_info().chain_info().clone();
-    peer_infos.push(PeerInfo::new(PeerId::random(), high_chain_info.clone()));
+    peer_infos.push(PeerInfo::new(
+        PeerId::random(),
+        high_chain_info.clone(),
+        vec![],
+        vec![],
+    ));
 
     let net2 = ChainNetwork::new_builtin(BuiltinNetworkID::Test);
     let (_, genesis_chain_info, _) =

--- a/types/src/peer_info.rs
+++ b/types/src/peer_info.rs
@@ -151,10 +151,10 @@ impl fmt::Display for PeerId {
 
 #[derive(Eq, PartialEq, Hash, Deserialize, Serialize, Clone, Debug)]
 pub struct PeerInfo {
-    peer_id: PeerId,
-    chain_info: ChainInfo,
-    notif_protocols: Vec<Cow<'static, str>>,
-    rpc_protocols: Vec<Cow<'static, str>>,
+    pub peer_id: PeerId,
+    pub chain_info: ChainInfo,
+    pub notif_protocols: Vec<Cow<'static, str>>,
+    pub rpc_protocols: Vec<Cow<'static, str>>,
 }
 
 impl PeerInfo {
@@ -215,10 +215,6 @@ impl PeerInfo {
 
     pub fn is_support_rpc_protocol(&self, protocol: Cow<'static, str>) -> bool {
         self.rpc_protocols.contains(&protocol)
-    }
-
-    pub fn into_inner(self) -> (PeerId, ChainInfo) {
-        (self.peer_id, self.chain_info)
     }
 
     pub fn random() -> Self {

--- a/types/src/peer_info.rs
+++ b/types/src/peer_info.rs
@@ -16,6 +16,7 @@ use std::str::FromStr;
 pub use network_p2p_types::multiaddr::Multiaddr;
 use network_p2p_types::multihash::Error;
 pub use network_p2p_types::multihash::Multihash;
+use std::borrow::Cow;
 
 #[derive(Eq, PartialEq, Hash, Clone, Debug)]
 pub struct PeerId(network_p2p_types::PeerId);
@@ -152,13 +153,22 @@ impl fmt::Display for PeerId {
 pub struct PeerInfo {
     peer_id: PeerId,
     chain_info: ChainInfo,
+    notif_protocols: Vec<Cow<'static, str>>,
+    rpc_protocols: Vec<Cow<'static, str>>,
 }
 
 impl PeerInfo {
-    pub fn new(peer_id: PeerId, chain_info: ChainInfo) -> Self {
+    pub fn new(
+        peer_id: PeerId,
+        chain_info: ChainInfo,
+        notif_protocols: Vec<Cow<'static, str>>,
+        rpc_protocols: Vec<Cow<'static, str>>,
+    ) -> Self {
         Self {
             peer_id,
             chain_info,
+            notif_protocols,
+            rpc_protocols,
         }
     }
 
@@ -190,6 +200,23 @@ impl PeerInfo {
         self.chain_info.update_status(chain_status)
     }
 
+    /// This peer is support notification
+    pub fn is_support_notification(&self) -> bool {
+        !self.notif_protocols.is_empty()
+    }
+
+    pub fn is_support_notif_protocol(&self, protocol: Cow<'static, str>) -> bool {
+        self.notif_protocols.contains(&protocol)
+    }
+
+    pub fn is_support_rpc(&self) -> bool {
+        !self.rpc_protocols.is_empty()
+    }
+
+    pub fn is_support_rpc_protocol(&self, protocol: Cow<'static, str>) -> bool {
+        self.rpc_protocols.contains(&protocol)
+    }
+
     pub fn into_inner(self) -> (PeerId, ChainInfo) {
         (self.peer_id, self.chain_info)
     }
@@ -198,6 +225,8 @@ impl PeerInfo {
         Self {
             peer_id: PeerId::random(),
             chain_info: ChainInfo::random(),
+            notif_protocols: vec![],
+            rpc_protocols: vec![],
         }
     }
 }


### PR DESCRIPTION
1.  Peer 握手时交换互相支持的 notif protocols 和 rpc protocols.
2.  同步时只从支持 rpc_protocols 的 peer 同步。当前节点在 handshake 消息中未携带 rpc protocols，所以暂时不能启用过滤器。