### PR TITLE
[move-unit-test] Fix move unit test cost table bug.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "abigen"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "anyhow",
  "bcs",
@@ -856,7 +856,7 @@ dependencies = [
 [[package]]
 name = "boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -885,7 +885,7 @@ dependencies = [
 [[package]]
 name = "borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "diem-workspace-hack",
  "mirai-annotations",
@@ -946,7 +946,7 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 [[package]]
 name = "bytecode"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "borrow-graph",
  "bytecode-verifier",
@@ -971,7 +971,7 @@ dependencies = [
 [[package]]
 name = "bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "anyhow",
  "bytecode",
@@ -991,7 +991,7 @@ dependencies = [
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -1004,7 +1004,7 @@ dependencies = [
 [[package]]
 name = "bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "anyhow",
  "bcs",
@@ -1020,7 +1020,7 @@ dependencies = [
 [[package]]
 name = "bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "anyhow",
  "borrow-graph",
@@ -2117,7 +2117,7 @@ checksum = "850878694b7933ca4c9569d30a34b55031b9b139ee1fc7b94a527c4ef960d690"
 [[package]]
 name = "diem-crypto"
 version = "0.0.2"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "aes-gcm 0.8.0",
  "anyhow",
@@ -2148,7 +2148,7 @@ dependencies = [
 [[package]]
 name = "diem-crypto-derive"
 version = "0.0.2"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "proc-macro2 1.0.30",
  "quote 1.0.9",
@@ -2158,7 +2158,7 @@ dependencies = [
 [[package]]
 name = "diem-proptest-helpers"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "crossbeam 0.8.0",
  "diem-workspace-hack",
@@ -2169,7 +2169,7 @@ dependencies = [
 [[package]]
 name = "diem-temppath"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "diem-workspace-hack",
  "hex",
@@ -2179,7 +2179,7 @@ dependencies = [
 [[package]]
 name = "diem-workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -2317,7 +2317,7 @@ dependencies = [
 [[package]]
 name = "disassembler"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "anyhow",
  "bytecode-source-map",
@@ -2345,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "docgen"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "anyhow",
  "bytecode",
@@ -2511,7 +2511,7 @@ dependencies = [
 [[package]]
 name = "errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "anyhow",
  "bcs",
@@ -2709,7 +2709,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.8.4",
  "rand_core 0.6.3",
- "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=0dabf7726f1d856ea18df685c10e51d6fae53e8c)",
+ "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c)",
  "serde",
  "serde_bytes",
  "starcoin-crypto",
@@ -3784,7 +3784,7 @@ checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 [[package]]
 name = "ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "anyhow",
  "bytecode-source-map",
@@ -3803,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "anyhow",
  "diem-workspace-hack",
@@ -5135,7 +5135,7 @@ checksum = "b48e78b8626927bd980dff38d8147006323f5d7634d7bc9e31c3a59e07da1b28"
 [[package]]
 name = "move-binary-format"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "anyhow",
  "diem-workspace-hack",
@@ -5151,7 +5151,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "anyhow",
  "diem-workspace-hack",
@@ -5206,7 +5206,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "anyhow",
  "diem-workspace-hack",
@@ -5217,7 +5217,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.2"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5236,7 +5236,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5275,7 +5275,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "anyhow",
  "diem-workspace-hack",
@@ -5289,7 +5289,7 @@ dependencies = [
 [[package]]
 name = "move-lang"
 version = "0.0.1"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5317,7 +5317,7 @@ dependencies = [
 [[package]]
 name = "move-lang-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "datatest-stable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "diem-workspace-hack",
@@ -5328,7 +5328,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "anyhow",
  "bytecode-source-map",
@@ -5355,7 +5355,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "abigen",
  "anyhow",
@@ -5393,7 +5393,7 @@ dependencies = [
 [[package]]
 name = "move-prover-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "anyhow",
  "diem-workspace-hack",
@@ -5405,7 +5405,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "diem-workspace-hack",
  "docgen",
@@ -5426,7 +5426,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "diem-workspace-hack",
  "once_cell",
@@ -5436,7 +5436,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "anyhow",
  "bytecode-interpreter",
@@ -5461,7 +5461,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "bytecode-verifier",
  "diem-workspace-hack",
@@ -5479,7 +5479,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "anyhow",
  "diem-workspace-hack",
@@ -5491,7 +5491,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "bcs",
  "diem-workspace-hack",
@@ -5655,7 +5655,7 @@ dependencies = [
  "network-p2p-types",
  "parking_lot 0.11.2",
  "rand 0.8.4",
- "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=0dabf7726f1d856ea18df685c10e51d6fae53e8c)",
+ "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c)",
  "serde",
  "starcoin-crypto",
  "starcoin-logger",
@@ -5720,7 +5720,7 @@ dependencies = [
  "libp2p",
  "rand 0.8.4",
  "sc-peerset",
- "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=0dabf7726f1d856ea18df685c10e51d6fae53e8c)",
+ "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c)",
  "serde",
  "serde_json",
 ]
@@ -6044,9 +6044,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "openrpc-rs"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/openrpc-rs?rev=e2dea2118a2509f4d67fd2b70bef0ab2b5b03de3#e2dea2118a2509f4d67fd2b70bef0ab2b5b03de3"
+source = "git+https://github.com/starcoinorg/openrpc-rs?rev=554c12cc27dca6446443318946341d2d338b9906#554c12cc27dca6446443318946341d2d338b9906"
 dependencies = [
- "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=0dabf7726f1d856ea18df685c10e51d6fae53e8c)",
+ "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c)",
  "serde",
  "serde_json",
 ]
@@ -7379,7 +7379,7 @@ dependencies = [
 [[package]]
 name = "resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "anyhow",
  "bcs",
@@ -7714,13 +7714,13 @@ dependencies = [
 [[package]]
 name = "schemars"
 version = "0.8.3"
-source = "git+https://github.com/starcoinorg/schemars?rev=0dabf7726f1d856ea18df685c10e51d6fae53e8c#0dabf7726f1d856ea18df685c10e51d6fae53e8c"
+source = "git+https://github.com/starcoinorg/schemars?rev=4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c#4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c"
 dependencies = [
  "diem-crypto",
  "dyn-clone",
  "move-core-types",
  "multiaddr",
- "schemars_derive 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=0dabf7726f1d856ea18df685c10e51d6fae53e8c)",
+ "schemars_derive 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c)",
  "serde",
  "serde_json",
 ]
@@ -7740,7 +7740,7 @@ dependencies = [
 [[package]]
 name = "schemars_derive"
 version = "0.8.3"
-source = "git+https://github.com/starcoinorg/schemars?rev=0dabf7726f1d856ea18df685c10e51d6fae53e8c#0dabf7726f1d856ea18df685c10e51d6fae53e8c"
+source = "git+https://github.com/starcoinorg/schemars?rev=4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c#4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c"
 dependencies = [
  "proc-macro2 1.0.30",
  "quote 1.0.9",
@@ -8135,7 +8135,7 @@ checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
 [[package]]
 name = "short-hex-str"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "diem-workspace-hack",
  "mirai-annotations",
@@ -8365,7 +8365,7 @@ dependencies = [
  "hex",
  "move-binary-format",
  "once_cell",
- "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=0dabf7726f1d856ea18df685c10e51d6fae53e8c)",
+ "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c)",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -8395,7 +8395,7 @@ version = "1.8.0-rc.1"
 dependencies = [
  "anyhow",
  "hex",
- "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=0dabf7726f1d856ea18df685c10e51d6fae53e8c)",
+ "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c)",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -8437,7 +8437,7 @@ dependencies = [
  "hex",
  "rand 0.8.4",
  "rand_core 0.6.3",
- "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=0dabf7726f1d856ea18df685c10e51d6fae53e8c)",
+ "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c)",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -8483,7 +8483,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.8.4",
  "rand_core 0.6.3",
- "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=0dabf7726f1d856ea18df685c10e51d6fae53e8c)",
+ "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c)",
  "serde",
  "starcoin-crypto",
  "starcoin-logger",
@@ -8719,7 +8719,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "rand 0.8.4",
  "rand_core 0.6.3",
- "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=0dabf7726f1d856ea18df685c10e51d6fae53e8c)",
+ "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c)",
  "serde",
  "serde_json",
  "starcoin-crypto",
@@ -9036,7 +9036,7 @@ dependencies = [
  "log4rs",
  "once_cell",
  "parking_lot 0.11.2",
- "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=0dabf7726f1d856ea18df685c10e51d6fae53e8c)",
+ "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c)",
  "serde",
  "slog",
  "slog-async",
@@ -9521,8 +9521,8 @@ dependencies = [
  "jsonrpc-server-utils 17.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "network-api",
  "network-p2p-types",
- "openrpc-rs 0.1.0 (git+https://github.com/starcoinorg/openrpc-rs?rev=e2dea2118a2509f4d67fd2b70bef0ab2b5b03de3)",
- "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=0dabf7726f1d856ea18df685c10e51d6fae53e8c)",
+ "openrpc-rs 0.1.0 (git+https://github.com/starcoinorg/openrpc-rs?rev=554c12cc27dca6446443318946341d2d338b9906)",
+ "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c)",
  "serde",
  "serde-helpers",
  "serde_json",
@@ -9690,7 +9690,7 @@ dependencies = [
  "futures-timer",
  "log 0.4.14",
  "once_cell",
- "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=0dabf7726f1d856ea18df685c10e51d6fae53e8c)",
+ "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c)",
  "serde",
  "stest",
  "thiserror",
@@ -9893,7 +9893,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "network-api",
- "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=0dabf7726f1d856ea18df685c10e51d6fae53e8c)",
+ "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c)",
  "serde",
  "starcoin-accumulator",
  "starcoin-crypto",
@@ -9994,7 +9994,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "futures-channel",
- "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=0dabf7726f1d856ea18df685c10e51d6fae53e8c)",
+ "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c)",
  "serde",
  "starcoin-crypto",
  "starcoin-types",
@@ -10032,7 +10032,7 @@ dependencies = [
  "proptest-derive",
  "rand 0.8.4",
  "rand_core 0.6.3",
- "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=0dabf7726f1d856ea18df685c10e51d6fae53e8c)",
+ "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c)",
  "serde",
  "serde_json",
  "starcoin-accumulator",
@@ -10101,7 +10101,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.8.4",
- "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=0dabf7726f1d856ea18df685c10e51d6fae53e8c)",
+ "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c)",
  "serde",
  "serde-helpers",
  "serde_bytes",
@@ -10225,7 +10225,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "pin-project 0.4.28",
  "pin-utils",
- "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=0dabf7726f1d856ea18df685c10e51d6fae53e8c)",
+ "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c)",
  "serde",
  "starcoin-logger",
  "stest",
@@ -11623,7 +11623,7 @@ name = "vm-status-translator"
 version = "1.8.0-rc.1"
 dependencies = [
  "anyhow",
- "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=0dabf7726f1d856ea18df685c10e51d6fae53e8c)",
+ "schemars 0.8.3 (git+https://github.com/starcoinorg/schemars?rev=4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c)",
  "serde",
  "starcoin-move-explain",
  "starcoin-vm-types",
@@ -11971,7 +11971,7 @@ checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 [[package]]
 name = "x"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "anyhow",
  "camino",
@@ -12000,7 +12000,7 @@ dependencies = [
 [[package]]
 name = "x-core"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "camino",
  "determinator",
@@ -12018,7 +12018,7 @@ dependencies = [
 [[package]]
 name = "x-lint"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/diem?rev=5a8ea734641cce096914fe10a2fbd8aea2e65fd1#5a8ea734641cce096914fe10a2fbd8aea2e65fd1"
+source = "git+https://github.com/starcoinorg/diem?rev=77c39e00b2030959abfc200aeabdfe1096c12a1c#77c39e00b2030959abfc200aeabdfe1096c12a1c"
 dependencies = [
  "camino",
  "guppy",

--- a/abi/decoder/Cargo.toml
+++ b/abi/decoder/Cargo.toml
@@ -14,11 +14,11 @@ serde_bytes = "0.11"
 anyhow = "1.0.41"
 once_cell = "1.8.0"
 hex = "0.4.3"
-move-binary-format = {git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
+move-binary-format = {git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
 starcoin-resource-viewer = {path = "../../vm/resource-viewer"}
 starcoin-vm-types = { path = "../../vm/types" }
 starcoin-abi-types = {path = "../types"}
 starcoin-abi-resolver = {path = "../resolver"}
 bcs-ext = {path = "../../commons/bcs_ext"}
 bcs = "0.1"
-schemars = {git = "https://github.com/starcoinorg/schemars", rev="0dabf7726f1d856ea18df685c10e51d6fae53e8c"}
+schemars = {git = "https://github.com/starcoinorg/schemars", rev="4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c"}

--- a/abi/resolver/Cargo.toml
+++ b/abi/resolver/Cargo.toml
@@ -11,7 +11,7 @@ starcoin-vm-types = {path = "../../vm/types"}
 starcoin-abi-types = {path = "../types"}
 anyhow="~1"
 starcoin-resource-viewer = {path = "../../vm/resource-viewer"}
-move-model = { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
+move-model = { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
 [dev-dependencies]
 stdlib = {path = "../../vm/stdlib"}
 serde_json = "1"

--- a/abi/types/Cargo.toml
+++ b/abi/types/Cargo.toml
@@ -14,4 +14,4 @@ serde="~1"
 serde_bytes = "0.11"
 serde_json = "~1"
 hex = "0.4"
-schemars = {git = "https://github.com/starcoinorg/schemars", rev="0dabf7726f1d856ea18df685c10e51d6fae53e8c"}
+schemars = {git = "https://github.com/starcoinorg/schemars", rev="4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c"}

--- a/account/api/Cargo.toml
+++ b/account/api/Cargo.toml
@@ -21,7 +21,7 @@ rand = "0.8.4"
 rand_core = { version = "0.6.3", default-features = false }
 futures = "0.3.12"
 starcoin-service-registry = { path = "../../commons/service-registry" }
-schemars = {git = "https://github.com/starcoinorg/schemars", rev="0dabf7726f1d856ea18df685c10e51d6fae53e8c"}
+schemars = {git = "https://github.com/starcoinorg/schemars", rev="4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c"}
 
 [dev-dependencies]
 

--- a/cmd/starcoin/Cargo.toml
+++ b/cmd/starcoin/Cargo.toml
@@ -47,13 +47,13 @@ starcoin-resource-viewer = { path = "../../vm/resource-viewer" }
 starcoin-service-registry = { path = "../../commons/service-registry" }
 starcoin-move-explain = { path = "../../vm/move-explain" }
 vm-status-translator = {path = "../../vm/vm-status-translator"}
-errmapgen = { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
+errmapgen = { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
 network-api = {path = "../../network/api", package="network-api"}
 starcoin-network-rpc-api = {path = "../../network-rpc/api"}
-short-hex-str = { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
+short-hex-str = { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
 starcoin-abi-decoder = {path = "../../abi/decoder"}
 starcoin-abi-types = {path = "../../abi/types"}
-move-command-line-common = {git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1" }
+move-command-line-common = {git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c" }
 
 [dev-dependencies]
 test-helper= {path = "../../test-helper"}

--- a/commons/accumulator/Cargo.toml
+++ b/commons/accumulator/Cargo.toml
@@ -19,7 +19,7 @@ bcs-ext = { package="bcs-ext", path = "../../commons/bcs_ext" }
 serde = { version = "1.0.130" }
 lru = "0.7.0"
 parking_lot = "0.11.2"
-schemars = {git = "https://github.com/starcoinorg/schemars", rev="0dabf7726f1d856ea18df685c10e51d6fae53e8c"}
+schemars = {git = "https://github.com/starcoinorg/schemars", rev="4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c"}
 
 [dev-dependencies]
 rand = "0.8.4"

--- a/commons/crypto/Cargo.toml
+++ b/commons/crypto/Cargo.toml
@@ -11,8 +11,8 @@ serde = { version = "1.0.130" }
 serde_bytes = "0.11.5"
 hex = "0.4.3"
 anyhow = "1.0"
-diem-crypto = { package="diem-crypto",  git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1" , features = ["fuzzing"] }
-diem-crypto-derive = { package="diem-crypto-derive",  git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
+diem-crypto = { package="diem-crypto",  git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c" , features = ["fuzzing"] }
+diem-crypto-derive = { package="diem-crypto-derive",  git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
 bcs-ext = { package="bcs-ext", path = "../bcs_ext" }
 crypto-macro = { package="starcoin-crypto-macro", path = "./crypto-macro"}
 rand = "0.8.4"

--- a/commons/forkable-jellyfish-merkle/Cargo.toml
+++ b/commons/forkable-jellyfish-merkle/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "1.0"
 hex= "0.4.3"
 once_cell = "1.8.0"
 bcs-ext = { path = "../../commons/bcs_ext", package = "bcs-ext" }
-schemars = {git = "https://github.com/starcoinorg/schemars", rev="0dabf7726f1d856ea18df685c10e51d6fae53e8c"}
+schemars = {git = "https://github.com/starcoinorg/schemars", rev="4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c"}
 
 [dev-dependencies]
 rand = "0.8.4"

--- a/commons/logger/Cargo.toml
+++ b/commons/logger/Cargo.toml
@@ -19,4 +19,4 @@ log4rs = { version="1.0.0", features = ["background_rotation", "gzip"]}
 once_cell = "1.8.0"
 serde = { version = "1.0.130", features = ["derive"] }
 parking_lot = "0.11.2"
-schemars = {git = "https://github.com/starcoinorg/schemars", rev="0dabf7726f1d856ea18df685c10e51d6fae53e8c"}
+schemars = {git = "https://github.com/starcoinorg/schemars", rev="4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c"}

--- a/commons/proptest-helpers/Cargo.toml
+++ b/commons/proptest-helpers/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 crossbeam = "0.7.3"
-diem-proptest-helpers = { package="diem-proptest-helpers",  git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
+diem-proptest-helpers = { package="diem-proptest-helpers",  git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
 
 proptest = "1.0.0"
 proptest-derive = "0.3.0"

--- a/commons/service-registry/Cargo.toml
+++ b/commons/service-registry/Cargo.toml
@@ -18,7 +18,7 @@ futures-timer = "3.0"
 serde = { version = "1.0.130", features = ["derive"] }
 once_cell = "1.8.0"
 log = "0.4.14"
-schemars = {git = "https://github.com/starcoinorg/schemars", rev="0dabf7726f1d856ea18df685c10e51d6fae53e8c"}
+schemars = {git = "https://github.com/starcoinorg/schemars", rev="4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c"}
 
 [dev-dependencies]
 stest = { path = "../../commons/stest" }

--- a/commons/stream-task/Cargo.toml
+++ b/commons/stream-task/Cargo.toml
@@ -16,7 +16,7 @@ pin-project = "0.4.8"
 log = "0.4.14"
 serde = { version = "1.0.130", features = ["derive"] }
 parking_lot = "0.11.2"
-schemars = {git = "https://github.com/starcoinorg/schemars", rev="0dabf7726f1d856ea18df685c10e51d6fae53e8c"}
+schemars = {git = "https://github.com/starcoinorg/schemars", rev="4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c"}
 
 [dev-dependencies]
 stest = { path = "../stest" }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -30,9 +30,9 @@ starcoin-vm-types = { path = "../vm/types" }
 starcoin-uint = { path = "../types/uint" }
 network-p2p-types = { path = "../network-p2p/types"}
 starcoin-logger = {path = "../commons/logger", package="starcoin-logger"}
-diem-temppath = { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
+diem-temppath = { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
 starcoin-system = {path = "../commons/system", package="starcoin-system"}
 network-api = {path = "../network/api", package="network-api"}
 stdlib = { path = "../vm/stdlib"}
-schemars = {git = "https://github.com/starcoinorg/schemars", rev="0dabf7726f1d856ea18df685c10e51d6fae53e8c"}
+schemars = {git = "https://github.com/starcoinorg/schemars", rev="4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c"}
 starcoin-metrics = { path = "../commons/metrics" }

--- a/devtools/x/Cargo.toml
+++ b/devtools/x/Cargo.toml
@@ -23,7 +23,7 @@ globset = "0.4.8"
 regex = "1.4.3"
 rayon = "1.5.1"
 indexmap = "1.6.2"
-x-core = { package="x-core", git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
-x-lint = { package="x-lint", git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
-diem-workspace-hack = { package="diem-workspace-hack", git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
-diem-x = { package="x", git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
+x-core = { package="x-core", git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
+x-lint = { package="x-lint", git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
+diem-workspace-hack = { package="diem-workspace-hack", git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
+diem-x = { package="x", git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }

--- a/network-p2p/types/Cargo.toml
+++ b/network-p2p/types/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0.130", features = ["derive"] }
 serde_json = { version="1.0", features = ["arbitrary_precision"]}
 libp2p = { version = "0.39.1", default-features = false, features = ["request-response"] }
 sc-peerset = { path = "../peerset"}
-schemars = {git = "https://github.com/starcoinorg/schemars", rev="0dabf7726f1d856ea18df685c10e51d6fae53e8c"}
+schemars = {git = "https://github.com/starcoinorg/schemars", rev="4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c"}
 [features]
 default = []
 

--- a/network/api/Cargo.toml
+++ b/network/api/Cargo.toml
@@ -20,5 +20,5 @@ starcoin-crypto = { path = "../../commons/crypto" }
 bcs-ext = { package = "bcs-ext", path = "../../commons/bcs_ext" }
 starcoin-service-registry = { path = "../../commons/service-registry" }
 network-p2p-types = {path = "../../network-p2p/types"}
-schemars = {git = "https://github.com/starcoinorg/schemars", rev="0dabf7726f1d856ea18df685c10e51d6fae53e8c"}
+schemars = {git = "https://github.com/starcoinorg/schemars", rev="4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c"}
 starcoin-metrics = {path = "../../commons/metrics"}

--- a/rpc/api/Cargo.toml
+++ b/rpc/api/Cargo.toml
@@ -37,8 +37,8 @@ serde-helpers = {path = "../../commons/serde-helpers"}
 network-p2p-types = {path = "../../network-p2p/types"}
 network-api = {path = "../../network/api", package="network-api"}
 jsonrpc-derive = {git = "https://github.com/fikgol/jsonrpc",rev="2f6c2b33d3048d57a85347ee735b312df0117b15"}
-schemars = {git = "https://github.com/starcoinorg/schemars", rev="0dabf7726f1d856ea18df685c10e51d6fae53e8c"}
-openrpc-rs = { git="https://github.com/starcoinorg/openrpc-rs",rev="e2dea2118a2509f4d67fd2b70bef0ab2b5b03de3"}
+schemars = {git = "https://github.com/starcoinorg/schemars", rev="4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c"}
+openrpc-rs = { git="https://github.com/starcoinorg/openrpc-rs",rev="554c12cc27dca6446443318946341d2d338b9906"}
 structopt = "0.3.25"
 [[bin]]
 name = "starcoin-rpc-schema-generate"

--- a/sync/api/Cargo.toml
+++ b/sync/api/Cargo.toml
@@ -15,4 +15,4 @@ starcoin-accumulator = {path = "../../commons/accumulator"}
 starcoin-service-registry = { path = "../../commons/service-registry" }
 stream-task ={ path = "../../commons/stream-task"}
 network-api = {path = "../../network/api", package="network-api"}
-schemars = {git = "https://github.com/starcoinorg/schemars", rev="0dabf7726f1d856ea18df685c10e51d6fae53e8c"}
+schemars = {git = "https://github.com/starcoinorg/schemars", rev="4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c"}

--- a/txpool/api/Cargo.toml
+++ b/txpool/api/Cargo.toml
@@ -13,4 +13,4 @@ futures-channel = "0.3"
 starcoin-types = {path = "../../types", package="starcoin-types"}
 starcoin-crypto = { package="starcoin-crypto", path = "../../commons/crypto"}
 serde = { version = "1.0.130", default-features = false }
-schemars = {git = "https://github.com/starcoinorg/schemars", rev="0dabf7726f1d856ea18df685c10e51d6fae53e8c"}
+schemars = {git = "https://github.com/starcoinorg/schemars", rev="4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c"}

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -29,7 +29,7 @@ starcoin-vm-types = { path = "../vm/types"}
 futures = "0.3.12"
 starcoin-accumulator = {path = "../commons/accumulator"}
 forkable-jellyfish-merkle = { path = "../commons/forkable-jellyfish-merkle"}
-schemars = {git = "https://github.com/starcoinorg/schemars", rev="0dabf7726f1d856ea18df685c10e51d6fae53e8c"}
+schemars = {git = "https://github.com/starcoinorg/schemars", rev="4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c"}
 
 [features]
 default = []

--- a/vm/compiler/Cargo.toml
+++ b/vm/compiler/Cargo.toml
@@ -11,10 +11,10 @@ anyhow = "1.0.41"
 once_cell = "1.8.0"
 tempfile = "3.1.0"
 regex = { version = "1.4.3", default-features = false, features = ["std", "perf"] }
-move-lang = { package="move-lang", git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
-move-command-line-common = {git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"}
-move-lang-test-utils = { package="move-lang-test-utils", git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
-move-binary-format = { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
+move-lang = { package="move-lang", git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
+move-command-line-common = {git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"}
+move-lang-test-utils = { package="move-lang-test-utils", git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
+move-binary-format = { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
 petgraph = "0.5.1"
 walkdir = "2.3"
 rayon = "1.5.1"

--- a/vm/functional-tests/Cargo.toml
+++ b/vm/functional-tests/Cargo.toml
@@ -31,8 +31,8 @@ starcoin-genesis = { path = "../../genesis" }
 starcoin-consensus = { path = "../../consensus" }
 starcoin-account-api = { path = "../../account/api" }
 vm-status-translator = {path = "../vm-status-translator"}
-move-lang = { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
-move-command-line-common = { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
+move-lang = { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
+move-command-line-common = { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
 [dev-dependencies]
 starcoin-vm-types = { path = "../types"}
 

--- a/vm/move-cli/Cargo.toml
+++ b/vm/move-cli/Cargo.toml
@@ -18,28 +18,28 @@ structopt = "0.3.25"
 
 bcs = "0.1.2"
 starcoin-logger = {path = "../../commons/logger"}
-bytecode-verifier = { package = "bytecode-verifier", git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
+bytecode-verifier = { package = "bytecode-verifier", git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
 # diem-framework-releases = { path = "../../diem-framework/releases" }
-disassembler = { package = "disassembler", git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
-errmapgen = { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
-diem-workspace-hack = { package="diem-workspace-hack", git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
+disassembler = { package = "disassembler", git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
+errmapgen = { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
+diem-workspace-hack = { package="diem-workspace-hack", git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
 # diem-state-view = { path = "../../../storage/state-view" }
 starcoin-types = { path = "../../types" }
 # diem-vm = { path = "../../diem-vm" }
-move-coverage =  { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
+move-coverage =  { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
 starcoin-vm-types = {path = "../../vm/types"}
-move-lang = { package="move-lang", git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
-move-core-types = { git = "https://github.com/starcoinorg/diem", rev = "5a8ea734641cce096914fe10a2fbd8aea2e65fd1" }
-# move-vm-types = { git = "https://github.com/starcoinorg/diem", rev = "5a8ea734641cce096914fe10a2fbd8aea2e65fd1" }
-move-vm-runtime = { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1" }
+move-lang = { package="move-lang", git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
+move-core-types = { git = "https://github.com/starcoinorg/diem", rev = "77c39e00b2030959abfc200aeabdfe1096c12a1c" }
+# move-vm-types = { git = "https://github.com/starcoinorg/diem", rev = "77c39e00b2030959abfc200aeabdfe1096c12a1c" }
+move-vm-runtime = { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c" }
 resource-viewer = { path = "../resource-viewer", package = "starcoin-resource-viewer" }
-move-unit-test = { git = "https://github.com/starcoinorg/diem", rev = "5a8ea734641cce096914fe10a2fbd8aea2e65fd1" }
-move-command-line-common = { git = "https://github.com/starcoinorg/diem", rev = "5a8ea734641cce096914fe10a2fbd8aea2e65fd1" }
+move-unit-test = { git = "https://github.com/starcoinorg/diem", rev = "77c39e00b2030959abfc200aeabdfe1096c12a1c" }
+move-command-line-common = { git = "https://github.com/starcoinorg/diem", rev = "77c39e00b2030959abfc200aeabdfe1096c12a1c" }
 starcoin-config ={path = "../../config"}
 stdlib = {path = "../stdlib"}
 starcoin-vm-runtime = {path = "../vm-runtime"}
 # diem-framework = { path = "../../diem-framework" }
-vm = { package = "move-binary-format", git = "https://github.com/starcoinorg/diem", rev = "5a8ea734641cce096914fe10a2fbd8aea2e65fd1"}
+vm = { package = "move-binary-format", git = "https://github.com/starcoinorg/diem", rev = "77c39e00b2030959abfc200aeabdfe1096c12a1c"}
 starcoin-functional-tests = {path = "../functional-tests"}
 # vm-genesis = { path = "../vm-genesis" }
 walkdir = "2.3.1"

--- a/vm/move-coverage/Cargo.toml
+++ b/vm/move-coverage/Cargo.toml
@@ -17,9 +17,9 @@ codespan = { version = "0.8.0", features = ["serialization"] }
 colored = "2.0.0"
 bcs = "0.1.2"
 
-bytecode-source-map = { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
-move-coverage = { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
-move-binary-format = { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
+bytecode-source-map = { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
+move-coverage = { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
+move-binary-format = { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
 [features]
 default = []
 

--- a/vm/move-explain/Cargo.toml
+++ b/vm/move-explain/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 structopt = "0.3.25"
 stdlib = { package="stdlib", path = "../stdlib"}
-move-core-types = { git = "https://github.com/starcoinorg/diem", rev = "5a8ea734641cce096914fe10a2fbd8aea2e65fd1" }
+move-core-types = { git = "https://github.com/starcoinorg/diem", rev = "77c39e00b2030959abfc200aeabdfe1096c12a1c" }
 bcs-ext = { package="bcs-ext", path = "../../commons/bcs_ext" }
 
 [features]

--- a/vm/move-prover/Cargo.toml
+++ b/vm/move-prover/Cargo.toml
@@ -8,8 +8,8 @@ license = "Apache-2.0"
 
 [dependencies]
 ## diem dependencies
-diem-temppath = { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
-move-prover = { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
+diem-temppath = { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
+move-prover = { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
 
 # external dependencies
 codespan-reporting = "0.11"
@@ -18,8 +18,8 @@ anyhow = "1.0.41"
 
 [dev-dependencies]
 datatest-stable = "0.1"
-move-prover-test-utils = {git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
-move-command-line-common= {git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1" }
+move-prover-test-utils = {git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
+move-command-line-common= {git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c" }
 shell-words = "1.0.0"
 walkdir = "2.3"
 once_cell = "1.7.2"

--- a/vm/natives/Cargo.toml
+++ b/vm/natives/Cargo.toml
@@ -7,14 +7,14 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-errmapgen = { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1" }
-docgen = { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1" }
-move-command-line-common = { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1" }
-move-prover = { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1" }
-move-vm-types = { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1" }
-move-vm-runtime = { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1" }
-move-binary-format = { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1" }
-move-core-types = { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1" }
+errmapgen = { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c" }
+docgen = { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c" }
+move-command-line-common = { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c" }
+move-prover = { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c" }
+move-vm-types = { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c" }
+move-vm-runtime = { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c" }
+move-binary-format = { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c" }
+move-core-types = { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c" }
 starcoin-crypto={path = "../../commons/crypto"}
 log = "0.4.14"
 walkdir = "2.3.1"

--- a/vm/natives/src/lib.rs
+++ b/vm/natives/src/lib.rs
@@ -38,3 +38,8 @@ pub enum NativeCostIndex {
     RIPEMD160 = 21,
     ECRECOVER = 22,
 }
+
+impl NativeCostIndex {
+    //note: should change this value when add new native function.
+    pub const NUMBER_OF_NATIVE_FUNCTIONS: usize = 23;
+}

--- a/vm/resource-viewer/Cargo.toml
+++ b/vm/resource-viewer/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 starcoin-vm-types = { path = "../types" }
-move-binary-format = {git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
+move-binary-format = {git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
 serde_json = "1.0"
 serde = { version = "1.0.130", features = ["derive", "rc"] }
 anyhow = "1.0.41"

--- a/vm/stdlib/Cargo.toml
+++ b/vm/stdlib/Cargo.toml
@@ -9,14 +9,14 @@ edition = "2018"
 [dependencies]
 walkdir = "2.3"
 anyhow = "1.0.41"
-bytecode-verifier = { package="bytecode-verifier", git = "https://github.com/starcoinorg/diem",rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
-#datatest-stable = { package="datatest-stable", git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
+bytecode-verifier = { package="bytecode-verifier", git = "https://github.com/starcoinorg/diem",rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
+#datatest-stable = { package="datatest-stable", git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
 datatest-stable = "0.1.1"
 starcoin-crypto = { path = "../../commons/crypto"}
 starcoin-vm-types = { path = "../types"}
 bcs-ext = { package="bcs-ext", path = "../../commons/bcs_ext" }
 starcoin-move-compiler = { path = "../../vm/compiler"}
-move-prover = { package="move-prover", git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
+move-prover = { package="move-prover", git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
 once_cell = "1.8.0"
 include_dir = "0.6.2"
 sha2 = "0.9.1"

--- a/vm/transaction-builder-generator/Cargo.toml
+++ b/vm/transaction-builder-generator/Cargo.toml
@@ -19,7 +19,7 @@ serde-generate = {git="https://github.com/starcoinorg/serde-reflection" , rev="6
 serde-reflection = {git="https://github.com/starcoinorg/serde-reflection" , rev="694048797338ff7385006d968e786b6d9dbdeb8b"}
 
 starcoin-vm-types = { path = "../types"}
-move-core-types = {git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1"  }
+move-core-types = {git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c"  }
 bcs = "0.1.3"
 
 [dev-dependencies]

--- a/vm/types/Cargo.toml
+++ b/vm/types/Cargo.toml
@@ -23,22 +23,22 @@ bech32 = "0.8"
 
 proptest = { version = "1.0.0", default-features = false, optional = true }
 proptest-derive = { version = "0.3.0", default-features = false, optional = true }
-move-core-types = { git = "https://github.com/starcoinorg/diem", rev = "5a8ea734641cce096914fe10a2fbd8aea2e65fd1" }
-move-vm-types = { git = "https://github.com/starcoinorg/diem", rev = "5a8ea734641cce096914fe10a2fbd8aea2e65fd1" }
-bytecode-verifier = { git = "https://github.com/starcoinorg/diem", rev = "5a8ea734641cce096914fe10a2fbd8aea2e65fd1" }
-vm = { git = "https://github.com/starcoinorg/diem", package = "move-binary-format", rev = "5a8ea734641cce096914fe10a2fbd8aea2e65fd1"}
-move-ir-types = { git = "https://github.com/starcoinorg/diem", rev = "5a8ea734641cce096914fe10a2fbd8aea2e65fd1" }
+move-core-types = { git = "https://github.com/starcoinorg/diem", rev = "77c39e00b2030959abfc200aeabdfe1096c12a1c" }
+move-vm-types = { git = "https://github.com/starcoinorg/diem", rev = "77c39e00b2030959abfc200aeabdfe1096c12a1c" }
+bytecode-verifier = { git = "https://github.com/starcoinorg/diem", rev = "77c39e00b2030959abfc200aeabdfe1096c12a1c" }
+vm = { git = "https://github.com/starcoinorg/diem", package = "move-binary-format", rev = "77c39e00b2030959abfc200aeabdfe1096c12a1c"}
+move-ir-types = { git = "https://github.com/starcoinorg/diem", rev = "77c39e00b2030959abfc200aeabdfe1096c12a1c" }
 
 bcs-ext = { package = "bcs-ext", path = "../../commons/bcs_ext" }
 starcoin-proptest-helpers = { path = "../../commons/proptest-helpers", optional = true }
 starcoin-crypto = { path = "../../commons/crypto" }
 starcoin-accumulator = { path = "../../commons/accumulator"}
 forkable-jellyfish-merkle = { path = "../../commons/forkable-jellyfish-merkle"}
-schemars = {git = "https://github.com/starcoinorg/schemars", rev="0dabf7726f1d856ea18df685c10e51d6fae53e8c"}
+schemars = {git = "https://github.com/starcoinorg/schemars", rev="4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c"}
 [dev-dependencies]
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
-vm = { git = "https://github.com/starcoinorg/diem",package = "move-binary-format", rev = "5a8ea734641cce096914fe10a2fbd8aea2e65fd1", features = ["fuzzing"]}
+vm = { git = "https://github.com/starcoinorg/diem",package = "move-binary-format", rev = "77c39e00b2030959abfc200aeabdfe1096c12a1c", features = ["fuzzing"]}
 starcoin-crypto = { path = "../../commons/crypto", features = ["fuzzing"] }
 starcoin-proptest-helpers = { path = "../../commons/proptest-helpers"}
 

--- a/vm/vm-runtime/Cargo.toml
+++ b/vm/vm-runtime/Cargo.toml
@@ -11,8 +11,8 @@ anyhow = "1.0.41"
 once_cell = "1.8.0"
 
 starcoin-types = { path = "../../types"}
-move-vm-runtime = { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1" }
-move-stdlib = { git = "https://github.com/starcoinorg/diem", rev="5a8ea734641cce096914fe10a2fbd8aea2e65fd1" }
+move-vm-runtime = { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c" }
+move-stdlib = { git = "https://github.com/starcoinorg/diem", rev="77c39e00b2030959abfc200aeabdfe1096c12a1c" }
 tracing = "0.1.29"
 starcoin-config = { path = "../../config"}
 starcoin-logger = {path = "../../commons/logger"}

--- a/vm/vm-runtime/src/starcoin_vm.rs
+++ b/vm/vm-runtime/src/starcoin_vm.rs
@@ -16,6 +16,7 @@ use move_vm_runtime::session::Session;
 use once_cell::sync::Lazy;
 use starcoin_config::INITIAL_GAS_SCHEDULE;
 use starcoin_logger::prelude::*;
+use starcoin_natives::NativeCostIndex;
 use starcoin_types::account_config::config_change::ConfigChangeEvent;
 use starcoin_types::account_config::{
     access_path_for_module_upgrade_strategy, access_path_for_two_phase_upgrade_v2,
@@ -67,7 +68,7 @@ use std::convert::{TryFrom, TryInto};
 use std::sync::Arc;
 
 static ZERO_COST_SCHEDULE: Lazy<CostTable> =
-    Lazy::new(|| zero_cost_schedule(super::natives::starcoin_natives().len()));
+    Lazy::new(|| zero_cost_schedule(NativeCostIndex::NUMBER_OF_NATIVE_FUNCTIONS));
 
 #[derive(Clone)]
 #[allow(clippy::upper_case_acronyms)]

--- a/vm/vm-status-translator/Cargo.toml
+++ b/vm/vm-status-translator/Cargo.toml
@@ -11,4 +11,4 @@ serde = "~1"
 anyhow = "~1"
 starcoin-vm-types = {path = "../types"}
 starcoin-move-explain = {path = "../move-explain"}
-schemars = {git = "https://github.com/starcoinorg/schemars", rev="0dabf7726f1d856ea18df685c10e51d6fae53e8c"}
+schemars = {git = "https://github.com/starcoinorg/schemars", rev="4d4f930c3d4428d5ad800f70c7b9e7d823e55a7c"}


### PR DESCRIPTION
ensure native cost table len equals native functions len, fix

```
move unit-test src unittest -f test_verify_sig
Running Move unit tests
thread '<unnamed>' panicked at 'index out of bounds: the len is 21 but the index is 22', /Users/badu/.cargo/git/checkouts/diem-5aa6d6b8b0487904/5a8ea73/language/move-core/types/src/gas_schedule.rs:251:10
stack backtrace:
   0:        0x1017768c4 - std::backtrace_rs::backtrace::libunwind::trace::hd9b9204470182ffc
                               at /rustc/c8dfcfe046a7680554bf4eb612bad840e7631c4b/library/std/src/../../backtrace/src/backtrace/libunwind.rs:90:5
```

diem update: https://github.com/starcoinorg/diem/pull/210