### PR TITLE
[sync] Enable support rpc filter when sync.

### DIFF
--- a/network-rpc/api/src/lib.rs
+++ b/network-rpc/api/src/lib.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use futures::future::BoxFuture;
 use network_rpc_core::{NetRpcError, RpcErrorCode};
 use network_rpc_derive::*;
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use starcoin_accumulator::node::AccumulatorStoreType;
 use starcoin_accumulator::AccumulatorNode;
@@ -15,7 +16,7 @@ use starcoin_types::access_path::AccessPath;
 use starcoin_types::account_address::AccountAddress;
 use starcoin_types::account_state::AccountState;
 use starcoin_types::block::{Block, BlockHeader, BlockInfo, BlockNumber};
-use starcoin_types::peer_info::PeerId;
+use starcoin_types::peer_info::{PeerId, RpcInfo};
 use starcoin_types::transaction::{SignedUserTransaction, Transaction, TransactionInfo};
 
 mod remote_chain_state;
@@ -30,6 +31,8 @@ pub const MAX_BLOCK_HEADER_REQUEST_SIZE: u64 = 1000;
 pub const MAX_TXN_REQUEST_SIZE: u64 = 1000;
 pub const MAX_BLOCK_INFO_REQUEST_SIZE: u64 = 1000;
 pub const MAX_BLOCK_IDS_REQUEST_SIZE: u64 = 10000;
