### PR TITLE
[block-relayer] Verify block body when construct block by compact block.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8114,6 +8114,8 @@ dependencies = [
  "hex",
  "network-api",
  "once_cell",
+ "starcoin-chain",
+ "starcoin-chain-api",
  "starcoin-config",
  "starcoin-crypto",
  "starcoin-logger",

--- a/block-relayer/Cargo.toml
+++ b/block-relayer/Cargo.toml
@@ -13,6 +13,8 @@ config = {path = "../config", package="starcoin-config"}
 crypto = { package="starcoin-crypto", path = "../commons/crypto"}
 logger = {path = "../commons/logger",package="starcoin-logger"}
 async-trait = "0.1"
+starcoin-chain-api = {path="../chain/api"}
+starcoin-chain = {path="../chain"}
 starcoin-txpool-api = { path = "../txpool/api" }
 starcoin-txpool = { path = "../txpool" }
 network-api = { package = "network-api", path = "../network/api" }

--- a/cmd/starcoin/src/node/manager/mod.rs
+++ b/cmd/starcoin/src/node/manager/mod.rs
@@ -31,6 +31,11 @@ pub enum NodeManagerOpt {
         #[structopt(name = "block-hash")]
         block_hash: HashValue,
     },
+    /// Delete the failed block record from database.
+    DeleteFailedBlock {
+        #[structopt(name = "block-hash")]
+        block_hash: HashValue,
+    },
 }
 
 pub struct NodeManagerCommand;
@@ -56,6 +61,9 @@ impl CommandAction for NodeManagerCommand {
             }
             NodeManagerOpt::Reset { block_hash } => {
                 client.node_reset(*block_hash)?;
+            }
+            NodeManagerOpt::DeleteFailedBlock { block_hash } => {
+                client.node_delete_failed_block(*block_hash)?;
             }
         }
 

--- a/network-p2p/src/protocol.rs
+++ b/network-p2p/src/protocol.rs
@@ -32,9 +32,9 @@ use std::time;
 /// Interval at which we perform time based maintenance
 const TICK_TIMEOUT: time::Duration = time::Duration::from_millis(1100);
 /// Current protocol version.
-pub(crate) const CURRENT_VERSION: u32 = 2;
+pub(crate) const CURRENT_VERSION: u32 = 3;
 /// Lowest version we support
-pub(crate) const MIN_VERSION: u32 = 1;
+pub(crate) const MIN_VERSION: u32 = 2;
 
 pub(crate) const HARD_CORE_PROTOCOL_ID: sc_peerset::SetId = sc_peerset::SetId::from(0);
 

--- a/node/api/src/message.rs
+++ b/node/api/src/message.rs
@@ -18,6 +18,7 @@ pub enum NodeRequest {
     ResetNode(HashValue),
     ReExecuteBlock(HashValue),
     DeleteBlock(HashValue),
+    DeleteFailedBlock(HashValue),
 }
 
 #[derive(Debug)]

--- a/node/api/src/node_service.rs
+++ b/node/api/src/node_service.rs
@@ -28,6 +28,7 @@ pub trait NodeAsyncService:
     async fn reset_node(&self, block_hash: HashValue) -> Result<()>;
     async fn re_execute_block(&self, block_hash: HashValue) -> Result<()>;
     async fn delete_block(&self, block_hash: HashValue) -> Result<()>;
+    async fn delete_failed_block(&self, block_hash: HashValue) -> Result<()>;
 }
 
 #[async_trait::async_trait]
@@ -114,6 +115,11 @@ where
 
     async fn delete_block(&self, block_hash: HashValue) -> Result<()> {
         self.try_send(NodeRequest::DeleteBlock(block_hash))?;
+        Ok(())
+    }
+
+    async fn delete_failed_block(&self, block_hash: HashValue) -> Result<()> {
+        self.try_send(NodeRequest::DeleteFailedBlock(block_hash))?;
         Ok(())
     }
 }

--- a/node/src/node.rs
+++ b/node/src/node.rs
@@ -182,6 +182,14 @@ impl ServiceHandler<Self, NodeRequest> for NodeService {
                         .and_then(|_| storage.delete_block(block_hash)),
                 )
             }
+            NodeRequest::DeleteFailedBlock(block_hash) => {
+                let storage = self
+                    .registry
+                    .get_shared_sync::<Arc<Storage>>()
+                    .expect("Storage must exist.");
+                info!("Prepare to delete failed block {:?}", block_hash);
+                NodeResponse::Result(storage.delete_failed_block(block_hash))
+            }
         })
     }
 }

