### PR TITLE
Dry run api

### DIFF
--- a/cmd/starcoin/src/dev/call_api_cmd.rs
+++ b/cmd/starcoin/src/dev/call_api_cmd.rs
@@ -1,0 +1,55 @@
+// Copyright (c) The Starcoin Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::cli_state::CliState;
+use crate::StarcoinOpt;
+use anyhow::Result;
+use scmd::{CommandAction, ExecContext};
+use serde_json::Value;
+use starcoin_rpc_client::Params;
+use structopt::StructOpt;
+
+/// Call rpc api command
+///  Some examples:
+///  ``` shell
+///  dev call-api node.info
+///  dev call-api chain.get_block_by_number [0]
+///  ```
+#[derive(Debug, StructOpt)]
+#[structopt(name = "call-api")]
+pub struct CallApiOpt {
+    #[structopt(name = "rpc-api-name")]
+    /// api name to call, example: node.info
+    rpc_api_name: String,
+
+    #[structopt(name = "api-params")]
+    /// api params, should be a json array string
+    params: Option<String>,
+}
+
+pub struct CallApiCommand;
+
+impl CommandAction for CallApiCommand {
+    type State = CliState;
+    type GlobalOpt = StarcoinOpt;
+    type Opt = CallApiOpt;
+    type ReturnItem = Value;
+
+    fn run(
+        &self,
+        ctx: &ExecContext<Self::State, Self::GlobalOpt, Self::Opt>,
+    ) -> Result<Self::ReturnItem> {
+        let opt = ctx.opt();
+
+        let params = match opt.params.as_ref() {
+            Some(param) => serde_json::from_str(param.as_str())?,
+            None => Params::None,
+        };
+
+        let result = ctx
+            .state()
+            .client()
+            .call_raw_api(opt.rpc_api_name.as_str(), params)?;
+        Ok(result)
+    }
+}

--- a/cmd/starcoin/src/dev/mod.rs
+++ b/cmd/starcoin/src/dev/mod.rs
@@ -13,6 +13,7 @@ pub use upgrade_module_proposal_cmd::*;
 pub use upgrade_module_queue_cmd::*;
 pub use upgrade_vm_config_proposal_cmd::*;
 
+pub(crate) mod call_api_cmd;
 mod call_contract_cmd;
 mod compile_cmd;
 mod deploy_cmd;

