### PR TITLE
[metrics] Rework on network metrics.

### DIFF
--- a/block-relayer/src/block_relayer.rs
+++ b/block-relayer/src/block_relayer.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::metrics::BLOCK_RELAYER_METRICS;
+use crate::metrics::BlockRelayerMetrics;
 use anyhow::{ensure, format_err, Result};
 use config::NodeConfig;
 use crypto::HashValue;
@@ -37,22 +37,33 @@ pub struct BlockRelayer {
     txpool: TxPoolService,
     sync_status: Option<SyncStatus>,
     time_service: Arc<dyn TimeService>,
+    metrics: Option<BlockRelayerMetrics>,
 }
 
 impl ServiceFactory<Self> for BlockRelayer {
     fn create(ctx: &mut ServiceContext<BlockRelayer>) -> Result<BlockRelayer> {
         let txpool = ctx.get_shared::<TxPoolService>()?;
-        let time_service = ctx.get_shared::<Arc<NodeConfig>>()?.net().time_service();
-        Ok(Self::new(txpool, time_service))
+        let node_config = ctx.get_shared::<Arc<NodeConfig>>()?;
+        let time_service = node_config.net().time_service();
+        let metrics = node_config
+            .metrics
+            .registry()
+            .and_then(|registry| BlockRelayerMetrics::register(registry).ok());
+        Ok(Self::new(txpool, time_service, metrics))
     }
 }
 
 impl BlockRelayer {
-    pub fn new(txpool: TxPoolService, time_service: Arc<dyn TimeService>) -> Self {
+    pub fn new(
+        txpool: TxPoolService,
+        time_service: Arc<dyn TimeService>,
+        metrics: Option<BlockRelayerMetrics>,
+    ) -> Self {
         Self {
             txpool,
             sync_status: None,
             time_service,
+            metrics,
         }
     }
 
@@ -85,25 +96,30 @@ impl BlockRelayer {
         rpc_client: VerifiedRpcClient,
         compact_block: CompactBlock,
         peer_id: PeerId,
+        metrics: Option<BlockRelayerMetrics>,
     ) -> Result<Block> {
         let expect_txn_len = compact_block.txn_len();
+        let mut filled_from_txpool: u64 = 0;
+        let mut filled_from_prefilled: u64 = 0;
+        let mut filled_from_network: u64 = 0;
+
         let txns = if expect_txn_len == 0 {
             vec![]
         } else {
             let mut txns: Vec<Option<SignedUserTransaction>> = vec![None; expect_txn_len];
-            BLOCK_RELAYER_METRICS
-                .block_txns_count
-                .set(expect_txn_len as u64);
+
             let mut missing_txn_short_ids = HashSet::new();
             // Fill the block txns by tx pool
             for (index, short_id) in compact_block.short_ids.iter().enumerate() {
                 if let Some(txn) = txpool.find_txn(&short_id.0) {
-                    BLOCK_RELAYER_METRICS.txns_filled_from_txpool.inc();
+                    filled_from_txpool += 1;
                     txns[index] = Some(txn);
                 } else {
                     missing_txn_short_ids.insert(short_id);
                 }
             }
+
+            //TODO move prefilled before txpool
 
             // Fill the block txns by prefilled txn
             for prefilled_txn in compact_block.prefilled_txn {
@@ -112,7 +128,7 @@ impl BlockRelayer {
                 }
                 let id = prefilled_txn.tx.id();
                 txns[prefilled_txn.index as usize] = Some(prefilled_txn.tx);
-                BLOCK_RELAYER_METRICS.txns_filled_from_prefill.inc();
+                filled_from_prefilled += 1;
                 missing_txn_short_ids.remove(&ShortId(id));
             }
             // Fetch the missing txns from peer
@@ -140,14 +156,8 @@ impl BlockRelayer {
             for (index, short_id) in compact_block.short_ids.iter().enumerate() {
                 if txns[index].is_none() {
                     if let Some(txn) = fetched_missing_txn_map.remove(short_id) {
-                        if txn.is_err() {
-                            BLOCK_RELAYER_METRICS
-                                .txns_filled_failed
-                                .with_label_values(&["miss"])
-                                .inc();
-                        }
                         txns[index] = Some(txn?);
-                        BLOCK_RELAYER_METRICS.txns_filled_from_network.inc();
+                        filled_from_network += 1;
                     }
                 }
             }
@@ -158,8 +168,28 @@ impl BlockRelayer {
                 collect_txns.len(),
                 expect_txn_len
             );
+
+            if let Some(metrics) = metrics {
+                metrics
+                    .txns_filled
+                    .with_label_values(&["expect"])
+                    .inc_by(expect_txn_len as u64);
+                metrics
+                    .txns_filled
+                    .with_label_values(&["txpool"])
+                    .inc_by(filled_from_txpool);
+                metrics
+                    .txns_filled
+                    .with_label_values(&["network"])
+                    .inc_by(filled_from_network);
+                metrics
+                    .txns_filled
+                    .with_label_values(&["prefilled"])
+                    .inc_by(filled_from_prefilled);
+            }
             collect_txns
         };
+
         let body = BlockBody::new(txns, compact_block.uncles);
         let block = Block::new(compact_block.header, body);
         //ensure the block is filled correct.
@@ -175,6 +205,7 @@ impl BlockRelayer {
         let network = ctx.get_shared::<NetworkServiceRef>()?;
         let block_connector_service = ctx.service_ref::<BlockConnectorService>()?.clone();
         let txpool = self.txpool.clone();
+        let metrics = self.metrics.clone();
         let fut = async move {
             let compact_block = compact_block_msg.message.compact_block;
             let peer_id = compact_block_msg.peer_id;
@@ -189,15 +220,18 @@ impl BlockRelayer {
                     .ok_or_else(|| format_err!("CompatBlockMessage's peer {} is not connected"))?;
                 let peer_selector = PeerSelector::new(vec![peer], PeerStrategy::default(), None);
                 let rpc_client = VerifiedRpcClient::new(peer_selector, network);
-                let timer = BLOCK_RELAYER_METRICS.txns_filled_time.start_timer();
+                let _timer = metrics
+                    .as_ref()
+                    .map(|metrics| metrics.txns_filled_time.start_timer());
                 let block = BlockRelayer::fill_compact_block(
                     txpool.clone(),
                     rpc_client,
                     compact_block,
                     peer_id.clone(),
+                    metrics,
                 )
                 .await?;
-                timer.observe_duration();
+
                 block_connector_service.notify(PeerNewBlock::new(peer_id, block))?;
             }
             Ok(())
@@ -276,21 +310,22 @@ impl EventHandler<Self, PeerCompactBlockMessage> for BlockRelayer {
         let block_timestamp = compact_block_msg.message.compact_block.header.timestamp();
         let current_timestamp = self.time_service.now_millis();
         let time = current_timestamp.saturating_sub(block_timestamp);
-        let time_sec = (time as f64) / 1000_f64;
-        BLOCK_RELAYER_METRICS.block_broadcast_time.observe(time_sec);
+        let time_sec: f64 = (time as f64) / 1000_f64;
+        if let Some(metrics) = self.metrics.as_ref() {
+            metrics.block_relay_time.observe(time_sec);
+        }
         sl_info!(
             "{action} {hash} {time_sec}",
             time_sec = time_sec,
             hash = compact_block_msg.message.compact_block.header.id().to_hex(),
-            action = "sync_broadcast_time",
+            action = "block_relay_time",
         );
         //TODO should filter too old block?
 
         if let Err(e) = self.handle_block_event(compact_block_msg, ctx) {
-            BLOCK_RELAYER_METRICS
-                .txns_filled_failed
-                .with_label_values(&["error"])
-                .inc();
+            if let Some(metrics) = self.metrics.as_ref() {
+                metrics.txns_filled_failed.inc();
+            }
             error!(
                 "[block-relay] handle PeerCompactBlockMessage error: {:?}",
                 e

--- a/block-relayer/src/metrics.rs
+++ b/block-relayer/src/metrics.rs
@@ -1,63 +1,66 @@
-use once_cell::sync::Lazy;
-use starcoin_metrics::{
-    default_registry, register_histogram, register_int_gauge, register_uint_gauge, Histogram,
-    IntGauge, Opts, PrometheusError, UIntCounterVec, UIntGauge,
-};
+// Copyright (c) The Starcoin Core Contributors
+// SPDX-License-Identifier: Apache-2.0
 
-pub static BLOCK_RELAYER_METRICS: Lazy<BlockRelayerMetrics> =
-    Lazy::new(|| BlockRelayerMetrics::register().expect("BlockRelayerMetrics register should ok."));
+use starcoin_metrics::{
+    register, Histogram, HistogramOpts, Opts, PrometheusError, Registry, UIntCounter,
+    UIntCounterVec,
+};
 
 #[derive(Clone)]
 pub struct BlockRelayerMetrics {
-    pub txns_filled_from_network: IntGauge,
-    pub txns_filled_from_txpool: IntGauge,
-    pub txns_filled_from_prefill: IntGauge,
+    pub txns_filled: UIntCounterVec,
     pub txns_filled_time: Histogram,
-    pub block_broadcast_time: Histogram,
-    pub txns_filled_failed: UIntCounterVec,
-    pub block_txns_count: UIntGauge,
+    pub block_relay_time: Histogram,
+    pub txns_filled_failed: UIntCounter,
 }
 
 impl BlockRelayerMetrics {
-    pub fn register() -> Result<Self, PrometheusError> {
-        let txns_filled_from_network = register_int_gauge!(Opts::new(
-            "txns_filled_from_network",
-            "Count of block filled transactions from network"
-        )
-        .namespace("starcoin"))?;
-        let txns_filled_from_txpool = register_int_gauge!(Opts::new(
-            "txns_filled_from_txpool",
-            "Count of block filled transactions from txpool"
-        )
-        .namespace("starcoin"))?;
-        let txns_filled_from_prefill = register_int_gauge!(Opts::new(
-            "txns_filled_from_prefill",
-            "Count of block filled transactions from prefill"
-        )
-        .namespace("starcoin"))?;
-        let txns_filled_time =
-            register_histogram!("starcoin_txns_filled_time", "txns filled time")?;
-        let block_broadcast_time = register_histogram!("block_broadcast", "block broadcast time.")?;
-
-        let txns_filled_failed = UIntCounterVec::new(
-            Opts::new(
-                "starcoin_txns_filled_failed",
-                "txns filled failed".to_string(),
-            )
-            .namespace("starcoin"),
-            &["type"],
+    pub fn register(registry: &Registry) -> Result<Self, PrometheusError> {
+        let txns_filled = register(
+            UIntCounterVec::new(
+                Opts::new(
+                    "txns_filled",
+                    "Count of block filled transactions from network|txpool|prefill",
+                )
+                .namespace("starcoin"),
+                &["source"],
+            )?,
+            registry,
         )?;
-        let broadcast_txns_count =
-            register_uint_gauge!("starcoin_broadcast_txns_count", "broadcast txns count.")?;
-        default_registry().register(Box::new(txns_filled_failed.clone()))?;
+
+        let txns_filled_time = register(
+            Histogram::with_opts(
+                HistogramOpts::new("txns_filled_time", "txns filled time").namespace("starcoin"),
+            )?,
+            registry,
+        )?;
+        let block_relay_time = register(
+            Histogram::with_opts(
+                HistogramOpts::new(
+                    "block_relay_time",
+                    "block relay time, measure the time usage in network",
+                )
+                .namespace("starcoin"),
+            )?,
+            registry,
+        )?;
+
+        let txns_filled_failed = register(
+            UIntCounter::with_opts(
+                Opts::new(
+                    "txns_filled_failed",
+                    "txns filled failed counter".to_string(),
+                )
+                .namespace("starcoin"),
+            )?,
+            registry,
+        )?;
+
         Ok(Self {
-            txns_filled_from_network,
-            txns_filled_from_txpool,
-            txns_filled_from_prefill,
+            txns_filled,
             txns_filled_time,
-            block_broadcast_time,
+            block_relay_time,
             txns_filled_failed,
-            block_txns_count: broadcast_txns_count,
         })
     }
 }

--- a/cmd/peer-watcher/src/lib.rs
+++ b/cmd/peer-watcher/src/lib.rs
@@ -22,5 +22,6 @@ pub fn build_lighting_network(
         chain_info,
         NotificationMessage::protocols(),
         None,
+        None,
     )
 }

--- a/network/src/service.rs
+++ b/network/src/service.rs
@@ -61,6 +61,7 @@ impl NetworkActorService {
             chain_info,
             config.network.supported_network_protocols(),
             rpc,
+            config.metrics.registry().cloned(),
         )?;
         let service = worker.service().clone();
         //let self_info = PeerInfo::new(config.network.self_peer_id(), chain_info);

--- a/network/src/worker.rs
+++ b/network/src/worker.rs
@@ -12,8 +12,8 @@ use network_p2p::{
     identity, NetworkConfiguration, NetworkWorker, NodeKeyConfig, Params, ProtocolId, Secret,
 };
 use network_p2p_types::{is_memory_addr, ProtocolRequest};
-use prometheus::default_registry;
 use starcoin_config::NetworkConfig;
+use starcoin_metrics::Registry;
 use starcoin_network_rpc::NetworkRpcService;
 use starcoin_service_registry::ServiceRef;
 use starcoin_types::peer_info::RpcInfo;
@@ -30,6 +30,7 @@ pub fn build_network_worker(
     chain_info: ChainInfo,
     protocols: Vec<Cow<'static, str>>,
     rpc_service: Option<(RpcInfo, ServiceRef<NetworkRpcService>)>,
+    metrics_registry: Option<Registry>,
 ) -> Result<(PeerInfo, NetworkWorker)> {
     let node_name = network_config.node_name();
     let discover_local = network_config.discover_local();
@@ -112,8 +113,7 @@ pub fn build_network_worker(
         config,
         protocol_id,
         chain_info,
-        //TODO use a custom registry for each instance.
-        Some(default_registry().clone()),
+        metrics_registry,
     ))?;
 
     Ok((self_info, worker))

--- a/network/tests/network_service_test.rs
+++ b/network/tests/network_service_test.rs
@@ -63,9 +63,14 @@ fn build_test_network_services(num: usize) -> Vec<NetworkComponent> {
         }
         let mut protocols = NotificationMessage::protocols();
         protocols.push(TEST_NOTIF_PROTOCOL_NAME.into());
-        let (_peer_info, worker) =
-            build_network_worker(&node_config.network, chain_info.clone(), protocols, None)
-                .unwrap();
+        let (_peer_info, worker) = build_network_worker(
+            &node_config.network,
+            chain_info.clone(),
+            protocols,
+            None,
+            None,
+        )
+        .unwrap();
         let network_service = worker.service().clone();
         async_std::task::spawn(worker);
         result.push({


### PR DESCRIPTION
重构 block relay metrics

1. 将多个 txns_filled metris 合并成 Vec，并通过 Counter 替代 Guage。
2. block_txns_count metrics 删除，因为从 block_txns_count 的 Guage 无法得出一个有效的监控信息。