### PR TITLE
fix node missing

### DIFF
--- a/vm/compiler/src/dependency_order.rs
+++ b/vm/compiler/src/dependency_order.rs
@@ -45,10 +45,9 @@ impl<'a> DependencyGraph<'a> {
         let mut graph = DiGraphMap::new();
         for module in &modules {
             let module_idx: ModuleIndex = *reverse_modules.get(&module.self_id()).unwrap();
+            graph.add_node(module_idx);
             let mut deps = module.immediate_dependencies();
-            if deps.is_empty() {
-                graph.add_node(module_idx);
-            } else {
+            if !deps.is_empty() {
                 // make the function stable.
                 deps.sort();
                 for dep in deps {


### PR DESCRIPTION
Fix dependency ordering missing module when a module use external modules.

```
module SafeMath {
    use 0x1::Math;
    use 0x1::Errors;
}
```