--- a/cmd/starcoin/src/lib.rs
+++ b/cmd/starcoin/src/lib.rs
@@ -115,6 +115,7 @@ pub fn add_command(
                 .subcommand(dev::UpgradeVMConfigProposalCommand)
                 .subcommand(dev::PackageCmd)
                 .subcommand(dev::CallContractCommand)
+                .subcommand(dev::call_api_cmd::CallApiCommand)
                 .subcommand(
                     Command::with_name("subscribe")
                         .with_about("Subscribe the chain events")

--- a/node/src/rpc_service_factory.rs
+++ b/node/src/rpc_service_factory.rs
@@ -80,7 +80,6 @@ impl ServiceFactory<RpcService> for RpcServiceFactory {
                 account_service,
                 txpool_service,
                 chain_state_service,
-                chain_service,
                 dev_playground,
             )
         };

--- a/rpc/api/src/contract_api.rs
+++ b/rpc/api/src/contract_api.rs
@@ -8,6 +8,7 @@ use crate::types::{
 use crate::FutureResult;
 use starcoin_vm_types::account_address::AccountAddress;
 use starcoin_vm_types::language_storage::{ModuleId, StructTag};
+use starcoin_vm_types::transaction::authenticator::AccountPublicKey;
 
 #[rpc]
 pub trait ContractApi {
@@ -29,4 +30,12 @@ pub trait ContractApi {
 
     #[rpc(name = "contract.dry_run")]
     fn dry_run(&self, txn: DryRunTransactionRequest) -> FutureResult<TransactionOutputView>;
+
+    /// Dry run RawUserTransaction, the raw_txn parameter is RawUserTransaction's hex
+    #[rpc(name = "contract.dry_run_raw")]
+    fn dry_run_raw(
+        &self,
+        raw_txn: String,
+        sender_public_key: StrView<AccountPublicKey>,
+    ) -> FutureResult<TransactionOutputView>;
 }

--- a/rpc/api/src/types.rs
+++ b/rpc/api/src/types.rs
@@ -170,12 +170,12 @@ impl From<RawUserTransaction> for TransactionRequest {
     }
 }
 
-#[derive(Default, Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
 pub struct DryRunTransactionRequest {
     #[serde(flatten)]
     pub transaction: TransactionRequest,
     /// Sender's public key
-    pub sender_public_key: Option<StrView<AccountPublicKey>>,
+    pub sender_public_key: StrView<AccountPublicKey>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/rpc/server/src/module/account_rpc.rs
+++ b/rpc/server/src/module/account_rpc.rs
@@ -56,12 +56,11 @@ where
             node_config,
         }
     }
-    fn txn_request_filler(&self) -> TransactionRequestFiller<Account, Pool, State, Chain> {
+    fn txn_request_filler(&self) -> TransactionRequestFiller<Account, Pool, State> {
         TransactionRequestFiller {
             account: Some(self.account.clone()),
             pool: self.pool.clone(),
             chain_state: self.chain_state.clone(),
-            chain: self.chain.clone(),
             node_config: self.node_config.clone(),
         }
     }

--- a/rpc/server/src/module/contract_rpc.rs
+++ b/rpc/server/src/module/contract_rpc.rs
@@ -6,7 +6,6 @@ use crate::module::map_err;
 use futures::future::TryFutureExt;
 use futures::FutureExt;
 use starcoin_account_api::AccountAsyncService;
-use starcoin_chain_service::ChainAsyncService;
 use starcoin_config::NodeConfig;
 use starcoin_dev::playground::PlaygroudService;
 use starcoin_rpc_api::contract_api::ContractApi;
@@ -19,60 +18,56 @@ use starcoin_state_api::ChainStateAsyncService;
 use starcoin_txpool_api::TxPoolSyncService;
 use starcoin_types::account_address::AccountAddress;
 use starcoin_types::language_storage::{ModuleId, StructTag};
-use starcoin_types::transaction::DryRunTransaction;
+use starcoin_types::transaction::{DryRunTransaction, RawUserTransaction};
 use starcoin_vm_types::access_path::AccessPath;
+use starcoin_vm_types::transaction::authenticator::AccountPublicKey;
+use std::str::FromStr;
 use std::sync::Arc;
 
-pub struct ContractRpcImpl<Account, Pool, State, Chain> {
+pub struct ContractRpcImpl<Account, Pool, State> {
     pub(crate) account: Option<Account>,
     pub(crate) pool: Pool,
     pub(crate) chain_state: State,
-    pub(crate) chain: Chain,
     pub(crate) node_config: Arc<NodeConfig>,
     playground: PlaygroudService,
 }
 
-impl<Account, Pool, State, Chain> ContractRpcImpl<Account, Pool, State, Chain>
+impl<Account, Pool, State> ContractRpcImpl<Account, Pool, State>
 where
     Account: AccountAsyncService + 'static,
     Pool: TxPoolSyncService + 'static,
     State: ChainStateAsyncService + 'static,
-    Chain: ChainAsyncService + 'static,
 {
     pub fn new(
         node_config: Arc<NodeConfig>,
         account: Option<Account>,
         pool: Pool,
         chain_state: State,
-        chain: Chain,
         playground: PlaygroudService,
     ) -> Self {
         Self {
             account,
             pool,
             chain_state,
-            chain,
             node_config,
             playground,
         }
     }
-    fn txn_request_filler(&self) -> TransactionRequestFiller<Account, Pool, State, Chain> {
+    fn txn_request_filler(&self) -> TransactionRequestFiller<Account, Pool, State> {
         TransactionRequestFiller {
             account: self.account.clone(),
             pool: self.pool.clone(),
             chain_state: self.chain_state.clone(),
-            chain: self.chain.clone(),
             node_config: self.node_config.clone(),
         }
     }
 }
 
-impl<Account, Pool, State, Chain> ContractApi for ContractRpcImpl<Account, Pool, State, Chain>
+impl<Account, Pool, State> ContractApi for ContractRpcImpl<Account, Pool, State>
 where
     Account: AccountAsyncService + 'static,
     Pool: TxPoolSyncService + 'static,
     State: ChainStateAsyncService + 'static,
-    Chain: ChainAsyncService + 'static,
 {
     fn get_code(&self, module_id: StrView<ModuleId>) -> FutureResult<Option<StrView<Vec<u8>>>> {
         let service = self.chain_state.clone();
@@ -148,6 +143,29 @@ where
                 state_root,
                 DryRunTransaction {
                     raw_txn: txn,
+                    public_key: sender_public_key.0,
+                },
+            )?;
+            Ok(output.1.into())
+        }
+        .map_err(map_err);
+        Box::pin(f.boxed())
+    }
+
+    fn dry_run_raw(
+        &self,
+        raw_txn: String,
+        sender_public_key: StrView<AccountPublicKey>,
+    ) -> FutureResult<TransactionOutputView> {
+        let service = self.chain_state.clone();
+        let playground = self.playground.clone();
+        let f = async move {
+            let state_root = service.state_root().await?;
+            let raw_txn = RawUserTransaction::from_str(raw_txn.as_str())?;
+            let output = playground.dry_run(
+                state_root,
+                DryRunTransaction {
+                    raw_txn,
                     public_key: sender_public_key.0,
                 },
             )?;

--- a/vm/types/src/transaction/mod.rs
+++ b/vm/types/src/transaction/mod.rs
@@ -39,6 +39,7 @@ pub use script::{
     TypeArgumentABI,
 };
 use starcoin_crypto::hash::SPARSE_MERKLE_PLACEHOLDER_HASH;
+use std::str::FromStr;
 pub use transaction_argument::{
     parse_transaction_argument, parse_transaction_arguments, TransactionArgument,
 };
@@ -276,6 +277,14 @@ impl RawUserTransaction {
             .len()
     }
 
+    pub fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self> {
+        Self::from_bytes(hex::decode(hex)?)
+    }
+
+    pub fn from_bytes<T: AsRef<[u8]>>(bytes: T) -> Result<Self> {
+        bcs_ext::from_bytes(bytes.as_ref())
+    }
+
     pub fn mock() -> Self {
         Self::mock_by_sender(AccountAddress::random())
     }
@@ -302,6 +311,31 @@ impl RawUserTransaction {
             u64::max_value(),
             ChainId::test(),
         )
+    }
+}
+
+impl FromStr for RawUserTransaction {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.strip_prefix("0x").unwrap_or(s);
+        Self::from_hex(s)
+    }
+}
+
+impl TryFrom<&[u8]> for RawUserTransaction {
+    type Error = anyhow::Error;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        Self::from_bytes(bytes)
+    }
+}
+
+impl TryFrom<Vec<u8>> for RawUserTransaction {
+    type Error = anyhow::Error;
+
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        Self::from_bytes(bytes)
     }
 }
 


### PR DESCRIPTION
1. 提供 dry_run RawUserTransaction rpc api。
2. 提供 dev call-api 命令，可调用任意的 json rpc api 。

resolve #2480 #2620 