### PR TITLE
[cli] dev deploy/upgrade_module commands's file option supports mv and package file

### DIFF
--- a/cmd/starcoin/src/dev/deploy_cmd.rs
+++ b/cmd/starcoin/src/dev/deploy_cmd.rs
@@ -2,15 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::cli_state::CliState;
+use crate::dev::dev_helper;
 use crate::view::{ExecuteResultView, TransactionOptions};
 use crate::StarcoinOpt;
 use anyhow::{ensure, Result};
 use scmd::{CommandAction, ExecContext};
-use starcoin_move_compiler::MOVE_COMPILED_EXTENSION;
-use starcoin_types::transaction::{Module, Package};
 use starcoin_vm_types::transaction::TransactionPayload;
-use std::fs::File;
-use std::io::Read;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -21,10 +18,8 @@ pub struct DeployOpt {
     #[structopt(flatten)]
     transaction_opts: TransactionOptions,
 
-    #[structopt(
-        name = "mv-or-package-file",
-        help = "move bytecode file path or package binary path"
-    )]
+    #[structopt(name = "mv-or-package-file")]
+    /// move bytecode file path or package binary path
     mv_or_package_file: PathBuf,
 }
 
@@ -41,22 +36,8 @@ impl CommandAction for DeployCommand {
         ctx: &ExecContext<Self::State, Self::GlobalOpt, Self::Opt>,
     ) -> Result<Self::ReturnItem> {
         let opt = ctx.opt();
-        let mv_or_package_file = ctx.opt().mv_or_package_file.as_path();
-        ensure!(
-            mv_or_package_file.exists(),
-            "file {:?} not exist",
-            mv_or_package_file
-        );
 
-        let mut bytes = vec![];
-        File::open(mv_or_package_file)?.read_to_end(&mut bytes)?;
-
-        let package =
-            if mv_or_package_file.extension().unwrap_or_default() == MOVE_COMPILED_EXTENSION {
-                Package::new_with_module(Module::new(bytes))?
-            } else {
-                bcs_ext::from_bytes(&bytes)?
-            };
+        let package = dev_helper::load_package_from_file(opt.mv_or_package_file.as_path())?;
 
         let package_address = package.package_address();
         let mut transaction_opts = opt.transaction_opts.clone();

--- a/cmd/starcoin/src/dev/dev_helper.rs
+++ b/cmd/starcoin/src/dev/dev_helper.rs
@@ -1,0 +1,32 @@
+// Copyright (c) The Starcoin Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{ensure, format_err, Result};
+use starcoin_move_compiler::MOVE_COMPILED_EXTENSION;
+use starcoin_vm_types::transaction::{Module, Package};
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+pub fn load_package_from_file(mv_or_package_file: &Path) -> Result<Package> {
+    ensure!(
+        mv_or_package_file.exists(),
+        "file {:?} not exist",
+        mv_or_package_file
+    );
+
+    let mut bytes = vec![];
+    File::open(mv_or_package_file)?.read_to_end(&mut bytes)?;
+
+    let package = if mv_or_package_file.extension().unwrap_or_default() == MOVE_COMPILED_EXTENSION {
+        Package::new_with_module(Module::new(bytes))?
+    } else {
+        bcs_ext::from_bytes(&bytes).map_err(|e| {
+            format_err!(
+                "Decode Package failed {:?}, please ensure the file is a Package binary file.",
+                e
+            )
+        })?
+    };
+    Ok(package)
+}

--- a/cmd/starcoin/src/dev/mod.rs
+++ b/cmd/starcoin/src/dev/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod call_api_cmd;
 mod call_contract_cmd;
 mod compile_cmd;
 mod deploy_cmd;
+pub(crate) mod dev_helper;
 pub(crate) mod gen_block_cmd;
 mod get_coin_cmd;
 pub(crate) mod log_cmd;

--- a/cmd/starcoin/src/dev/tests.rs
+++ b/cmd/starcoin/src/dev/tests.rs
@@ -18,6 +18,7 @@ use starcoin_vm_types::account_address::AccountAddress;
 use starcoin_vm_types::account_config::core_code_address;
 use starcoin_vm_types::identifier::Identifier;
 use starcoin_vm_types::language_storage::ModuleId;
+use starcoin_vm_types::token::stc::STC_TOKEN_CODE;
 use starcoin_vm_types::transaction::{
     RawUserTransaction, SignedUserTransaction, TransactionPayload,
 };
@@ -27,6 +28,7 @@ use starcoin_vm_types::{
     transaction::Package,
 };
 use starcoin_vm_types::{language_storage::TypeTag, parser::parse_type_tag};
+use std::convert::TryInto;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::{thread::sleep, time::Duration};
@@ -226,6 +228,7 @@ fn test_upgrade_module() {
         2,
         dao_config.min_action_delay,
         false,
+        STC_TOKEN_CODE.clone(),
         config.net().stdlib_version(),
     );
 
@@ -267,9 +270,8 @@ fn test_upgrade_module() {
     // 3. vote
     let proposal_id = 0;
     let mut type_tags: Vec<TypeTag> = Vec::new();
-    let stc = parse_type_tag("0x1::STC::STC").unwrap();
     let module = parse_type_tag("0x1::UpgradeModuleDaoProposal::UpgradeModuleV2").unwrap();
-    type_tags.push(stc);
+    type_tags.push(STC_TOKEN_CODE.clone().try_into().unwrap());
     type_tags.push(module);
     let mut args: Vec<TransactionArgument> = Vec::new();
     let arg_1 = parse_transaction_argument("0x0000000000000000000000000a550c18").unwrap();
@@ -324,6 +326,7 @@ fn test_upgrade_module() {
     let module_upgrade_queue = build_module_upgrade_queue(
         association_address(),
         proposal_id,
+        STC_TOKEN_CODE.clone(),
         config.net().stdlib_version(),
     );
     let queue_txn = sign_txn_with_account_by_rpc_client(

--- a/cmd/starcoin/src/dev/upgrade_module_exe_cmd.rs
+++ b/cmd/starcoin/src/dev/upgrade_module_exe_cmd.rs
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::cli_state::CliState;
+use crate::dev::dev_helper;
 use crate::view::{ExecuteResultView, TransactionOptions};
 use crate::StarcoinOpt;
 use anyhow::Result;
 use scmd::{CommandAction, ExecContext};
 use starcoin_vm_types::transaction::TransactionPayload;
-use std::fs::File;
-use std::io::Read;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -21,12 +20,12 @@ pub struct UpgradeModuleExeOpt {
 
     #[structopt(
         short = "m",
-        name = "module-package-file",
-        long = "module",
-        help = "path for module package file.",
+        name = "mv-or-package-file",
+        long = "mv-or-package-file",
         parse(from_os_str)
     )]
-    module_package_file: PathBuf,
+    /// path for module or package file.
+    mv_or_package_file: PathBuf,
 }
 
 pub struct UpgradeModuleExeCommand;
@@ -42,9 +41,8 @@ impl CommandAction for UpgradeModuleExeCommand {
         ctx: &ExecContext<Self::State, Self::GlobalOpt, Self::Opt>,
     ) -> Result<Self::ReturnItem> {
         let opt = ctx.opt();
-        let mut bytes = vec![];
-        File::open(opt.module_package_file.as_path())?.read_to_end(&mut bytes)?;
-        let upgrade_package = bcs_ext::from_bytes(&bytes)?;
+        let upgrade_package = dev_helper::load_package_from_file(opt.mv_or_package_file.as_path())?;
+
         ctx.state().build_and_execute_transaction(
             opt.transaction_opts.clone(),
             TransactionPayload::Package(upgrade_package),

--- a/cmd/starcoin/src/dev/upgrade_module_proposal_cmd.rs
+++ b/cmd/starcoin/src/dev/upgrade_module_proposal_cmd.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::cli_state::CliState;
+use crate::dev::dev_helper;
 use crate::dev::sign_txn_helper::get_dao_config;
 use crate::view::{ExecuteResultView, TransactionOptions};
 use crate::StarcoinOpt;
@@ -10,12 +11,9 @@ use scmd::{CommandAction, ExecContext};
 use starcoin_rpc_client::RemoteStateReader;
 use starcoin_state_api::StateReaderExt;
 use starcoin_transaction_builder::build_module_upgrade_proposal;
-use starcoin_types::transaction::Package;
 use starcoin_vm_types::genesis_config::StdlibVersion;
 use starcoin_vm_types::on_chain_config::Version;
 use starcoin_vm_types::transaction::TransactionPayload;
-use std::fs::File;
-use std::io::Read;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -26,29 +24,21 @@ pub struct UpgradeModuleProposalOpt {
     #[structopt(flatten)]
     transaction_opts: TransactionOptions,
 
-    #[structopt(
-        short = "e",
-        name = "enforced",
-        long = "enforced",
-        help = "enforced upgrade regardless of compatible or not"
-    )]
+    #[structopt(short = "e", name = "enforced", long = "enforced")]
+    /// enforced upgrade regardless of compatible or not
     enforced: bool,
 
     #[structopt(
         short = "m",
-        name = "module-package-file",
-        long = "module",
-        help = "path for module package file.",
+        name = "mv-or-package-file",
+        long = "mv-or-package-file",
         parse(from_os_str)
     )]
-    module_package_file: PathBuf,
+    /// path for module or package file.
+    mv_or_package_file: PathBuf,
 
-    #[structopt(
-        short = "v",
-        name = "module-version",
-        long = "module_version",
-        help = "new version number for the module"
-    )]
+    #[structopt(short = "v", name = "module-version", long = "module-version")]
+    /// new version number for the modules
     version: u64,
 }
 
