### PR TITLE
[account] Remove AccountSignature and define SignedMessage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,7 +2005,7 @@ dependencies = [
  "starcoin-storage",
  "starcoin-types",
  "starcoin-vm-types",
- "structopt 0.3.21",
+ "structopt 0.3.22",
 ]
 
 [[package]]
@@ -7928,6 +7928,7 @@ version = "1.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bcs-ext",
  "futures 0.3.13",
  "hex",
  "rand 0.8.4",

--- a/account/api/Cargo.toml
+++ b/account/api/Cargo.toml
@@ -12,6 +12,7 @@ thiserror = "1.0"
 async-trait = "0.1"
 serde = { version = "1.0.126", default-features = false }
 serde_bytes = "0.11.5"
+bcs-ext ={package= "bcs-ext", path = "../../commons/bcs_ext" }
 hex= "0.4.3"
 starcoin-types = { path = "../../types"}
 starcoin-crypto = { path = "../../commons/crypto"}

--- a/account/api/src/message.rs
+++ b/account/api/src/message.rs
@@ -6,8 +6,7 @@ use anyhow::Result;
 use starcoin_service_registry::ServiceRequest;
 use starcoin_types::account_address::AccountAddress;
 use starcoin_types::account_config::token_code::TokenCode;
-use starcoin_types::sign_message::SigningMessage;
-use starcoin_types::transaction::authenticator::AccountSignature;
+use starcoin_types::sign_message::{SignedMessage, SigningMessage};
 use starcoin_types::transaction::{RawUserTransaction, SignedUserTransaction};
 use std::time::Duration;
 
@@ -64,6 +63,6 @@ pub enum AccountResponse {
     UnlockAccountResponse,
     ExportAccountResponse(Vec<u8>),
     AcceptedTokens(Vec<TokenCode>),
-    MessageSignature(Box<AccountSignature>),
+    SignedMessage(Box<SignedMessage>),
     None,
 }

--- a/account/api/src/types.rs
+++ b/account/api/src/types.rs
@@ -8,9 +8,7 @@ use starcoin_types::{
     transaction::authenticator::AuthenticationKey,
 };
 