--- a/rpc/api/src/node_manager.rs
+++ b/rpc/api/src/node_manager.rs
@@ -41,4 +41,8 @@ pub trait NodeManagerApi {
     /// Delete block of block_id
     #[rpc(name = "node_manager.delete_block")]
     fn delete_block(&self, block_hash: HashValue) -> FutureResult<()>;
+
+    /// Delete failed block of block_id from failed block database
+    #[rpc(name = "node_manager.delete_failed_block")]
+    fn delete_failed_block(&self, block_hash: HashValue) -> FutureResult<()>;
 }

--- a/rpc/client/src/lib.rs
+++ b/rpc/client/src/lib.rs
@@ -248,18 +248,27 @@ impl RpcClient {
         self.call_rpc_blocking(|inner| inner.node_manager_client.shutdown_system())
             .map_err(map_err)
     }
+
     pub fn node_reset(&self, block_hash: HashValue) -> anyhow::Result<()> {
         self.call_rpc_blocking(|inner| inner.node_manager_client.reset_to_block(block_hash))
             .map_err(map_err)
     }
+
     pub fn node_re_execute_block(&self, block_id: HashValue) -> anyhow::Result<()> {
         self.call_rpc_blocking(|inner| inner.node_manager_client.re_execute_block(block_id))
             .map_err(map_err)
     }
+
     pub fn node_delete_block(&self, block_id: HashValue) -> anyhow::Result<()> {
         self.call_rpc_blocking(|inner| inner.node_manager_client.delete_block(block_id))
             .map_err(map_err)
     }
+
+    pub fn node_delete_failed_block(&self, block_id: HashValue) -> anyhow::Result<()> {
+        self.call_rpc_blocking(|inner| inner.node_manager_client.delete_failed_block(block_id))
+            .map_err(map_err)
+    }
+
     pub fn next_sequence_number_in_txpool(
         &self,
         address: AccountAddress,

--- a/rpc/server/src/module/node_manager_rpc.rs
+++ b/rpc/server/src/module/node_manager_rpc.rs
@@ -105,4 +105,14 @@ where
         .map_err(map_err);
         Box::pin(fut.boxed())
     }
+
+    fn delete_failed_block(&self, block_id: HashValue) -> FutureResult<()> {
+        let service = self.service.clone();
+        let fut = async move {
+            service.delete_failed_block(block_id).await?;
+            Ok(())
+        }
+        .map_err(map_err);
+        Box::pin(fut.boxed())
+    }
 }

--- a/storage/src/block/mod.rs
+++ b/storage/src/block/mod.rs
@@ -245,6 +245,10 @@ impl BlockStorage {
             .put(block_id, (block, peer_id, failed).into())
     }
 
+    pub fn delete_failed_block(&self, block_id: HashValue) -> Result<()> {
+        self.failed_block_storage.remove(block_id)
+    }
+
     pub fn get_failed_block_by_id(
         &self,
         block_id: HashValue,

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -137,6 +137,8 @@ pub trait BlockStore {
         failed: String,
     ) -> Result<()>;
 
+    fn delete_failed_block(&self, block_id: HashValue) -> Result<()>;
+
     fn get_failed_block_by_id(
         &self,
         block_id: HashValue,
@@ -348,6 +350,10 @@ impl BlockStore for Storage {
     ) -> Result<()> {
         self.block_storage
             .save_failed_block(block_id, block, peer_id, failed)
+    }
+
+    fn delete_failed_block(&self, block_id: HashValue) -> Result<()> {
+        self.block_storage.delete_failed_block(block_id)
     }
 
     fn get_failed_block_by_id(

--- a/types/src/cmpact_block.rs
+++ b/types/src/cmpact_block.rs
@@ -39,6 +39,12 @@ impl CompactBlock {
             uncles: block.body.uncles,
         }
     }
+
+    pub fn txn_len(&self) -> usize {
+        self.short_ids
+            .len()
+            .saturating_add(self.prefilled_txn.len())
+    }
 }
 
 impl From<Block> for CompactBlock {


### PR DESCRIPTION
当前 fill_compact_block 中通过 short_id 组装 Block 时，如果从对方 peer 获取交易返回空，会导致组装出错误的区块。
所以

1. 增加验证，确保组装出正确的区块。
2. 将 p2p protocol 的 min version 改为 2，current version 改为 3， 拒绝 version 为 1 的节点（部分 barnard 网络的老节点）
3. 增加 `node manager delete-failed-block` 命令用户清理掉验证失败的区块。