### PR TITLE
[abi] Fix resolve new module by code self dependency bug.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7960,6 +7960,7 @@ dependencies = [
  "starcoin-resource-viewer",
  "starcoin-vm-types",
  "stdlib",
+ "test-helper",
 ]
 
 [[package]]

--- a/abi/resolver/Cargo.toml
+++ b/abi/resolver/Cargo.toml
@@ -15,3 +15,4 @@ starcoin-resource-viewer = {path = "../../vm/resource-viewer"}
 [dev-dependencies]
 stdlib = {path = "../../vm/stdlib"}
 serde_json = "1"
+test-helper= {path = "../../test-helper"}

--- a/vm/resource-viewer/src/resolver.rs
+++ b/vm/resource-viewer/src/resolver.rs
@@ -39,6 +39,10 @@ impl<'a> Resolver<'a> {
         Resolver { state, cache }
     }
 
+    pub fn update_cache(&self, module: CompiledModule) {
+        self.cache.insert(module.self_id(), module);
+    }
+
     pub fn get_module(
         &self,
         address: &AccountAddress,


### PR DESCRIPTION
修复一个 resolve 链上不存在的 module 时的 bug，该 module 需要预先放入 module cache，否则 module 中的类型引用当前 module 的其他类型时，resolve 会报错。