### PR TITLE
indexer: fix #2493

### DIFF
--- a/cmd/indexer/src/es_sinker.rs
+++ b/cmd/indexer/src/es_sinker.rs
@@ -167,6 +167,11 @@ impl EsSinker {
             anyhow::bail!("cannot get block data with id {}", block_id);
         };
 
+        // first, rollback tip header
+        let rollback_to = (parent_hash, tip_header.block_number - 1);
+        self.update_local_tip_header(rollback_to.0, rollback_to.1)
+            .await?;
+
         // delete block
         {
             let resp = self
@@ -202,10 +207,6 @@ impl EsSinker {
             }
         }
 
-        // rollback tip header
-        let rollback_to = (parent_hash, tip_header.block_number - 1);
-        self.update_local_tip_header(rollback_to.0, rollback_to.1)
-            .await?;
         info!(
             "Rollback to block: {}, height: {}",
             rollback_to.0, rollback_to.1


### PR DESCRIPTION
先更新 tip header，再删除es 数据。
如果 client 解析不成功，重试会拿到更新后 的tip header。