### PR TITLE
[transaction] Use peer_to_peer_v2 when transfer, deprecated auth key parameter.

### DIFF
--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -6,7 +6,6 @@ use starcoin_executor::{peer_to_peer_txn_sent_as_association, DEFAULT_EXPIRATION
 use crypto::ed25519::random_public_key;
 use starcoin_config::ChainNetwork;
 use starcoin_vm_types::account_address;
-use starcoin_vm_types::transaction::authenticator::AuthenticationKey;
 use types::transaction::SignedUserTransaction;
 
 pub mod chain;
@@ -18,7 +17,6 @@ pub fn random_txn(seq_num: u64, net: &ChainNetwork) -> SignedUserTransaction {
     let addr = account_address::from_public_key(&random_public_key);
     peer_to_peer_txn_sent_as_association(
         addr,
-        Some(AuthenticationKey::ed25519(&random_public_key)),
         seq_num,
         1000,
         net.time_service().now_secs() + DEFAULT_EXPIRATION_TIME,

--- a/chain/tests/test_block_chain.rs
+++ b/chain/tests/test_block_chain.rs
@@ -16,7 +16,6 @@ use starcoin_types::block::{Block, BlockHeader};
 use starcoin_types::filter::Filter;
 use starcoin_vm_types::account_config::genesis_address;
 use starcoin_vm_types::event::EventKey;
-use starcoin_vm_types::transaction::authenticator::AuthenticationKey;
 use std::sync::Arc;
 
 #[stest::test(timeout = 120)]
@@ -379,7 +378,6 @@ async fn test_block_chain_txn_info_fork_mapping() -> Result<()> {
     let signed_txn_t2 = {
         let txn = build_transfer_from_association(
             account_address,
-            Some(AuthenticationKey::ed25519(&public_key)),
             0,
             10000,
             config.net().time_service().now_secs() + DEFAULT_EXPIRATION_TIME,

--- a/chain/tests/test_opened_block.rs
+++ b/chain/tests/test_opened_block.rs
@@ -9,7 +9,6 @@ use starcoin_executor::{
 };
 use starcoin_open_block::OpenedBlock;
 use starcoin_state_api::StateReaderExt;
-use starcoin_types::transaction::authenticator::AuthenticationKey;
 use starcoin_types::{account_address, account_config, U256};
 use std::{convert::TryInto, sync::Arc};
 
@@ -42,7 +41,6 @@ pub fn test_open_block() -> Result<()> {
     let receiver = account_address::from_public_key(&receive_public_key);
     let txn1 = build_transfer_from_association(
         receiver,
-        Some(AuthenticationKey::ed25519(&receive_public_key)),
         association_sequence_num,
         50_000_000,
         config.net().time_service().now_secs() + DEFAULT_EXPIRATION_TIME,
@@ -72,7 +70,6 @@ pub fn test_open_block() -> Result<()> {
         build_transfer_txn(
             receiver,
             address,
-            Some(AuthenticationKey::ed25519(&pubkey)),
             seq_number,
             10_000,
             1,

--- a/cmd/faucet/src/faucet.rs
+++ b/cmd/faucet/src/faucet.rs
@@ -1,14 +1,10 @@
 use anyhow::{format_err, Result};
-
 use starcoin_account_api::AccountInfo;
-use starcoin_crypto::ed25519::Ed25519PublicKey;
 use starcoin_executor::DEFAULT_EXPIRATION_TIME;
 use starcoin_rpc_client::{RemoteStateReader, RpcClient};
 use starcoin_state_api::AccountStateReader;
 use starcoin_types::account_address::AccountAddress;
-use starcoin_types::transaction::authenticator::AuthenticationKey;
 use starcoin_types::transaction::helpers::get_current_timestamp;
-use std::convert::TryFrom;
 
 pub struct Faucet {
     client: RpcClient,
@@ -26,12 +22,7 @@ impl Faucet {
         }
     }
 
-    pub fn transfer(
-        &self,
-        amount: u128,
-        receiver: AccountAddress,
-        public_key: Vec<u8>,
-    ) -> Result<()> {
+    pub fn transfer(&self, amount: u128, receiver: AccountAddress) -> Result<()> {
         let chain_state_reader = RemoteStateReader::new(&self.client)?;
         let account_state_reader = AccountStateReader::new(&chain_state_reader);
         let account_resource = account_state_reader
@@ -42,11 +33,9 @@ impl Faucet {
                     self.faucet_account.address()
                 )
             })?;
-        let public_key = Ed25519PublicKey::try_from(public_key.as_slice())?;
         let raw_tx = starcoin_executor::build_transfer_txn(
             self.faucet_account.address,
             receiver,
-            Some(AuthenticationKey::ed25519(&public_key)),
             account_resource.sequence_number(),
             amount,
             DEFAULT_GAS_PRICE,

--- a/cmd/starcoin/src/dev/tests.rs
+++ b/cmd/starcoin/src/dev/tests.rs
@@ -112,7 +112,6 @@ fn create_default_account(
     let transfer_raw_txn = starcoin_executor::build_transfer_txn(
         association_address(),
         default_account.address,
-        Some(default_account.public_key.authentication_key()),
         seq_num,
         transfer_amount,
         1,

--- a/cmd/tx-factory/src/txn_generator.rs
+++ b/cmd/tx-factory/src/txn_generator.rs
@@ -3,30 +3,21 @@
 
 use anyhow::Result;
 use starcoin_account_api::AccountInfo;
-use starcoin_crypto::ed25519::Ed25519PublicKey;
 use starcoin_types::account_address::AccountAddress;
 use starcoin_types::genesis_config::ChainId;
-use starcoin_types::transaction::authenticator::AuthenticationKey;
 use starcoin_types::transaction::RawUserTransaction;
 
 pub struct MockTxnGenerator {
     chain_id: ChainId,
     receiver_address: AccountAddress,
-    receiver_public_key: Option<Ed25519PublicKey>,
     account: AccountInfo,
 }
 
 impl MockTxnGenerator {
-    pub fn new(
-        chain_id: ChainId,
-        account: AccountInfo,
-        receiver_address: AccountAddress,
-        receiver_public_key: Option<Ed25519PublicKey>,
-    ) -> Self {
+    pub fn new(chain_id: ChainId, account: AccountInfo, receiver_address: AccountAddress) -> Self {
         MockTxnGenerator {
             chain_id,
             receiver_address,
-            receiver_public_key,
             account,
         }
     }
@@ -41,9 +32,6 @@ impl MockTxnGenerator {
         let transfer_txn = starcoin_executor::build_transfer_txn(
             self.account.address,
             self.receiver_address,
-            self.receiver_public_key
-                .as_ref()
-                .map(|k| AuthenticationKey::ed25519(k)),
             sequence_number,
             amount_to_transfer,
             1,
@@ -59,7 +47,6 @@ impl MockTxnGenerator {
         sequence_number: u64,
         sender: AccountAddress,
         receiver_address: AccountAddress,
-        receiver_public_key: Option<Ed25519PublicKey>,
         amount: u128,
         gas_price: u64,
         expiration_timestamp: u64,
@@ -67,9 +54,6 @@ impl MockTxnGenerator {
         let transfer_txn = starcoin_executor::build_transfer_txn(
             sender,
             receiver_address,
-            receiver_public_key
-                .as_ref()
-                .map(|k| AuthenticationKey::ed25519(k)),
             sequence_number,
             amount,
             gas_price,
@@ -85,7 +69,6 @@ impl MockTxnGenerator {
         sequence_number: u64,
         sender: AccountAddress,
         receiver_address_vec: Vec<AccountAddress>,
-        receiver_auth_keys: Vec<AuthenticationKey>,
         amount: u128,
         gas_price: u64,
         expiration_timestamp: u64,
@@ -93,7 +76,6 @@ impl MockTxnGenerator {
         let transfer_txn = starcoin_executor::build_batch_transfer_txn(
             sender,
             receiver_address_vec,
-            receiver_auth_keys,
             sequence_number,
             amount,
             gas_price,

--- a/executor/benchmark/src/lib.rs
+++ b/executor/benchmark/src/lib.rs
@@ -179,7 +179,6 @@ impl TransactionGenerator {
                     encode_transfer_script_function(
                         self.net.stdlib_version(),
                         receiver.address,
-                        Some(AuthenticationKey::ed25519(&receiver.public_key)),
                         1, /* amount */
                     ),
                     self.net.time_service().now_secs() + j as u64 + 1,

--- a/executor/src/account.rs
+++ b/executor/src/account.rs
@@ -658,7 +658,6 @@ pub fn peer_to_peer_txn(
 ) -> SignedUserTransaction {
     let mut args: Vec<Vec<u8>> = Vec::new();
     args.push(bcs_ext::to_bytes(receiver.address()).unwrap());
-    args.push(bcs_ext::to_bytes(&receiver.auth_key().to_vec()).unwrap());
     args.push(bcs_ext::to_bytes(&transfer_amount).unwrap());
 
     // get a SignedTransaction
@@ -668,7 +667,7 @@ pub fn peer_to_peer_txn(
                 core_code_address(),
                 Identifier::new("TransferScripts").unwrap(),
             ),
-            Identifier::new("peer_to_peer").unwrap(),
+            Identifier::new("peer_to_peer_v2").unwrap(),
             vec![stc_type_tag()],
             args,
         )),

--- a/executor/src/error_code_test.rs
+++ b/executor/src/error_code_test.rs
@@ -20,7 +20,6 @@ use starcoin_vm_types::account_config::{genesis_address, stc_type_tag};
 use starcoin_vm_types::genesis_config::ChainId;
 use starcoin_vm_types::token::stc::STC_TOKEN_CODE;
 use starcoin_vm_types::token::token_code::TokenCode;
-use starcoin_vm_types::transaction::authenticator::AuthenticationKey;
 use starcoin_vm_types::transaction::Package;
 use starcoin_vm_types::transaction::RawUserTransaction;
 use starcoin_vm_types::transaction::TransactionPayload;
@@ -137,7 +136,6 @@ fn test_execute_transfer_txn_with_wrong_token_code() -> Result<()> {
     let raw_txn = crate::build_transfer_txn_by_token_type(
         *account1.address(),
         *account2.address(),
-        Some(account2.auth_key()),
         0,
         1000,
         1,
@@ -173,7 +171,6 @@ fn test_execute_transfer_txn_with_dummy_gas_token_code() -> Result<()> {
     let raw_txn = raw_peer_to_peer_txn_with_non_default_gas_token(
         *account1.address(),
         *account2.address(),
-        Some(account2.auth_key()),
         0,
         1000,
         1,
@@ -196,7 +193,6 @@ fn test_execute_transfer_txn_with_dummy_gas_token_code() -> Result<()> {
 pub fn raw_peer_to_peer_txn_with_non_default_gas_token(
     sender: AccountAddress,
     receiver: AccountAddress,
-    recipient_auth_key: Option<AuthenticationKey>,
     transfer_amount: u128,
     seq_num: u64,
     gas_price: u64,
@@ -211,7 +207,6 @@ pub fn raw_peer_to_peer_txn_with_non_default_gas_token(
         TransactionPayload::ScriptFunction(encode_transfer_script_by_token_code(
             StdlibVersion::Latest,
             receiver,
-            recipient_auth_key,
             transfer_amount,
             STC_TOKEN_CODE.clone(),
         )),

--- a/rpc/server/src/module/pubsub/tests.rs
+++ b/rpc/server/src/module/pubsub/tests.rs
@@ -24,7 +24,6 @@ use starcoin_storage::BlockStore;
 use starcoin_txpool_api::TxPoolSyncService;
 use starcoin_types::system_events::MintBlockEvent;
 use starcoin_types::system_events::NewHeadBlock;
-use starcoin_types::transaction::authenticator::AuthenticationKey;
 use starcoin_types::{account_address, U256};
 use starcoin_vm_types::genesis_config::ConsensusStrategy;
 use std::sync::Arc;
@@ -48,7 +47,6 @@ pub async fn test_subscribe_to_events() -> Result<()> {
     let txn = {
         let txn = starcoin_executor::build_transfer_from_association(
             account_address,
-            Some(AuthenticationKey::ed25519(&public_key)),
             0,
             10000,
             config.net().time_service().now_secs() + DEFAULT_EXPIRATION_TIME,
@@ -166,7 +164,6 @@ pub async fn test_subscribe_to_pending_transactions() -> Result<()> {
         let account = AccountInfo::random();
         let txn = starcoin_executor::build_transfer_from_association(
             account.address,
-            Some(account.public_key.authentication_key()),
             0,
             10000,
             DEFAULT_EXPIRATION_TIME,

--- a/sync/tests/txn_sync_test.rs
+++ b/sync/tests/txn_sync_test.rs
@@ -3,7 +3,6 @@ use executor::DEFAULT_EXPIRATION_TIME;
 use starcoin_crypto::keygen::KeyGen;
 use starcoin_service_registry::RegistryAsyncService;
 use starcoin_txpool_api::TxPoolSyncService;
-use starcoin_types::transaction::authenticator::AuthenticationKey;
 use starcoin_types::{account_address, transaction::SignedUserTransaction};
 use std::sync::Arc;
 use std::time::Duration;
@@ -57,7 +56,6 @@ fn gen_user_txn(config: &NodeConfig) -> SignedUserTransaction {
     let account_address = account_address::from_public_key(&public_key);
     let txn = executor::build_transfer_from_association(
         account_address,
-        Some(AuthenticationKey::ed25519(&public_key)),
         0,
         10000,
         config.net().time_service().now_secs() + DEFAULT_EXPIRATION_TIME,

--- a/testsuite/tests/steps/transaction.rs
+++ b/testsuite/tests/steps/transaction.rs
@@ -63,7 +63,6 @@ fn transfer_txn(
     let raw_txn = starcoin_executor::build_transfer_txn(
         from,
         to.address,
-        Some(to.public_key.authentication_key()),
         account_resource.sequence_number(),
         amount,
         1,

--- a/txpool/src/test.rs
+++ b/txpool/src/test.rs
@@ -76,7 +76,6 @@ async fn test_tx_pool() -> Result<()> {
     let account_address = account_address::from_public_key(&public_key);
     let txn = starcoin_executor::build_transfer_from_association(
         account_address,
-        Some(AuthenticationKey::ed25519(&public_key)),
         0,
         10000,
         1,
@@ -142,7 +141,6 @@ async fn test_rollback() -> Result<()> {
         let account_address = account_address::from_public_key(&public_key);
         let txn = starcoin_executor::build_transfer_from_association(
             account_address,
-            Some(AuthenticationKey::ed25519(&public_key)),
             0,
             10000,
             start_timestamp + DEFAULT_EXPIRATION_TIME,
@@ -157,7 +155,6 @@ async fn test_rollback() -> Result<()> {
         let account_address = account_address::from_public_key(&public_key);
         let txn = starcoin_executor::build_transfer_from_association(
             account_address,
-            Some(AuthenticationKey::ed25519(&public_key)),
             0,
             20000,
             start_timestamp + DEFAULT_EXPIRATION_TIME,
@@ -257,7 +254,6 @@ fn generate_txn(config: Arc<NodeConfig>, seq: u64) -> SignedUserTransaction {
         TransactionPayload::ScriptFunction(encode_transfer_script_function(
             config.net().stdlib_version(),
             account_address,
-            Some(AuthenticationKey::ed25519(&public_key)),
             10000,
         )),
         seq,

--- a/vm/types/src/transaction/authenticator.rs
+++ b/vm/types/src/transaction/authenticator.rs
@@ -397,7 +397,7 @@ impl AccountPublicKey {
 
     pub fn receipt_identifier(&self) -> ReceiptIdentifier {
         let auth_key = self.authentication_key();
-        ReceiptIdentifier::v1(auth_key.derived_address(), Some(auth_key))
+        ReceiptIdentifier::v1(auth_key.derived_address())
     }
 
     /// Unique identifier for the signature scheme


### PR DESCRIPTION
转账使用 peer_to_peer_v2  function，废弃 auth key 参数