@@ -68,10 +58,7 @@ impl CommandAction for UpgradeModuleProposalCommand {
         let cli_state = ctx.state();
 
         let module_version = opt.version;
-        let module_file = opt.module_package_file.as_path();
-        let mut bytes = vec![];
-        File::open(module_file)?.read_to_end(&mut bytes)?;
-        let upgrade_package: Package = bcs_ext::from_bytes(&bytes)?;
+        let upgrade_package = dev_helper::load_package_from_file(opt.mv_or_package_file.as_path())?;
         eprintln!(
             "upgrade package address : {:?}",
             upgrade_package.package_address()

--- a/cmd/starcoin/src/dev/upgrade_module_queue_cmd.rs
+++ b/cmd/starcoin/src/dev/upgrade_module_queue_cmd.rs
@@ -12,6 +12,7 @@ use starcoin_transaction_builder::build_module_upgrade_queue;
 use starcoin_vm_types::account_address::AccountAddress;
 use starcoin_vm_types::genesis_config::StdlibVersion;
 use starcoin_vm_types::on_chain_config::Version;
+use starcoin_vm_types::token::token_code::TokenCode;
 use starcoin_vm_types::transaction::TransactionPayload;
 use structopt::StructOpt;
 
@@ -33,6 +34,14 @@ pub struct UpgradeModuleQueueOpt {
         help = "proposal id."
     )]
     proposal_id: u64,
+
+    #[structopt(
+        name = "dao-token",
+        long = "dao-token",
+        default_value = "0x1::STC::STC"
+    )]
+    /// The token for dao governance, default is 0x1::STC::STC
+    dao_token: TokenCode,
 }
 
 pub struct UpgradeModuleQueueCommand;