+
+pub static RPC_INFO: Lazy<RpcInfo> = Lazy::new(|| RpcInfo::new(gen_client::get_rpc_info()));
 
 pub trait RpcRequest {
     fn verify(&self) -> Result<()> {

--- a/network-rpc/derive/src/to_client.rs
+++ b/network-rpc/derive/src/to_client.rs
@@ -72,8 +72,8 @@ pub fn generate_client_module(rpc_trait: &ItemTrait) -> anyhow::Result<TokenStre
         })
         .collect();
     let get_rpc_info_method = quote! {
-        pub fn get_rpc_info() -> Vec<String> {
-            vec![#(stringify!(#rpc_info).to_string()),*]
+        pub fn get_rpc_info() -> Vec<&'static str> {
+            vec![#(stringify!(#rpc_info)),*]
         }
     };
 

--- a/network/api/src/peer_provider.rs
+++ b/network/api/src/peer_provider.rs
@@ -16,6 +16,7 @@ use rand::Rng;
 use serde::{Deserialize, Serialize};
 use starcoin_types::block::BlockHeader;
 use starcoin_types::U256;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -336,6 +337,11 @@ impl PeerSelector {
     /// Retain the peer which supported rpc call.
     pub fn retain_rpc_peers(&self) {
         self.retain_by_filter(|peer| peer.peer_info.is_support_rpc())
+    }
+
+    /// Retain the peer which supported rpc call.
+    pub fn retain_rpc_peers_by_protocol(&self, protocols: &[Cow<'static, str>]) {
+        self.retain_by_filter(move |peer| peer.peer_info.is_support_rpc_protocols(protocols))
     }
 
     pub fn remove_peer(&self, peer: &PeerId) -> usize {

--- a/network/api/src/peer_provider.rs
+++ b/network/api/src/peer_provider.rs
@@ -335,8 +335,7 @@ impl PeerSelector {
 
     /// Retain the peer which supported rpc call.
     pub fn retain_rpc_peers(&self) {
-        //TODO enable retain when most node upgrade and send rpc protocol in handshake.
-        //self.retain_by_filter(|peer| peer.peer_info.is_support_rpc())
+        self.retain_by_filter(|peer| peer.peer_info.is_support_rpc())
     }
 
     pub fn remove_peer(&self, peer: &PeerId) -> usize {

--- a/network/src/service_ref.rs
+++ b/network/src/service_ref.rs
@@ -8,7 +8,7 @@ use anyhow::{format_err, Result};
 use futures::channel::oneshot::Receiver;
 use futures::future::BoxFuture;
 use futures::FutureExt;
-use log::debug;
+use log::warn;
 use network_api::messages::NotificationMessage;
 use network_api::{NetworkService, PeerProvider, ReputationChange, SupportedRpcProtocol};
 use network_p2p_types::network_state::NetworkState;
@@ -98,9 +98,9 @@ impl RawRpcClient for NetworkServiceRef {
                     .await
                     .map_err(|e| e.into())
             } else {
-                debug!(
+                warn!(
                     "[network] remote peer: {:?} not support rpc protocol :{:?}",
-                    peer_id, rpc_path
+                    peer_id, protocol
                 );
                 Err(NetRpcError::method_not_fount(rpc_path)).map_err(|e| e.into())
             }

--- a/network/tests/network_rpc_test.rs
+++ b/network/tests/network_rpc_test.rs
@@ -23,7 +23,7 @@ pub struct TestRequest {
 #[stest::test]
 async fn test_network_raw_rpc() {
     use std::time::Duration;
-    let rpc_info = RpcInfo::new(vec!["test".to_string()]);
+    let rpc_info = RpcInfo::new(vec!["test"]);
 
     let service1 = build_network(None, Some((rpc_info.clone(), MockRpcHandler::echo())))
         .await

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -18,6 +18,7 @@ use starcoin_rpc_server::service::RpcService;
 use starcoin_service_registry::bus::{Bus, BusService};
 use starcoin_service_registry::{RegistryAsyncService, RegistryService, ServiceInfo, ServiceRef};
 use starcoin_storage::Storage;
+use starcoin_sync::sync::SyncService;
 use starcoin_txpool::TxPoolService;
 use starcoin_types::block::Block;
 use starcoin_types::system_events::{GenerateBlockEvent, NewHeadBlock};
@@ -139,6 +140,10 @@ impl NodeHandle {
         self.registry
             .get_shared_sync::<NetworkServiceRef>()
             .expect("NetworkAsyncService must exist.")
+    }
+
+    pub fn sync_service(&self) -> Result<ServiceRef<SyncService>> {
+        block_on(async { self.registry.service_ref::<SyncService>().await })
     }
 
     pub fn rpc_service(&self) -> Result<ServiceRef<RpcService>> {

--- a/node/src/network_service_factory.rs
+++ b/node/src/network_service_factory.rs
@@ -11,7 +11,6 @@ use starcoin_service_registry::{ServiceContext, ServiceFactory};
 use starcoin_storage::{BlockStore, Storage};
 use starcoin_sync::announcement::AnnouncementService;
 use starcoin_txpool::TxPoolActorService;
-use starcoin_types::peer_info::RpcInfo;
 use std::sync::Arc;
 
 pub struct NetworkServiceFactory;
@@ -20,7 +19,7 @@ impl ServiceFactory<NetworkActorService> for NetworkServiceFactory {
     fn create(ctx: &mut ServiceContext<NetworkActorService>) -> Result<NetworkActorService> {
         let config = ctx.get_shared::<Arc<NodeConfig>>()?;
         let storage = ctx.get_shared::<Arc<Storage>>()?;
-        let rpc_info = RpcInfo::new(starcoin_network_rpc_api::gen_client::get_rpc_info());
+        let rpc_info = starcoin_network_rpc_api::RPC_INFO.clone();
         let txpool_service = ctx.service_ref::<TxPoolActorService>()?.clone();
         let block_relayer = ctx.service_ref::<BlockRelayer>()?.clone();
         let network_rpc_service = ctx.service_ref::<NetworkRpcService>()?.clone();

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -219,8 +219,6 @@ impl NodeService {
         registry.register::<ChainReaderService>().await?;
 
         registry.register::<ChainNotifyHandlerService>().await?;
-        //registry.register::<DownloadService>().await?;
-        //registry.register::<SyncService>().await?;
 
         registry.register::<BlockConnectorService>().await?;
         registry.register::<SyncService>().await?;
@@ -259,6 +257,10 @@ impl NodeService {
             info!("Config.miner.enable_miner_client is false, No in process MinerClient.");
         }
 
+        registry
+            .register_by_factory::<Stratum, StratumFactory>()
+            .await?;
+
         registry.register::<GenerateBlockEventPacemaker>().await?;
 
         // start metrics push service
@@ -268,13 +270,6 @@ impl NodeService {
         // wait for service init.
         Delay::new(Duration::from_millis(1000)).await;
 
-        registry
-            .register_by_factory::<Stratum, StratumFactory>()
-            .await?;
-        registry
-            .register_by_factory::<StratumService, StratumServiceFactory>()
-            .await?;
-
         bus.broadcast(SystemStarted)?;
 
         registry
@@ -282,6 +277,9 @@ impl NodeService {
             .await?;
         registry
             .register_by_factory::<RpcService, RpcServiceFactory>()
+            .await?;
+        registry
+            .register_by_factory::<StratumService, StratumServiceFactory>()
             .await?;
 
         Ok((registry, node_service))

--- a/stratum/src/stratum.rs
+++ b/stratum/src/stratum.rs
@@ -65,6 +65,11 @@ impl ActorService for Stratum {
         ctx.subscribe::<MintBlockEvent>();
         Ok(())
     }
+
+    fn stopped(&mut self, ctx: &mut ServiceContext<Self>) -> Result<()> {
+        ctx.unsubscribe::<MintBlockEvent>();
+        Ok(())
+    }
 }
 
 impl EventHandler<Self, MintBlockEvent> for Stratum {

--- a/sync/src/sync.rs
+++ b/sync/src/sync.rs
@@ -203,7 +203,7 @@ impl SyncService {
                 SYNC_METRICS.sync_times.with_label_values(&["start"]).inc();
                 Ok(Some(fut.await?))
             } else {
-                debug!("[sync]No better peer to request.");
+                debug!("[sync]No best peer to request, current is beast.");
                 Ok(None)
             }
         };

--- a/sync/src/tasks/mock.rs
+++ b/sync/src/tasks/mock.rs
@@ -11,6 +11,7 @@ use futures::channel::mpsc::UnboundedReceiver;
 use futures::future::BoxFuture;
 use futures::{FutureExt, StreamExt};
 use futures_timer::Delay;
+use network_api::messages::NotificationMessage;
 use network_api::{PeerInfo, PeerSelector, PeerStrategy};
 use network_rpc_core::{NetRpcError, RpcErrorCode};
 use rand::Rng;
@@ -19,6 +20,7 @@ use starcoin_chain::BlockChain;
 use starcoin_chain_api::ChainReader;
 use starcoin_chain_mock::MockChain;
 use starcoin_crypto::HashValue;
+use starcoin_network_rpc_api::RPC_INFO;
 use starcoin_sync_api::SyncTarget;
 use starcoin_types::block::{Block, BlockIdAndNumber, BlockInfo, BlockNumber};
 use starcoin_types::peer_info::PeerId;
@@ -144,7 +146,12 @@ impl SyncNodeMocker {
     ) -> Result<Self> {
         let chain = MockChain::new(net)?;
         let peer_id = PeerId::random();
-        let peer_info = PeerInfo::new(peer_id.clone(), chain.chain_info(), vec![], vec![]);
+        let peer_info = PeerInfo::new(
+            peer_id.clone(),
+            chain.chain_info(),
+            NotificationMessage::protocols(),
+            RPC_INFO.clone().into_protocols(),
+        );
         let peer_selector = PeerSelector::new(vec![peer_info], PeerStrategy::default());
         Ok(Self::new_inner(
             peer_id,

--- a/sync/src/tasks/mod.rs
+++ b/sync/src/tasks/mod.rs
@@ -71,6 +71,11 @@ pub trait SyncFetcher: PeerOperator + BlockIdFetcher + BlockFetcher + BlockInfoF
                 peers,
             }))
         } else {
+            debug!(
+                "get_best_target return None, total_peers_in_selector: {}, min_difficulty: {}",
+                self.peer_selector().len(),
+                min_difficulty
+            );
             Ok(None)
         }
     }

--- a/sync/src/txn_sync/mod.rs
+++ b/sync/src/txn_sync/mod.rs
@@ -5,7 +5,7 @@ use network_api::{NetworkService, PeerProvider, PeerSelector, PeerStrategy};
 use starcoin_network_rpc_api::{gen_client::NetworkRpcClient, GetTxnsWithSize, RawRpcClient};
 use starcoin_service_registry::{ActorService, EventHandler, ServiceContext};
 use starcoin_txpool_api::TxPoolSyncService;
-use starcoin_types::peer_info::PeerId;
+use starcoin_types::peer_info::{PeerId, RpcInfo};
 use starcoin_types::system_events::SyncStatusChangeEvent;
 use std::sync::Arc;
 use txpool::TxPoolService;
@@ -78,6 +78,10 @@ impl Inner {
         // get all peers and sort by difficulty, try peer with max difficulty.
         let peers = self.peer_provider.peer_set().await?;
         let peer_selector = PeerSelector::new(peers, PeerStrategy::default());
+        peer_selector.retain_rpc_peers_by_protocol(
+            vec![format!("{}/{}", RpcInfo::RPC_PROTOCOL_PREFIX, "get_txns_from_pool").into()]
+                .as_slice(),
+        );
         let best_peers = peer_selector.top(10);
         if best_peers.is_empty() {
             info!("No peer to sync txn.");

--- a/sync/tests/test_sync/mod.rs
+++ b/sync/tests/test_sync/mod.rs
@@ -2,6 +2,7 @@ use config::NodeConfig;
 use futures::executor::block_on;
 use logger::prelude::*;
 use starcoin_chain_service::ChainAsyncService;
+use starcoin_sync_api::SyncAsyncService;
 use std::thread::sleep;
 use std::{sync::Arc, time::Duration};
 use test_helper::run_node_by_config;
@@ -11,6 +12,8 @@ pub fn test_sync() {
     info!("first peer : {:?}", first_config.network.self_peer_id());
     let first_node = run_node_by_config(first_config.clone()).unwrap();
     let first_chain = first_node.chain_service().unwrap();
+    let first_network = first_node.network();
+    let first_peer_id = first_config.network.self_peer_id();
     let count = 5;
     for _i in 0..count {
         first_node.generate_block().unwrap();
@@ -25,11 +28,31 @@ pub fn test_sync() {
     let mut second_config = NodeConfig::random_for_test();
     info!("second peer : {:?}", second_config.network.self_peer_id());
     second_config.network.seeds = vec![first_config.network.self_address()].into();
-    second_config.miner.disable_miner_client = Some(false);
+    second_config.miner.disable_miner_client = Some(true);
 
-    let second_node = run_node_by_config(Arc::new(second_config)).unwrap();
+    let second_node = run_node_by_config(Arc::new(second_config.clone())).unwrap();
     let second_chain = second_node.chain_service().unwrap();
-
+    let second_sync_service = second_node.sync_service().unwrap();
+    let second_network = second_node.network();
+    let second_peer_id = second_config.network.self_peer_id();
+    std::thread::sleep(Duration::from_secs(2));
+    block_on(async {
+        assert!(
+            second_network.is_connected(first_peer_id).await,
+            "second node should connect to first node."
+        );
+        assert!(
+            first_network.is_connected(second_peer_id).await,
+            "first node should connect to second node."
+        );
+    });
+    //Try to trigger sync.
+    block_on(async {
+        second_sync_service
+            .start(false, vec![], false, None)
+            .await
+            .unwrap();
+    });
     //TODO add more check.
     let mut number_2 = 0;
     for i in 0..10_usize {

--- a/types/src/peer_info.rs
+++ b/types/src/peer_info.rs
@@ -5,18 +5,19 @@ use crate::block::BlockHeader;
 use crate::block::BlockNumber;
 use crate::startup_info::{ChainInfo, ChainStatus};
 use crate::U256;
+use anyhow::{format_err, Result};
 use network_p2p_types::identity::PublicKey;
+use network_p2p_types::multihash::Error;
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
 use starcoin_crypto::ed25519::Ed25519PublicKey;
 use starcoin_crypto::HashValue;
+use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::fmt;
 use std::str::FromStr;
 
 pub use network_p2p_types::multiaddr::Multiaddr;
-use network_p2p_types::multihash::Error;
 pub use network_p2p_types::multihash::Multihash;
-use std::borrow::Cow;
 
 #[derive(Eq, PartialEq, Hash, Clone, Debug)]
 pub struct PeerId(network_p2p_types::PeerId);
@@ -230,29 +231,56 @@ impl PeerInfo {
 
 #[derive(Eq, PartialEq, Hash, Deserialize, Serialize, Clone, Debug)]
 pub struct RpcInfo {
-    paths: Vec<String>,
+    protocols: Vec<Cow<'static, str>>,
 }
 
 impl RpcInfo {
+    pub const RPC_PROTOCOL_PREFIX: &'static str = "/starcoin/rpc/";
+
     pub fn is_empty(&self) -> bool {
-        self.paths.is_empty()
+        self.protocols.is_empty()
     }
 
     pub fn empty() -> Self {
-        Self { paths: vec![] }
+        Self { protocols: vec![] }
     }
-    pub fn new(mut paths: Vec<String>) -> Self {
-        paths.sort();
+    pub fn new(mut paths: Vec<&'static str>) -> Self {
+        paths.sort_unstable();
         paths.dedup();
-        Self { paths }
+        let protocols = paths
+            .into_iter()
+            .map(|path| {
+                let protocol_name: Cow<'static, str> =
+                    format!("{}{}", Self::RPC_PROTOCOL_PREFIX, path).into();
+                protocol_name
+            })
+            .collect();
+        Self { protocols }
+    }
+
+    pub fn into_protocols(self) -> Vec<Cow<'static, str>> {
+        self.protocols
+    }
+
+    /// Get rpc path from protocol
+    pub fn rpc_path(protocol: Cow<'static, str>) -> Result<String> {
+        let path = protocol
+            .strip_prefix(Self::RPC_PROTOCOL_PREFIX)
+            .ok_or_else(|| {
+                format_err!(
+                    "Invalid rpc protocol {}, do not contains rpc protocol prefix",
+                    protocol
+                )
+            })?;
+        Ok(path.to_string())
     }
 }
 
 impl IntoIterator for RpcInfo {
-    type Item = String;
-    type IntoIter = std::vec::IntoIter<String>;
+    type Item = Cow<'static, str>;
+    type IntoIter = std::vec::IntoIter<Cow<'static, str>>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.paths.into_iter()
+        self.protocols.into_iter()
     }
 }

--- a/types/src/peer_info.rs
+++ b/types/src/peer_info.rs
@@ -219,6 +219,15 @@ impl PeerInfo {
         self.rpc_protocols.contains(&protocol)
     }
 
+    pub fn is_support_rpc_protocols(&self, protocols: &[Cow<'static, str>]) -> bool {
+        for protocol in protocols {
+            if !self.is_support_rpc_protocol(protocol.clone()) {
+                return false;
+            }
+        }
+        true
+    }
+
     pub fn random() -> Self {
         Self {
             peer_id: PeerId::random(),


### PR DESCRIPTION
1. 同步时过滤不支持 rpc 接口的 peer。
2. 修复几个会导致测试用例偶发失败的 bug。