-pub use starcoin_types::transaction::authenticator::{
-    AccountPrivateKey, AccountPublicKey, AccountSignature,
-};
+pub use starcoin_types::transaction::authenticator::{AccountPrivateKey, AccountPublicKey};
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AccountInfo {

--- a/account/service/src/service.rs
+++ b/account/service/src/service.rs
@@ -139,7 +139,7 @@ impl ServiceHandler<AccountService, AccountRequest> for AccountService {
                 txn: raw_txn,
                 signer,
             } => AccountResponse::SignedTxn(Box::new(self.manager.sign_txn(signer, *raw_txn)?)),
-            AccountRequest::SignMessage { message, signer } => AccountResponse::MessageSignature(
+            AccountRequest::SignMessage { message, signer } => AccountResponse::SignedMessage(
                 Box::new(self.manager.sign_message(signer, message)?),
             ),
             AccountRequest::UnlockAccount(address, password, duration) => {

--- a/account/src/account_manager.rs
+++ b/account/src/account_manager.rs
@@ -11,8 +11,7 @@ use starcoin_account_api::{AccountInfo, AccountPrivateKey, AccountPublicKey, Acc
 use starcoin_crypto::ed25519::Ed25519PrivateKey;
 use starcoin_crypto::{Uniform, ValidCryptoMaterial};
 use starcoin_logger::prelude::*;
-use starcoin_types::sign_message::SigningMessage;
-use starcoin_types::transaction::authenticator::AccountSignature;
+use starcoin_types::sign_message::{SignedMessage, SigningMessage};
 use starcoin_types::{
     account_address::AccountAddress,
     account_config::token_code::TokenCode,
@@ -218,7 +217,7 @@ impl AccountManager {
         &self,
         signer_address: AccountAddress,
         message: SigningMessage,
-    ) -> AccountResult<AccountSignature> {
+    ) -> AccountResult<SignedMessage> {
         let pass = self.key_cache.write().get_pass(&signer_address);
         match pass {
             None => Err(AccountError::AccountLocked(signer_address)),

--- a/cmd/airdrop/src/main.rs
+++ b/cmd/airdrop/src/main.rs
@@ -18,6 +18,7 @@ use starcoin_types::identifier::Identifier;
 use starcoin_types::language_storage::ModuleId;
 use starcoin_types::transaction::authenticator::{AccountPrivateKey, AuthenticationKey};
 use starcoin_types::transaction::{RawUserTransaction, ScriptFunction};
+use starcoin_vm_types::transaction::SignedUserTransaction;
 use starcoin_vm_types::value::MoveValue;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -151,7 +152,7 @@ async fn main() -> Result<()> {
             ChainId::new(chain_id),
         );
         let signature = private_key.sign(&txn);
-        let signed_txn = signature.build_transaction(txn)?;
+        let signed_txn = SignedUserTransaction::new(txn, signature);
 
         let signed_txn_hex = hex::encode(signed_txn.encode()?);
         let txn_hash: HashValue = txpool_client

--- a/cmd/starcoin/src/account/verify_sign_cmd.rs
+++ b/cmd/starcoin/src/account/verify_sign_cmd.rs
@@ -4,7 +4,7 @@
 use crate::cli_state::CliState;
 use crate::view::BoolView;
 use crate::StarcoinOpt;
-use anyhow::{format_err, Result};
+use anyhow::Result;
 use scmd::{CommandAction, ExecContext};
 use starcoin_types::sign_message::SignedMessage;
 use structopt::StructOpt;
@@ -32,20 +32,13 @@ impl CommandAction for VerifySignMessageCmd {
         let opt = ctx.opt();
         let state = ctx.state();
         let signed_message = opt.signed_message.clone();
-        let account_resource = state
-            .get_account_resource(signed_message.account)?
-            .ok_or_else(|| {
-                format_err!(
-                    "Can not find account on chain by signed message address:{}",
-                    signed_message.account
-                )
-            })?;
+        let account_resource = state.get_account_resource(signed_message.account)?;
 
         let result = signed_message
             .check_signature()
-            .and_then(|_| signed_message.check_account(&account_resource));
+            .and_then(|_| signed_message.check_account(account_resource.as_ref()));
         if let Err(e) = result.as_ref() {
-            eprintln!("check signed message error: {:?}", e)
+            eprintln!("check signed message error: {}", e)
         }
         Ok(BoolView {
             result: result.is_ok(),

--- a/cmd/starcoin/src/account/verify_sign_cmd.rs
+++ b/cmd/starcoin/src/account/verify_sign_cmd.rs
@@ -4,22 +4,17 @@
 use crate::cli_state::CliState;
 use crate::view::BoolView;
 use crate::StarcoinOpt;
-use anyhow::Result;
+use anyhow::{format_err, Result};
 use scmd::{CommandAction, ExecContext};
-use starcoin_account_api::AccountSignature;
-use starcoin_crypto::ValidCryptoMaterialStringExt;
-use starcoin_types::sign_message::SigningMessage;
+use starcoin_types::sign_message::SignedMessage;
 use structopt::StructOpt;
 
 /// Verify the the message signed by the sign command.
 #[derive(Debug, StructOpt)]
 #[structopt(name = "verify-sign-message")]
 pub struct VerifySignMessageOpt {
-    #[structopt(short = "m", long = "source", name = "source-message")]
-    source: SigningMessage,
-
-    #[structopt(short = "d", long = "signed", name = "signed-message")]
-    signed: String,
+    #[structopt(short = "m")]
+    signed_message: SignedMessage,
 }
 
 pub struct VerifySignMessageCmd;
@@ -35,8 +30,23 @@ impl CommandAction for VerifySignMessageCmd {
         ctx: &ExecContext<Self::State, Self::GlobalOpt, Self::Opt>,
     ) -> Result<Self::ReturnItem> {
         let opt = ctx.opt();
-        let signed = AccountSignature::from_encoded_string(opt.signed.as_str())?;
-        let result = signed.verify(&opt.source);
+        let state = ctx.state();
+        let signed_message = opt.signed_message.clone();
+        let account_resource = state
+            .get_account_resource(signed_message.account)?
+            .ok_or_else(|| {
+                format_err!(
+                    "Can not find account on chain by signed message address:{}",
+                    signed_message.account
+                )
+            })?;
+
+        let result = signed_message
+            .check_signature()
+            .and_then(|_| signed_message.check_account(&account_resource));
+        if let Err(e) = result.as_ref() {
+            eprintln!("check signed message error: {:?}", e)
+        }
         Ok(BoolView {
             result: result.is_ok(),
         })

--- a/executor/src/account.rs
+++ b/executor/src/account.rs
@@ -203,9 +203,7 @@ impl Account {
             chain_id,
         );
         let signature = self.private_key.sign(&raw_txn);
-        signature
-            .build_transaction(raw_txn)
-            .expect("Build transaction should success")
+        SignedUserTransaction::new(raw_txn, signature)
     }
 
     // get_current_timestamp() + DEFAULT_EXPIRATION_TIME,
@@ -231,9 +229,7 @@ impl Account {
 
     pub fn sign_txn(&self, raw_txn: RawUserTransaction) -> SignedUserTransaction {
         let signature = self.private_key.sign(&raw_txn);
-        signature
-            .build_transaction(raw_txn)
-            .expect("build txn should success")
+        SignedUserTransaction::new(raw_txn, signature)
     }
 }
 

--- a/rpc/api/src/account/mod.rs
+++ b/rpc/api/src/account/mod.rs
@@ -86,6 +86,7 @@ pub trait AccountApi {
         new_password: String,
     ) -> FutureResult<AccountInfo>;
 
+    //TODO remove this api
     #[rpc(name = "account.accepted_tokens")]
     fn accepted_tokens(&self, address: AccountAddress) -> FutureResult<Vec<TokenCode>>;
 

--- a/rpc/api/src/account/mod.rs
+++ b/rpc/api/src/account/mod.rs
@@ -4,7 +4,7 @@
 use jsonrpc_derive::rpc;
 
 pub use self::gen_client::Client as AccountClient;
-use crate::types::{StrView, TransactionRequest};
+use crate::types::{SignedMessageView, TransactionRequest};
 use crate::FutureResult;
 use starcoin_account_api::AccountInfo;
 use starcoin_types::account_address::AccountAddress;
@@ -29,8 +29,11 @@ pub trait AccountApi {
     fn get(&self, address: AccountAddress) -> FutureResult<Option<AccountInfo>>;
 
     #[rpc(name = "account.sign")]
-    fn sign(&self, address: AccountAddress, data: SigningMessage)
-        -> FutureResult<StrView<Vec<u8>>>;
+    fn sign(
+        &self,
+        address: AccountAddress,
+        data: SigningMessage,
+    ) -> FutureResult<SignedMessageView>;
 
     /// sign a txn request, return hex encoded bcs_ext bytes of signed user txn.
     #[rpc(name = "account.sign_txn_request")]

--- a/rpc/api/src/types.rs
+++ b/rpc/api/src/types.rs
@@ -37,6 +37,7 @@ use starcoin_vm_types::block_metadata::BlockMetadata;
 use starcoin_vm_types::identifier::Identifier;
 use starcoin_vm_types::language_storage::{FunctionId, ModuleId, StructTag};
 use starcoin_vm_types::parser::{parse_transaction_argument, parse_type_tag};
+use starcoin_vm_types::sign_message::SignedMessage;
 use starcoin_vm_types::transaction::authenticator::AccountPublicKey;
 use starcoin_vm_types::transaction::{
     Script, SignedUserTransaction, Transaction, TransactionInfo, TransactionOutput,
@@ -1126,6 +1127,24 @@ where
         StrView::<T>::from_str(&s).map_err(D::Error::custom)
     }
 }
+
+pub type SignedMessageView = StrView<SignedMessage>;
+
+impl FromStr for SignedMessageView {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(StrView(SignedMessage::from_str(s)?))
+    }
+}
+
+impl std::fmt::Display for SignedMessageView {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", &self.0)
+    }
+}
+
+//TODO auto implement FromStr for StrView<T> where T:FromStr
 
 pub type ModuleIdView = StrView<ModuleId>;
 pub type TypeTagView = StrView<TypeTag>;

--- a/rpc/client/src/lib.rs
+++ b/rpc/client/src/lib.rs
@@ -26,7 +26,7 @@ use starcoin_rpc_api::types::{
     AccountStateSetView, AnnotatedMoveStructView, AnnotatedMoveValueView, BlockHeaderView,
     BlockSummaryView, BlockView, ChainId, ChainInfoView, ContractCall, DryRunOutputView,
     DryRunTransactionRequest, EpochUncleSummaryView, FactoryAction, MintedBlockView, PeerInfoView,
-    SignedUserTransactionView, StateWithProofView, StrView, TransactionInfoView,
+    SignedMessageView, SignedUserTransactionView, StateWithProofView, StrView, TransactionInfoView,
     TransactionRequest, TransactionView,
 };
 use starcoin_rpc_api::{
@@ -336,7 +336,7 @@ impl RpcClient {
         &self,
         signer: AccountAddress,
         message: SigningMessage,
-    ) -> anyhow::Result<StrView<Vec<u8>>> {
+    ) -> anyhow::Result<SignedMessageView> {
         self.call_rpc_blocking(|inner| inner.account_client.sign(signer, message))
             .map_err(map_err)
     }

--- a/rpc/server/src/module/account_rpc.rs
+++ b/rpc/server/src/module/account_rpc.rs
@@ -8,7 +8,7 @@ use futures::FutureExt;
 use starcoin_account_api::{AccountAsyncService, AccountInfo};
 use starcoin_chain_service::ChainAsyncService;
 use starcoin_config::NodeConfig;
-use starcoin_rpc_api::types::{StrView, TransactionRequest};
+use starcoin_rpc_api::types::{SignedMessageView, TransactionRequest};
 use starcoin_rpc_api::{account::AccountApi, FutureResult};
 use starcoin_state_api::ChainStateAsyncService;
 use starcoin_txpool_api::TxPoolSyncService;
@@ -126,7 +126,7 @@ where
         &self,
         address: AccountAddress,
         data: SigningMessage,
-    ) -> FutureResult<StrView<Vec<u8>>> {
+    ) -> FutureResult<SignedMessageView> {
         let account_service = self.account.clone();
         let f = async move {
             let signature = account_service.sign_message(address, data).await?;

--- a/test-helper/src/executor.rs
+++ b/test-helper/src/executor.rs
@@ -277,7 +277,7 @@ fn build_signed_txn(
 ) -> SignedUserTransaction {
     let txn = build_raw_txn(user_address, state, payload, net.chain_id());
     let signature = prikey.sign(&txn);
-    signature.build_transaction(txn).unwrap()
+    SignedUserTransaction::new(txn, signature)
 }
 
 #[allow(clippy::unnecessary_wraps)]

--- a/testsuite/features/cmd.feature
+++ b/testsuite/features/cmd.feature
@@ -103,7 +103,6 @@ Feature: cmd integration test
     Then cmd: "account remove @$.address@"
     Then cmd: "account list"
     Then cmd: "account show"
-#    Then cmd: "account execute-builtin --blocking --script empty_script -s @$.account.address@"
     Then cmd: "account accept-token 0x1::DummyToken::DummyToken"
     Then stop
 
@@ -113,9 +112,24 @@ Feature: cmd integration test
 
 #account sign message
   Scenario Outline: [cmd] account sign message
+    # test the account do not exist on chain
     Then cmd: "account unlock"
-    Then cmd: "account sign-message  -m ssyuan"
-    Then cmd: "account verify-sign-message -m ssyuan -d @$.result@"
+    Then cmd: "account sign-message -m helloworld"
+    Then cmd: "account verify-sign-message -m @$.result@"
+    Then assert: "$.result true"
+    # create the account on chain
+    Then cmd: "dev get-coin"
+    Then cmd: "account sign-message  -m helloworld"
+    Then cmd: "account verify-sign-message -m @$.result@"
+    Then assert: "$.result true"
+    # init the auth key on chain by send the first transaction, test authkey is not dummy key.
+    Then cmd: "account transfer -v 1000 -r 0xA550C18 -b"
+    Then cmd: "account sign-message -m helloworld"
+    Then cmd: "account verify-sign-message -m @$.result@"
+    Then assert: "$.result true"
+    # test multi sign account
+    Then cmd: "account sign-message -s 0xA550C18 -m helloworld"
+    Then cmd: "account verify-sign-message -m @$.result@"
     Then assert: "$.result true"
 
     Examples:

--- a/vm/functional-tests/src/evaluator.rs
+++ b/vm/functional-tests/src/evaluator.rs
@@ -327,7 +327,7 @@ fn make_script_transaction(
         ChainId::test(),
     );
     let signature = params.privkey.sign(&raw_txn);
-    signature.build_transaction(raw_txn)
+    Ok(SignedUserTransaction::new(raw_txn, signature))
 }
 
 /// Creates and signs a module transaction.
@@ -351,7 +351,7 @@ fn make_module_transaction(
         ChainId::test(),
     );
     let signature = params.privkey.sign(&raw_txn);
-    signature.build_transaction(raw_txn)
+    Ok(SignedUserTransaction::new(raw_txn, signature))
 }
 
 /// Runs a single transaction using the fake executor.

--- a/vm/types/src/sign_message.rs
+++ b/vm/types/src/sign_message.rs
@@ -1,9 +1,13 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::account_address::AccountAddress;
+use crate::account_config::AccountResource;
+use crate::transaction::authenticator::TransactionAuthenticator;
 use anyhow::{ensure, Error, Result};
 use serde::{Deserialize, Serialize};
 use starcoin_crypto::hash::{CryptoHash, CryptoHasher};
+use std::fmt::Formatter;
 use std::str::FromStr;
 
 /// SigningMessage is a message to be signed and encapsulates the salt
@@ -20,5 +24,63 @@ impl FromStr for SigningMessage {
         Ok(Self {
             message: s.as_bytes().to_vec(),
         })
+    }
+}
+
+/// A message has signed
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize, CryptoHasher, CryptoHash)]
+pub struct SignedMessage {
+    /// The account to sign the message.
+    pub account: AccountAddress,
+    pub message: SigningMessage,
+    pub authenticator: TransactionAuthenticator,
+}
+
+impl SignedMessage {
+    pub fn new(
+        account: AccountAddress,
+        message: SigningMessage,
+        authenticator: TransactionAuthenticator,
+    ) -> Self {
+        Self {
+            account,
+            message,
+            authenticator,
+        }
+    }
+    /// Checks that the signature of given message. Returns `Ok()` if the signature is valid.
+    /// Note: this method do not check the relation of account and public key.
+    pub fn check_signature(&self) -> Result<()> {
+        self.authenticator.verify(&self.message)
+    }
+
+    /// Checks the account by on chain account resource, please ensure the AccountResource's address == message.account
+    pub fn check_account(&self, account_resource: &AccountResource) -> Result<()> {
+        ensure!(
+            self.authenticator.authentication_key().as_ref()
+                == account_resource.authentication_key(),
+            "authenticator's public key do not match the account resource on chain"
+        );
+        Ok(())
+    }
+
+    pub fn to_hex(&self) -> String {
+        hex::encode(bcs_ext::to_bytes(self).expect("SignedMessage bcs serialize should success."))
+    }
+}
+
+impl FromStr for SignedMessage {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.strip_prefix("0x").unwrap_or(s);
+        let bytes = hex::decode(s)?;
+        bcs_ext::from_bytes(bytes.as_slice())
+    }
+}
+
+impl std::fmt::Display for SignedMessage {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "0x{}", self.to_hex())
     }
 }

--- a/vm/types/src/sign_message.rs
+++ b/vm/types/src/sign_message.rs
@@ -56,11 +56,18 @@ impl SignedMessage {
 
     /// Checks the account by on chain account resource, please ensure the AccountResource's address == message.account
     pub fn check_account(&self, account_resource: &AccountResource) -> Result<()> {
-        ensure!(
-            self.authenticator.authentication_key().as_ref()
-                == account_resource.authentication_key(),
-            "authenticator's public key do not match the account resource on chain"
-        );
+        let authkey = self.authenticator.authentication_key();
+        if authkey.is_dummy() {
+            ensure!(
+                authkey.derived_address() == self.account,
+                "authenticator's address do not match the signed message account"
+            )
+        } else {
+            ensure!(
+                authkey.as_ref() == account_resource.authentication_key(),
+                "authenticator's public key do not match the account resource on chain"
+            );
+        }
         Ok(())
     }
 

--- a/vm/types/src/transaction/authenticator.rs
+++ b/vm/types/src/transaction/authenticator.rs
@@ -3,7 +3,6 @@
 
 use crate::account_address::AccountAddress;
 use crate::sign_message::SigningMessage;
-use crate::transaction::{RawUserTransaction, SignedUserTransaction};
 use anyhow::{ensure, Error, Result};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
@@ -11,11 +10,8 @@ use rand::{rngs::OsRng, Rng};
 use serde::{Deserialize, Serialize};
 use starcoin_crypto::ed25519::{
     Ed25519PrivateKey, ED25519_PRIVATE_KEY_LENGTH, ED25519_PUBLIC_KEY_LENGTH,
-    ED25519_SIGNATURE_LENGTH,
 };
-use starcoin_crypto::multi_ed25519::multi_shard::{
-    MultiEd25519KeyShard, MultiEd25519SignatureShard,
-};
+use starcoin_crypto::multi_ed25519::multi_shard::MultiEd25519KeyShard;
 use starcoin_crypto::{
     derive::{DeserializeKey, SerializeKey},
     ed25519::{Ed25519PublicKey, Ed25519Signature},
@@ -57,7 +53,7 @@ impl fmt::Display for Scheme {
         write!(f, "Scheme::{}", display)
     }
 }
-
+//TODO should rename TransactionAuthenticator to Authenticator
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum TransactionAuthenticator {
     /// Single signature
@@ -146,6 +142,16 @@ impl TransactionAuthenticator {
     /// Return an authentication key derived from `self`'s public key and scheme id
     pub fn authentication_key(&self) -> AuthenticationKey {
         AuthenticationKey::from_preimage(&self.authentication_key_preimage())
+    }
+}
+
+impl FromStr for TransactionAuthenticator {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.strip_prefix("0x").unwrap_or(s);
+        let bytes = hex::decode(s)?;
+        bcs_ext::from_bytes(bytes.as_slice())
     }
 }
 
@@ -328,27 +334,6 @@ pub enum AccountPrivateKey {
     Multi(MultiEd25519KeyShard),
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, DeserializeKey, SerializeKey, Eq)]
-pub enum AccountSignature {
-    Single(Ed25519PublicKey, Ed25519Signature),
-    Multi(MultiEd25519PublicKey, MultiEd25519SignatureShard),
-}
-impl ValidCryptoMaterial for AccountSignature {
-    fn to_bytes(&self) -> Vec<u8> {
-        match self {
-            Self::Single(public_key, signature) => {
-                let mut bytes = public_key.to_bytes().to_vec();
-                bytes.extend(signature.to_bytes().to_vec());
-                bytes
-            }
-            Self::Multi(multi_key, multi_signed_shard) => {
-                let mut bytes = multi_key.to_bytes().to_vec();
-                bytes.extend(multi_signed_shard.to_bytes().to_vec());
-                bytes
-            }
-        }
-    }
-}
 impl ValidCryptoMaterial for AccountPublicKey {
     fn to_bytes(&self) -> Vec<u8> {
         match self {
@@ -460,15 +445,19 @@ impl AccountPrivateKey {
         }
     }
 
-    pub fn sign<T: CryptoHash + Serialize>(&self, message: &T) -> AccountSignature {
+    pub fn sign<T: CryptoHash + Serialize>(&self, message: &T) -> TransactionAuthenticator {
         match self {
-            Self::Single(key) => AccountSignature::Single(key.public_key(), key.sign(message)),
-            Self::Multi(key) => AccountSignature::Multi(key.public_key(), key.sign(message)),
+            Self::Single(key) => {
+                TransactionAuthenticator::ed25519(key.public_key(), key.sign(message))
+            }
+            Self::Multi(key) => {
+                TransactionAuthenticator::multi_ed25519(key.public_key(), key.sign(message).into())
+            }
         }
     }
 
-    pub fn sign_message(&self, message: SigningMessage) -> AccountSignature {
-        self.sign(&message)
+    pub fn sign_message(&self, message: &SigningMessage) -> TransactionAuthenticator {
+        self.sign(message)
     }
 }
 
@@ -494,52 +483,6 @@ impl TryFrom<&[u8]> for AccountPrivateKey {
             Ed25519PrivateKey::try_from(value).map(Self::Single)
         } else {
             MultiEd25519KeyShard::try_from(value).map(Self::Multi)
-        }
-    }
-}
-
-impl TryFrom<&[u8]> for AccountSignature {
-    type Error = CryptoMaterialError;
-
-    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        let length = value.len();
-        if length == ED25519_PUBLIC_KEY_LENGTH + ED25519_SIGNATURE_LENGTH {
-            let public_key = Ed25519PublicKey::try_from(&value[..ED25519_PUBLIC_KEY_LENGTH])?;
-            let signature = Ed25519Signature::try_from(&value[ED25519_PUBLIC_KEY_LENGTH..])?;
-            Ok(Self::Single(public_key, signature))
-        } else {
-            // 1 is MultiEd25519PublicKey's threshold
-            // 4 is  MultiEd25519Signature's bitmap
-            // 1 is MultiEd25519SignatureShard's threshold
-            let key_size =
-                (length - 1 - 4 - 1) / (ED25519_PUBLIC_KEY_LENGTH + ED25519_SIGNATURE_LENGTH);
-            let key_len = key_size * ED25519_PUBLIC_KEY_LENGTH + 1;
-            let multi_public_key = MultiEd25519PublicKey::try_from(&value[..key_len])?;
-            let multi_signature = MultiEd25519Signature::try_from(&value[key_len..length - 1])?;
-            Ok(Self::Multi(
-                multi_public_key,
-                MultiEd25519SignatureShard::new(multi_signature, value[length]),
-            ))
-        }
-    }
-}
-
-impl AccountSignature {
-    pub fn build_transaction(self, raw_txn: RawUserTransaction) -> Result<SignedUserTransaction> {
-        Ok(match self {
-            Self::Single(public_key, signature) => {
-                SignedUserTransaction::ed25519(raw_txn, public_key, signature)
-            }
-            Self::Multi(public_key, signature) => {
-                SignedUserTransaction::multi_ed25519(raw_txn, public_key, signature.into())
-            }
-        })
-    }
-
-    pub fn verify<T: Serialize + CryptoHash>(&self, message: &T) -> Result<()> {
-        match self {
-            Self::Single(public_key, signature) => signature.verify(message, public_key),
-            Self::Multi(public_key, signature) => signature.verify(message, public_key),
         }
     }
 }

--- a/vm/types/src/transaction/authenticator.rs
+++ b/vm/types/src/transaction/authenticator.rs
@@ -182,6 +182,8 @@ impl AuthenticationKey {
     /// The number of bytes in an authentication key.
     pub const LENGTH: usize = 32;
 
+    pub const DUMMY_KEY: [u8; AuthenticationKey::LENGTH] = [0; AuthenticationKey::LENGTH];
+
     /// Create an authentication key from a preimage by taking its sha3 hash
     pub fn from_preimage(preimage: &AuthenticationKeyPreimage) -> AuthenticationKey {
         AuthenticationKey::new(*HashValue::sha3_256_of(&preimage.0).as_ref())
@@ -223,6 +225,11 @@ impl AuthenticationKey {
         let mut rng = OsRng;
         let buf: [u8; Self::LENGTH] = rng.gen();
         AuthenticationKey::new(buf)
+    }
+
+    /// Check the auth key is dummy empty key
+    pub fn is_dummy(&self) -> bool {
+        self.0 == Self::DUMMY_KEY
     }
 }
 


### PR DESCRIPTION
1. 废弃 AccountSignature， 用 TransactionAuthenticator 替代。
2. 定义 SignedMessage， 包含 SigningMessage 以及签名的账号地址。
3. 通过链上数据校验账号和公钥之间的关系。