### PR TITLE
implement node reset

### DIFF
--- a/chain/api/src/chain.rs
+++ b/chain/api/src/chain.rs
@@ -23,7 +23,8 @@ pub type MintedUncleNumber = u64;
 pub trait ChainReader {
     fn info(&self) -> ChainInfo;
     fn status(&self) -> ChainStatus;
-    fn head_block(&self) -> Block;
+    /// Get latest block with block_info
+    fn head_block(&self) -> ExecutedBlock;
     fn current_header(&self) -> BlockHeader;
     fn get_header(&self, hash: HashValue) -> Result<Option<BlockHeader>>;
     fn get_header_by_number(&self, number: BlockNumber) -> Result<Option<BlockHeader>>;

--- a/chain/service/src/chain_service.rs
+++ b/chain/service/src/chain_service.rs
@@ -361,7 +361,7 @@ impl ReadableChainService for ChainReaderServiceInner {
     }
 
     fn main_head_block(&self) -> Block {
-        self.main.head_block()
+        self.main.head_block().block
     }
 
     fn main_block_by_number(&self, number: BlockNumber) -> Result<Option<Block>> {

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -169,7 +169,7 @@ impl BlockChain {
     fn epoch_uncles(&self) -> Result<HashMap<HashValue, MintedUncleNumber>> {
         let epoch = &self.epoch;
         let mut uncles: HashMap<HashValue, MintedUncleNumber> = HashMap::new();
-        let head_block = self.head_block();
+        let head_block = self.head_block().block;
         let head_number = head_block.header().number();
         debug_assert!(
             head_number >= epoch.start_block_number() && head_number < epoch.end_block_number(),
@@ -518,8 +518,8 @@ impl ChainReader for BlockChain {
         self.status.status.clone()
     }
 
-    fn head_block(&self) -> Block {
-        self.status.head.clone()
+    fn head_block(&self) -> ExecutedBlock {
+        ExecutedBlock::new(self.status.head.clone(), self.status.status.info.clone())
     }
 
     fn current_header(&self) -> BlockHeader {

--- a/chain/tests/test_block_chain.rs
+++ b/chain/tests/test_block_chain.rs
@@ -211,10 +211,11 @@ fn test_uncle() {
     uncles.push(uncle_block_header.clone());
     let block = product_a_block(mock_chain.head(), miner, uncles);
     mock_chain.apply(block).unwrap();
-    assert!(mock_chain.head().head_block().uncles().is_some());
+    assert!(mock_chain.head().head_block().block.uncles().is_some());
     assert!(mock_chain
         .head()
         .head_block()
+        .block
         .uncles()
         .unwrap()
         .contains(&uncle_block_header));
@@ -231,10 +232,11 @@ fn test_uncle_exist() {
     uncles.push(uncle_block_header.clone());
     let block = product_a_block(mock_chain.head(), &miner, uncles);
     mock_chain.apply(block).unwrap();
-    assert!(mock_chain.head().head_block().uncles().is_some());
+    assert!(mock_chain.head().head_block().block.uncles().is_some());
     assert!(mock_chain
         .head()
         .head_block()
+        .block
         .uncles()
         .unwrap()
         .contains(&uncle_block_header));
@@ -290,10 +292,12 @@ fn test_switch_epoch() {
     uncles.push(uncle_block_header.clone());
     let block = product_a_block(mock_chain.head(), &miner, uncles);
     mock_chain.apply(block).unwrap();
-    assert!(mock_chain.head().head_block().uncles().is_some());
+    assert!(mock_chain.head().head_block().block.uncles().is_some());
     assert!(mock_chain
         .head()
         .head_block()
+        .block
+        .block
         .uncles()
         .unwrap()
         .contains(&uncle_block_header));
@@ -314,7 +318,7 @@ fn test_switch_epoch() {
     // 5. switch epoch
     let block = product_a_block(mock_chain.head(), &miner, Vec::new());
     mock_chain.apply(block).unwrap();
-    assert!(mock_chain.head().head_block().uncles().is_none());
+    assert!(mock_chain.head().head_block().block.uncles().is_none());
     assert_eq!(mock_chain.head().current_epoch_uncles_size(), 0);
 }
 
@@ -340,7 +344,7 @@ fn test_uncle_in_diff_epoch() {
     // 4. switch epoch
     let block = product_a_block(mock_chain.head(), &miner, Vec::new());
     mock_chain.apply(block).unwrap();
-    assert!(mock_chain.head().head_block().uncles().is_none());
+    assert!(mock_chain.head().head_block().block.uncles().is_none());
     assert_eq!(mock_chain.head().current_epoch_uncles_size(), 0);
 
     // 5. mock chain apply

--- a/chain/tests/test_block_chain.rs
+++ b/chain/tests/test_block_chain.rs
@@ -297,7 +297,6 @@ fn test_switch_epoch() {
         .head()
         .head_block()
         .block
-        .block
         .uncles()
         .unwrap()
         .contains(&uncle_block_header));

--- a/cmd/starcoin/src/node/reset_cmd.rs
+++ b/cmd/starcoin/src/node/reset_cmd.rs
@@ -8,6 +8,8 @@ use scmd::{CommandAction, ExecContext};
 use starcoin_crypto::HashValue;
 use structopt::StructOpt;
 
+/// Reset the node chain to block of `block-hash`, and clean all blocks after the block.
+/// Note: this command may broken the block database in node.
 #[derive(Debug, StructOpt)]
 #[structopt(name = "reset")]
 pub struct ResetOpt {

--- a/node/api/src/message.rs
+++ b/node/api/src/message.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use futures::channel::oneshot::Receiver;
 use starcoin_crypto::HashValue;
 use starcoin_service_registry::{ServiceInfo, ServiceRequest, ServiceStatus};
 
@@ -22,6 +23,7 @@ pub enum NodeRequest {
 pub enum NodeResponse {
     Services(Vec<ServiceInfo>),
     Result(Result<()>),
+    AsyncResult(Receiver<Result<()>>),
     ServiceStatus(ServiceStatus),
 }
 

--- a/node/api/src/node_service.rs
+++ b/node/api/src/node_service.rs
@@ -95,7 +95,10 @@ where
         Ok(())
     }
     async fn reset_node(&self, block_id: HashValue) -> Result<()> {
-        self.try_send(NodeRequest::ResetNode(block_id))?;
+        let response = self.send(NodeRequest::ResetNode(block_id)).await??;
+        if let NodeResponse::AsyncResult(receiver) = response {
+            return receiver.await?;
+        }
         Ok(())
     }
     async fn delete_block(&self, block_id: HashValue) -> Result<()> {

--- a/rpc/api/src/node_manager.rs
+++ b/rpc/api/src/node_manager.rs
@@ -24,7 +24,7 @@ pub trait NodeManagerApi {
     #[rpc(name = "node_manager.shutdown_system")]
     fn shutdown_system(&self) -> FutureResult<()>;
     #[rpc(name = "node_manager.reset_to_block")]
-    fn reset_to_block(&self, block_number: HashValue) -> FutureResult<()>;
+    fn reset_to_block(&self, block_hash: HashValue) -> FutureResult<()>;
 
     // /// Delete block data in [start_number, end_number)
     // #[rpc(name = "node_manager.delete_block_range")]

--- a/sync/src/block_connector/block_connector_service.rs
+++ b/sync/src/block_connector/block_connector_service.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::block_connector::WriteBlockChainService;
+use crate::block_connector::{ResetRequest, WriteBlockChainService};
 use crate::sync::{CheckSyncEvent, SyncService};
 use crate::tasks::BlockConnectedEvent;
 use anyhow::{format_err, Result};
@@ -10,7 +10,9 @@ use logger::prelude::*;
 use network::NetworkServiceRef;
 use network_api::PeerProvider;
 use starcoin_chain_api::{ConnectBlockError, WriteableChainService};
-use starcoin_service_registry::{ActorService, EventHandler, ServiceContext, ServiceFactory};
+use starcoin_service_registry::{
+    ActorService, EventHandler, ServiceContext, ServiceFactory, ServiceHandler,
+};
 use starcoin_storage::{BlockStore, Storage};
 use starcoin_sync_api::PeerNewBlock;
 use starcoin_types::sync_status::SyncStatus;
@@ -162,5 +164,15 @@ impl EventHandler<Self, PeerNewBlock> for BlockConnectorService {
                 Err(e) => warn!("BlockConnector fail: {:?}, peer_id:{:?}", e, peer_id),
             }
         }
+    }
+}
+
+impl ServiceHandler<Self, ResetRequest> for BlockConnectorService {
+    fn handle(
+        &mut self,
+        msg: ResetRequest,
+        _ctx: &mut ServiceContext<BlockConnectorService>,
+    ) -> Result<()> {
+        self.chain_service.reset(msg.block_hash)
     }
 }

--- a/sync/src/block_connector/mod.rs
+++ b/sync/src/block_connector/mod.rs
@@ -1,6 +1,9 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use starcoin_crypto::HashValue;
+use starcoin_service_registry::ServiceRequest;
+
 mod block_connector_service;
 mod metrics;
 #[cfg(test)]
@@ -18,3 +21,12 @@ pub use test_write_block_chain::create_writeable_block_chain;
 pub use test_write_block_chain::gen_blocks;
 #[cfg(test)]
 pub use test_write_block_chain::new_block;
+
+#[derive(Debug, Clone)]
+pub struct ResetRequest {
+    pub block_hash: HashValue,
+}
+
+impl ServiceRequest for ResetRequest {
+    type Response = anyhow::Result<()>;
+}

--- a/sync/src/block_connector/write_block_chain.rs
+++ b/sync/src/block_connector/write_block_chain.rs
@@ -106,22 +106,18 @@ where
     }
 
     pub fn select_head(&mut self, new_branch: BlockChain) -> Result<()> {
-        let block = new_branch.head_block();
+        let executed_block = new_branch.head_block();
         let block_header = block.header().clone();
         let main_total_difficulty = self.main.get_total_difficulty()?;
         let branch_total_difficulty = new_branch.get_total_difficulty()?;
         let parent_is_main_head = self.is_main_head(&block_header.parent_hash());
-        //TODO refactor this.
-        let block_info = new_branch
-            .get_block_info(Some(block.id()))?
-            .expect("head block's block info should exist.");
-        let executed_block = ExecutedBlock::new(block.clone(), block_info);
+
         if branch_total_difficulty > main_total_difficulty {
             let (enacted_count, enacted_blocks, retracted_count, retracted_blocks) =
                 if !parent_is_main_head {
                     self.find_ancestors_from_accumulator(&new_branch)?
                 } else {
-                    (1, vec![block], 0, vec![])
+                    (1, vec![executed_block.block.clone()], 0, vec![])
                 };
             self.main = new_branch;
 

--- a/types/src/startup_info.rs
+++ b/types/src/startup_info.rs
@@ -161,8 +161,8 @@ impl StartupInfo {
         Self { main }
     }
 
-    pub fn update_main(&mut self, new_block_header: &BlockHeader) {
-        self.main = new_block_header.id();
+    pub fn update_main(&mut self, new_head: HashValue) {
+        self.main = new_head;
     }
 
     pub fn get_main(&self) -> &HashValue {


### PR DESCRIPTION
重新实现了 node reset 命令，用于将当前节点的区块重置到某个历史高度，然后重新执行。执行命令后无需重启节点。
 用于修复数据以及故障处理。