### PR TITLE
Support readonly account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7470,6 +7470,7 @@ dependencies = [
  "rand 0.8.3",
  "rand_core 0.6.2",
  "serde",
+ "serde_json",
  "starcoin-account-api",
  "starcoin-config",
  "starcoin-crypto",

--- a/account/Cargo.toml
+++ b/account/Cargo.toml
@@ -13,6 +13,7 @@ async-trait = "0.1"
 rand = "0.8.3"
 parking_lot = "0.11"
 serde = "1.0.126"
+serde_json = "~1"
 rand_core = { version = "0.6.2", default-features = false }
 starcoin-account-api = {path = "./api"}
 bcs-ext ={package= "bcs-ext", path = "../commons/bcs_ext" }

--- a/account/api/src/error.rs
+++ b/account/api/src/error.rs
@@ -16,12 +16,15 @@ pub enum AccountError {
 
     #[error("invalid password, cannot decrypt account {0}")]
     InvalidPassword(AccountAddress),
-    #[error("invalid private key")]
-    InvalidPrivateKey,
-
+    #[error("invalid private key: {0:?}")]
+    InvalidPrivateKey(starcoin_crypto::CryptoMaterialError),
+    #[error("invalid public key: {0:?}")]
+    InvalidPublicKey(starcoin_crypto::CryptoMaterialError),
     // logic error
     #[error("transaction sign error, {0:?}")]
     TransactionSignError(anyhow::Error),
+    #[error("message sign error, {0:?}")]
+    MessageSignError(anyhow::Error),
     // #[error("decrypt private key error, {0:?}")]
     // DecryptPrivateKeyError(anyhow::Error),
     #[error("no private key data associate with address {0}")]

--- a/account/api/src/message.rs
+++ b/account/api/src/message.rs
@@ -36,6 +36,10 @@ pub enum AccountRequest {
         private_key: Vec<u8>,
         password: String,
     },
+    ImportReadonlyAccount {
+        address: AccountAddress,
+        public_key: Vec<u8>,
+    },
     ExportAccount {
         address: AccountAddress,
         password: String,

--- a/account/api/src/rich_wallet.rs
+++ b/account/api/src/rich_wallet.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use starcoin_types::account_address::AccountAddress;
 use starcoin_types::account_config::token_code::TokenCode;
+use starcoin_types::account_config::STC_TOKEN_CODE;
 use starcoin_types::contract_event::EventWithProof;
 use starcoin_types::event::EventKey;
 use starcoin_types::transaction::{RawUserTransaction, SignedUserTransaction, TransactionPayload};
@@ -51,9 +52,35 @@ pub trait RichWallet {
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Setting {
-    default_expiration_timeout: u64,
-    default_gas_price: u64,
-    default_gas_token: TokenCode,
+    pub default_expiration_timeout: u64,
+    pub default_gas_price: u64,
+    pub default_gas_token: TokenCode,
+    /// this account is default account.
+    pub is_default: bool,
+    /// this account is readonly
+    pub is_readonly: bool,
+}
+
+impl Setting {
+    pub fn default() -> Self {
+        Setting {
+            default_expiration_timeout: 3600,
+            default_gas_price: 1,
+            default_gas_token: STC_TOKEN_CODE.clone(),
+            is_default: false,
+            is_readonly: false,
+        }
+    }
+
+    pub fn readonly() -> Self {
+        Setting {
+            default_expiration_timeout: 3600,
+            default_gas_price: 1,
+            default_gas_token: STC_TOKEN_CODE.clone(),
+            is_default: false,
+            is_readonly: true,
+        }
+    }
 }
 
 pub trait WalletStorageTrait {

--- a/account/api/src/service.rs
+++ b/account/api/src/service.rs
@@ -50,6 +50,12 @@ pub trait AccountAsyncService:
         password: String,
     ) -> Result<AccountInfo>;
 
+    async fn import_readonly_account(
+        &self,
+        address: AccountAddress,
+        public_key: Vec<u8>,
+    ) -> Result<AccountInfo>;
+
     /// Return the private key as bytes for `address`
     async fn export_account(&self, address: AccountAddress, password: String) -> Result<Vec<u8>>;
 
@@ -198,6 +204,24 @@ where
                 address,
                 password,
                 private_key,
+            })
+            .await??;
+        if let AccountResponse::AccountInfo(account) = response {
+            Ok(*account)
+        } else {
+            panic!("Unexpect response type.")
+        }
+    }
+
+    async fn import_readonly_account(
+        &self,
+        address: AccountAddress,
+        public_key: Vec<u8>,
+    ) -> Result<AccountInfo> {
+        let response = self
+            .send(AccountRequest::ImportReadonlyAccount {
+                address,
+                public_key,
             })
             .await??;
         if let AccountResponse::AccountInfo(account) = response {

--- a/account/api/src/types.rs
+++ b/account/api/src/types.rs
@@ -13,23 +13,30 @@ pub use starcoin_types::transaction::authenticator::{
     AccountPrivateKey, AccountPublicKey, AccountSignature,
 };
 
-#[derive(Clone, Debug, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AccountInfo {
     pub address: AccountAddress,
     /// This account is default at current wallet.
     /// Every wallet must has one default account.
     pub is_default: bool,
+    pub is_readonly: bool,
     pub public_key: AccountPublicKey,
     pub receipt_identifier: ReceiptIdentifier,
 }
 
 impl AccountInfo {
-    pub fn new(address: AccountAddress, public_key: AccountPublicKey, is_default: bool) -> Self {
+    pub fn new(
+        address: AccountAddress,
+        public_key: AccountPublicKey,
+        is_default: bool,
+        is_readonly: bool,
+    ) -> Self {
         let auth_key = public_key.authentication_key();
         Self {
             address,
             public_key,
             is_default,
+            is_readonly,
             receipt_identifier: ReceiptIdentifier::V1(address, Some(auth_key)),
         }
     }
@@ -51,6 +58,7 @@ impl AccountInfo {
         AccountInfo {
             address,
             is_default: false,
+            is_readonly: false,
             public_key: account_public_key,
             receipt_identifier: ReceiptIdentifier::V1(address, Some(auth_key)),
         }

--- a/cmd/starcoin/src/account/import_readonly_cmd.rs
+++ b/cmd/starcoin/src/account/import_readonly_cmd.rs
@@ -1,0 +1,47 @@
+// Copyright (c) The Starcoin Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli_state::CliState;
+use crate::StarcoinOpt;
+use anyhow::Result;
+use scmd::{CommandAction, ExecContext};
+use starcoin_account_api::{AccountInfo, AccountPublicKey};
+use starcoin_crypto::{ValidCryptoMaterial, ValidCryptoMaterialStringExt};
+use starcoin_vm_types::account_address::AccountAddress;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "import-readonly")]
+pub struct ImportReadonlyOpt {
+    #[structopt(name = "input", short = "i", help = "input of public key")]
+    from_input: String,
+
+    /// if account_address is absent, generate address by public_key.
+    #[structopt(name = "account_address")]
+    account_address: Option<AccountAddress>,
+}
+
+pub struct ImportReadonlyCommand;
+
+impl CommandAction for ImportReadonlyCommand {
+    type State = CliState;
+    type GlobalOpt = StarcoinOpt;
+    type Opt = ImportReadonlyOpt;
+    type ReturnItem = AccountInfo;
+
+    fn run(
+        &self,
+        ctx: &ExecContext<Self::State, Self::GlobalOpt, Self::Opt>,
+    ) -> Result<Self::ReturnItem> {
+        let client = ctx.state().client();
+        let opt: &ImportReadonlyOpt = ctx.opt();
+
+        let public_key = AccountPublicKey::from_encoded_string(opt.from_input.as_str())?;
+
+        let address = opt
+            .account_address
+            .unwrap_or_else(|| public_key.derived_address());
+        let account = client.account_import_readonly(address, public_key.to_bytes())?;
+        Ok(account)
+    }
+}

--- a/cmd/starcoin/src/account/mod.rs
+++ b/cmd/starcoin/src/account/mod.rs
@@ -29,6 +29,7 @@ mod export_cmd;
 pub mod generate_keypair;
 mod import_cmd;
 pub mod import_multisig_cmd;
+pub mod import_readonly_cmd;
 mod list_cmd;
 mod lock_cmd;
 pub mod receipt_identifier_cmd;

--- a/cmd/starcoin/src/lib.rs
+++ b/cmd/starcoin/src/lib.rs
@@ -37,6 +37,7 @@ pub fn add_command(
                 .subcommand(account::UnlockCommand)
                 .subcommand(account::ExportCommand)
                 .subcommand(account::ImportCommand)
+                .subcommand(account::import_readonly_cmd::ImportReadonlyCommand)
                 .subcommand(account::ExecuteScriptFunctionCmd)
                 .subcommand(account::ExecuteScriptCommand)
                 .subcommand(account::LockCommand)

--- a/rpc/api/src/account/mod.rs
+++ b/rpc/api/src/account/mod.rs
@@ -63,6 +63,14 @@ pub trait AccountApi {
         password: String,
     ) -> FutureResult<AccountInfo>;
 
+    /// Import a readonly account with public key.
+    #[rpc(name = "account.import_readonly")]
+    fn import_readonly(
+        &self,
+        address: AccountAddress,
+        public_key: Vec<u8>,
+    ) -> FutureResult<AccountInfo>;
+
     /// Return the private key as bytes for `address`
     #[rpc(name = "account.export")]
     fn export(&self, address: AccountAddress, password: String) -> FutureResult<Vec<u8>>;

--- a/rpc/client/src/lib.rs
+++ b/rpc/client/src/lib.rs
@@ -388,6 +388,15 @@ impl RpcClient {
             .map_err(map_err)
     }
 
+    pub fn account_import_readonly(
+        &self,
+        address: AccountAddress,
+        public_key: Vec<u8>,
+    ) -> anyhow::Result<AccountInfo> {
+        self.call_rpc_blocking(|inner| inner.account_client.import_readonly(address, public_key))
+            .map_err(map_err)
+    }
+
     pub fn account_accepted_tokens(
         &self,
         address: AccountAddress,

--- a/rpc/server/src/module/account_rpc.rs
+++ b/rpc/server/src/module/account_rpc.rs
@@ -212,6 +212,20 @@ where
         Box::pin(fut.boxed())
     }
 
+    fn import_readonly(
+        &self,
+        address: AccountAddress,
+        public_key: Vec<u8>,
+    ) -> FutureResult<AccountInfo> {
+        let service = self.account.clone();
+        let fut = async move {
+            let result = service.import_readonly_account(address, public_key).await?;
+            Ok(result)
+        }
+        .map_err(map_err);
+        Box::pin(fut.boxed())
+    }
+
     /// Return the private key as bytes for `address`
     fn export(&self, address: AccountAddress, password: String) -> FutureResult<Vec<u8>> {
         let service = self.account.clone();

--- a/vm/types/src/receipt_identifier.rs
+++ b/vm/types/src/receipt_identifier.rs
@@ -12,7 +12,7 @@ use std::fmt::Formatter;
 use std::str::FromStr;
 
 /// See sip-21
-#[derive(Copy, Clone, Debug, Hash)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum ReceiptIdentifier {
     V1(AccountAddress, Option<AuthenticationKey>),
 }


### PR DESCRIPTION
新增 account import-readonly 命令通过公钥导入只读账号


TODO

1. 更新默认账号时触发事件通知其他服务。
2. 增加文档