@@ -65,6 +74,7 @@ impl CommandAction for UpgradeModuleQueueCommand {
         let module_upgrade_queue = build_module_upgrade_queue(
             proposer_address,
             opt.proposal_id,
+            opt.dao_token.clone(),
             StdlibVersion::new(stdlib_version),
         );
         ctx.state().build_and_execute_transaction(

--- a/cmd/starcoin/src/view.rs
+++ b/cmd/starcoin/src/view.rs
@@ -39,9 +39,9 @@ pub struct TransactionOptions {
 
     #[structopt(
         short = "p",
-        long = "gas_unit_price",
+        long = "gas-unit-price",
         alias = "gas-price",
-        name = "price of gas"
+        name = "price of gas unit"
     )]
     /// gas price used to deploy the module
     pub gas_unit_price: Option<u64>,

--- a/vm/transaction-builder/src/lib.rs
+++ b/vm/transaction-builder/src/lib.rs
@@ -685,6 +685,7 @@ pub fn build_module_upgrade_proposal(
     version: u64,
     exec_delay: u64,
     enforced: bool,
+    token_code: TokenCode,
     stdlib_version: StdlibVersion,
 ) -> (ScriptFunction, HashValue) {
     let package_hash = package.crypto_hash();
@@ -719,7 +720,9 @@ pub fn build_module_upgrade_proposal(
                 Identifier::new("ModuleUpgradeScripts").unwrap(),
             ),
             Identifier::new(function_name).unwrap(),
-            vec![stc_type_tag()],
+            vec![token_code
+                .try_into()
+                .expect("Token code to type tag should success")],
             args,
         ),
         package_hash,
@@ -747,6 +750,7 @@ pub fn build_module_upgrade_plan(
 pub fn build_module_upgrade_queue(
     proposal_address: AccountAddress,
     proposal_id: u64,
+    token_code: TokenCode,
     stdlib_version: StdlibVersion,
 ) -> ScriptFunction {
     let upgrade_module = if stdlib_version >= StdlibVersion::Version(2) {
@@ -768,7 +772,12 @@ pub fn build_module_upgrade_queue(
     ScriptFunction::new(
         ModuleId::new(core_code_address(), Identifier::new("Dao").unwrap()),
         Identifier::new("queue_proposal_action").unwrap(),
-        vec![stc_type_tag(), upgrade_module],
+        vec![
+            token_code
+                .try_into()
+                .expect("Token code to type tag should success"),
+            upgrade_module,
+        ],
         vec![
             bcs_ext::to_bytes(&proposal_address).unwrap(),
             bcs_ext::to_bytes(&proposal_id).unwrap(),

--- a/vm/types/src/token/token_code.rs
+++ b/vm/types/src/token/token_code.rs
@@ -90,6 +90,14 @@ impl TryInto<StructTag> for TokenCode {
     }
 }
 
+impl TryInto<TypeTag> for TokenCode {
+    type Error = anyhow::Error;
+
+    fn try_into(self) -> Result<TypeTag, Self::Error> {
+        Ok(TypeTag::Struct(self.try_into()?))
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::language_storage::{StructTag, TypeTag};


### PR DESCRIPTION
1. 统一 dev 和部署相关的命令参数，兼容 mv 和 package 文件
2. 给 `dev module-proposal` 和 `dev module-queue` 增加 token code 参数，支持第三方 Token 通过治理升级合约。fix #2707 