### PR TITLE
[proof] Implement TransactionInfoWithProof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8599,6 +8599,8 @@ dependencies = [
  "once_cell",
  "proptest",
  "proptest-derive",
+ "rand 0.8.4",
+ "rand_core 0.6.3",
  "sp-utils",
  "starcoin-account-api",
  "starcoin-accumulator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8639,6 +8639,7 @@ dependencies = [
  "rand 0.8.4",
  "rand_core 0.6.3",
  "serde",
+ "starcoin-accumulator",
  "starcoin-crypto",
  "starcoin-service-registry",
  "starcoin-state-api",

--- a/account/api/src/rich_wallet.rs
+++ b/account/api/src/rich_wallet.rs
@@ -1,24 +1,15 @@
 use anyhow::Result;
-use futures::Stream;
 use serde::de::{MapAccess, Visitor};
 use serde::Serialize;
 use serde::{Deserialize, Deserializer};
 use starcoin_types::account_address::AccountAddress;
 use starcoin_types::account_config::token_code::TokenCode;
 use starcoin_types::account_config::STC_TOKEN_CODE;
-use starcoin_types::contract_event::EventWithProof;
-use starcoin_types::event::EventKey;
 use starcoin_types::transaction::{RawUserTransaction, SignedUserTransaction, TransactionPayload};
 use std::fmt;
 use std::marker::PhantomData;
 use std::str::FromStr;
 use std::time::Duration;
-
-pub trait ChainEventWatcher {
-    fn watch_event<S>(&self, key: EventKey) -> S
-    where
-        S: Stream<Item = EventWithProof>;
-}
 
 pub trait TransactionSubmitter {
     fn submit_transaction(&self, txn: SignedUserTransaction) -> Result<()>;

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -30,6 +30,8 @@ starcoin-vm-types = { path = "../vm/types"}
 proptest = { version = "1.0.0", default-features = false, optional = true }
 proptest-derive = { version = "0.3.0", default-features = false, optional = true }
 sp-utils = {path = "../commons/utils"}
+rand = "0.8.4"
+rand_core = { version = "0.6.3", default-features = false }
 
 [dev-dependencies]
 stdlib = { path = "../vm/stdlib" }

--- a/chain/api/Cargo.toml
+++ b/chain/api/Cargo.toml
@@ -20,6 +20,7 @@ starcoin-service-registry = { path = "../../commons/service-registry" }
 starcoin-vm-types = { path = "../../vm/types" }
 starcoin-state-api = { path = "../../state/api" }
 network-api = {package="network-api", path="../../network/api"}
+starcoin-accumulator = { path = "../../commons/accumulator"}
 
 [dev-dependencies]
 

--- a/chain/api/src/chain.rs
+++ b/chain/api/src/chain.rs
@@ -88,7 +88,7 @@ pub trait ChainReader {
         index: u64,
         event_index: Option<u64>,
         access_path: Option<AccessPath>,
-    ) -> Result<TransactionInfoWithProof>;
+    ) -> Result<Option<TransactionInfoWithProof>>;
 }
 
 pub trait ChainWriter {

--- a/chain/api/src/chain.rs
+++ b/chain/api/src/chain.rs
@@ -16,7 +16,10 @@ use starcoin_vm_types::on_chain_resource::Epoch;
 use starcoin_vm_types::time::TimeService;
 use std::collections::HashMap;
 
+use crate::TransactionProof;
 pub use starcoin_types::block::ExecutedBlock;
+use starcoin_vm_types::access_path::AccessPath;
+
 pub struct VerifiedBlock(pub Block);
 pub type MintedUncleNumber = u64;
 
@@ -69,12 +72,20 @@ pub trait ChainReader {
     /// Execute block and verify it execute state, and save result base current chain, but do not change current chain.
     fn execute(&self, block: VerifiedBlock) -> Result<ExecutedBlock>;
     /// Get chain transaction infos
-    fn get_txn_infos(
+    fn get_transaction_infos(
         &self,
         start_index: u64,
         reverse: bool,
         max_size: u64,
     ) -> Result<Vec<BlockTransactionInfo>>;
+
+    /// Get transaction info by accumulator leaf index
+    fn get_transaction_proof(
+        &self,
+        index: u64,
+        event_index: Option<u64>,
+        access_path: Option<AccessPath>,
+    ) -> Result<Option<TransactionProof>>;
 }
 
 pub trait ChainWriter {

--- a/chain/api/src/chain.rs
+++ b/chain/api/src/chain.rs
@@ -16,9 +16,10 @@ use starcoin_vm_types::on_chain_resource::Epoch;
 use starcoin_vm_types::time::TimeService;
 use std::collections::HashMap;
 
-use crate::TransactionProof;
+use crate::TransactionInfoWithProof;
 pub use starcoin_types::block::ExecutedBlock;
 use starcoin_vm_types::access_path::AccessPath;
+use starcoin_vm_types::contract_event::ContractEvent;
 
 pub struct VerifiedBlock(pub Block);
 pub type MintedUncleNumber = u64;
@@ -79,13 +80,15 @@ pub trait ChainReader {
         max_size: u64,
     ) -> Result<Vec<BlockTransactionInfo>>;
 
+    fn get_events(&self, txn_info_id: HashValue) -> Result<Option<Vec<ContractEvent>>>;
+
     /// Get transaction info by accumulator leaf index
     fn get_transaction_proof(
         &self,
         index: u64,
         event_index: Option<u64>,
         access_path: Option<AccessPath>,
-    ) -> Result<Option<TransactionProof>>;
+    ) -> Result<TransactionInfoWithProof>;
 }
 
 pub trait ChainWriter {

--- a/chain/api/src/lib.rs
+++ b/chain/api/src/lib.rs
@@ -2,6 +2,9 @@
 // SPDX-License-Identifier: Apache-2
 #![deny(clippy::integer_arithmetic)]
 
+use serde::{Deserialize, Serialize};
+use starcoin_accumulator::proof::AccumulatorProof;
+use starcoin_state_api::{StateProof, StateWithProof};
 use starcoin_vm_types::transaction::SignedUserTransaction;
 
 mod chain;
@@ -18,3 +21,17 @@ pub struct ExcludedTxns {
 pub use chain::{Chain, ChainReader, ChainWriter, ExecutedBlock, MintedUncleNumber, VerifiedBlock};
 pub use errors::*;
 pub use service::{ChainAsyncService, ReadableChainService, WriteableChainService};
+use starcoin_vm_types::contract_event::ContractEvent;
+
+#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+pub struct EventWithProof {
+    pub event: ContractEvent,
+    pub proof: AccumulatorProof,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
+pub struct TransactionProof {
+    pub txn_proof: AccumulatorProof,
+    pub event_proof: Option<EventWithProof>,
+    pub state_proof: Option<StateWithProof>,
+}

--- a/chain/api/src/lib.rs
+++ b/chain/api/src/lib.rs
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2
 #![deny(clippy::integer_arithmetic)]
 
+use anyhow::{bail, format_err, Result};
 use serde::{Deserialize, Serialize};
 use starcoin_accumulator::proof::AccumulatorProof;
-use starcoin_state_api::{StateProof, StateWithProof};
-use starcoin_vm_types::transaction::SignedUserTransaction;
+use starcoin_state_api::StateWithProof;
+use starcoin_vm_types::transaction::{SignedUserTransaction, TransactionInfo};
 
 mod chain;
 mod errors;
@@ -21,6 +22,9 @@ pub struct ExcludedTxns {
 pub use chain::{Chain, ChainReader, ChainWriter, ExecutedBlock, MintedUncleNumber, VerifiedBlock};
 pub use errors::*;
 pub use service::{ChainAsyncService, ReadableChainService, WriteableChainService};
+use starcoin_crypto::hash::PlainCryptoHash;
+use starcoin_crypto::HashValue;
+use starcoin_vm_types::access_path::AccessPath;
 use starcoin_vm_types::contract_event::ContractEvent;
 
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
@@ -29,9 +33,74 @@ pub struct EventWithProof {
     pub proof: AccumulatorProof,
 }
 
+impl EventWithProof {
+    pub fn verify(&self, expect_root: HashValue, event_index: u64) -> Result<()> {
+        self.proof
+            .verify(expect_root, self.event.crypto_hash(), event_index)
+    }
+}
+
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize)]
-pub struct TransactionProof {
-    pub txn_proof: AccumulatorProof,
+pub struct TransactionInfoWithProof {
+    pub transaction_info: TransactionInfo,
+    pub proof: AccumulatorProof,
     pub event_proof: Option<EventWithProof>,
     pub state_proof: Option<StateWithProof>,
+}
+
+impl TransactionInfoWithProof {
+    pub fn verify(
+        &self,
+        expect_root: HashValue,
+        transaction_index: u64,
+        event_index: Option<u64>,
+        access_path: Option<AccessPath>,
+    ) -> Result<()> {
+        self.proof
+            .verify(
+                expect_root,
+                self.transaction_info.crypto_hash(),
+                transaction_index,
+            )
+            .map_err(|e| format_err!("transaction info proof verify failed: {}", e))?;
+        match (self.event_proof.as_ref(), event_index) {
+            (Some(event_proof), Some(event_index)) => {
+                event_proof
+                    .verify(self.transaction_info.event_root_hash(), event_index)
+                    .map_err(|e| format_err!("event proof verify failed: {}", e))?;
+            }
+            (Some(_), None) => {
+                // skip
+            }
+            (None, None) => {
+                // skip
+            }
+            (None, Some(event_index)) => {
+                bail!(
+                    "TransactionInfoWithProof's event_proof is None, cannot verify event_index: {}",
+                    event_index
+                );
+            }
+        };
+        match (self.state_proof.as_ref(), access_path) {
+            (Some(state_proof), Some(access_path)) => {
+                state_proof
+                    .verify(self.transaction_info.state_root_hash(), access_path)
+                    .map_err(|e| format_err!("state proof verify failed: {}", e))?;
+            }
+            (Some(_), None) => {
+                // skip
+            }
+            (None, None) => {
+                // skip
+            }
+            (None, Some(access_path)) => {
+                bail!(
+                    "TransactionInfoWithProof's state_proof is None, cannot verify access_path: {}",
+                    access_path
+                );
+            }
+        };
+        Ok(())
+    }
 }

--- a/chain/service/src/chain_service.rs
+++ b/chain/service/src/chain_service.rs
@@ -385,7 +385,8 @@ impl ReadableChainService for ChainReaderServiceInner {
         reverse: bool,
         max_size: u64,
     ) -> Result<Vec<BlockTransactionInfo>> {
-        self.main.get_transaction_infos(start_index, reverse, max_size)
+        self.main
+            .get_transaction_infos(start_index, reverse, max_size)
     }
 }
 

--- a/chain/service/src/chain_service.rs
+++ b/chain/service/src/chain_service.rs
@@ -385,7 +385,7 @@ impl ReadableChainService for ChainReaderServiceInner {
         reverse: bool,
         max_size: u64,
     ) -> Result<Vec<BlockTransactionInfo>> {
-        self.main.get_txn_infos(start_index, reverse, max_size)
+        self.main.get_transaction_infos(start_index, reverse, max_size)
     }
 }
 

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -773,9 +773,13 @@ impl ChainReader for BlockChain {
         index: u64,
         event_index: Option<u64>,
         access_path: Option<AccessPath>,
-    ) -> Result<TransactionInfoWithProof> {
-        let txn_proof = self.txn_accumulator.get_proof(index)?;
+    ) -> Result<Option<TransactionInfoWithProof>> {
+        let txn_proof = match self.txn_accumulator.get_proof(index)? {
+            Some(proof) => proof,
+            None => return Ok(None),
+        };
 
+        //if can get proof by leaf_index, the leaf and transaction info should exist.
         let txn_info_hash = self
             .txn_accumulator
             .get_leaf(index)?
@@ -812,12 +816,12 @@ impl ChainReader for BlockChain {
         } else {
             None
         };
-        Ok(TransactionInfoWithProof {
+        Ok(Some(TransactionInfoWithProof {
             transaction_info: transaction_info.txn_info,
             proof: txn_proof,
             event_proof,
             state_proof,
-        })
+        }))
     }
 }
 

--- a/chain/tests/test_proof.rs
+++ b/chain/tests/test_proof.rs
@@ -1,0 +1,117 @@
+use anyhow::Result;
+use consensus::Consensus;
+use logger::prelude::debug;
+use rand::Rng;
+use starcoin_account_api::AccountInfo;
+use starcoin_accumulator::Accumulator;
+use starcoin_chain_api::{ChainReader, ChainWriter};
+use starcoin_config::NodeConfig;
+use starcoin_transaction_builder::{peer_to_peer_txn_sent_as_association, DEFAULT_EXPIRATION_TIME};
+use starcoin_vm_types::account_address::AccountAddress;
+use starcoin_vm_types::transaction::Transaction;
+use std::sync::Arc;
+
+#[stest::test(timeout = 480)]
+fn test_transaction_info_proof() -> Result<()> {
+    let config = Arc::new(NodeConfig::random_for_test());
+    let mut block_chain = test_helper::gen_blockchain_for_test(config.net())?;
+    let mut parent_header = block_chain.current_header();
+    let miner_account = AccountInfo::random();
+
+    let mut rng = rand::thread_rng();
+
+    let block_count: u64 = rng.gen_range(2..10);
+    let mut seq_number = 0;
+    let mut all_txns = vec![];
+    let mut all_address = vec![];
+    println!(
+        "txn accumulator info: {:?}",
+        block_chain.get_txn_accumulator().get_info()
+    );
+    let genesis_block = block_chain.get_block_by_number(0).unwrap().unwrap();
+    //put the genesis txn and genesis block metadata txn
+    all_txns.push(Transaction::UserTransaction(
+        genesis_block.body.transactions.get(0).cloned().unwrap(),
+    ));
+
+    all_txns.push(Transaction::BlockMetadata(genesis_block.to_metadata(0)));
+
+    (0..block_count).for_each(|_block_idx| {
+        let txn_count: u64 = rng.gen_range(1..10);
+        let txns = (0..txn_count)
+            .map(|_txn_idx| {
+                let account_address = AccountAddress::random();
+                all_address.push(account_address);
+                let txn = peer_to_peer_txn_sent_as_association(
+                    account_address,
+                    seq_number,
+                    10000,
+                    config.net().time_service().now_secs() + DEFAULT_EXPIRATION_TIME,
+                    config.net(),
+                );
+                seq_number += 1;
+                all_txns.push(Transaction::UserTransaction(txn.clone()));
+                txn
+            })
+            .collect();
+
+        let (template, _) = block_chain
+            .create_block_template(
+                *miner_account.address(),
+                Some(parent_header.id()),
+                txns,
+                vec![],
+                None,
+            )
+            .unwrap();
+
+        let block = block_chain
+            .consensus()
+            .create_block(template, config.net().time_service().as_ref())
+            .unwrap();
+        block_chain.apply(block.clone()).unwrap();
+        all_txns.push(Transaction::BlockMetadata(
+            block.to_metadata(parent_header.gas_used()),
+        ));
+        parent_header = block.header().clone();
+    });
+
+    let txn_index = rng.gen_range(0..all_txns.len());
+    debug!("all txns len: {}, txn index:{}", all_txns.len(), txn_index);
+
+    let txn = all_txns.get(txn_index).cloned().unwrap();
+    let txn_hash = txn.id();
+    let txn_info = block_chain.get_transaction_info(txn_hash)?.unwrap();
+
+    let txn_info_leaf = block_chain
+        .get_txn_accumulator()
+        .get_leaf(txn_index as u64)?
+        .unwrap();
+    assert_eq!(txn_info.txn_info.id(), txn_info_leaf);
+
+    let events = block_chain.get_events(txn_info.txn_info.id())?.unwrap();
+    let event_index = rng.gen_range(0..events.len()) as u64;
+    //let address_index = rng.gen_range(0..all_address.len());
+    //let addr = all_address.get(address_index).cloned().unwrap();
+    // let access_path =
+    //     AccessPath::resource_access_path(association_address(), AccountResource::struct_tag());
+    //let txn_block = block_chain.get_block(txn_info.block_id)?.unwrap();
+
+    let txn_proof = block_chain.get_transaction_proof(txn_index as u64, Some(event_index), None)?;
+
+    let result = txn_proof.verify(
+        block_chain.current_header().txn_accumulator_root(),
+        txn_index as u64,
+        Some(event_index),
+        None,
+    );
+
+    assert!(
+        result.is_ok(),
+        "{:?} verify failed, reason: {:?}",
+        txn_proof,
+        result.err().unwrap()
+    );
+
+    Ok(())
+}

--- a/chain/tests/test_proof.rs
+++ b/chain/tests/test_proof.rs
@@ -106,11 +106,9 @@ fn test_transaction_info_proof() -> Result<()> {
         let access_path: Option<AccessPath> = None;
         //AccessPath::resource_access_path(association_address(), AccountResource::struct_tag());
 
-        let txn_proof = block_chain.get_transaction_proof(
-            txn_index as u64,
-            Some(event_index),
-            access_path.clone(),
-        )?;
+        let txn_proof = block_chain
+            .get_transaction_proof(txn_index as u64, Some(event_index), access_path.clone())?
+            .expect("get transaction proof return none");
 
         let result = txn_proof.verify(
             block_chain.current_header().txn_accumulator_root(),

--- a/commons/accumulator/src/accumulator_test.rs
+++ b/commons/accumulator/src/accumulator_test.rs
@@ -324,7 +324,7 @@ fn proof_verify(
 ) {
     leaves.iter().enumerate().for_each(|(i, hash)| {
         let leaf_index = first_leaf_idx + i as u64;
-        let proof = accumulator.get_proof(leaf_index).unwrap();
+        let proof = accumulator.get_proof(leaf_index).unwrap().unwrap();
         assert!(
             proof.verify(root_hash, *hash, leaf_index).is_ok(),
             "leaf_index:{}, proof:{:?} verify failed",

--- a/commons/accumulator/src/accumulator_test.rs
+++ b/commons/accumulator/src/accumulator_test.rs
@@ -326,7 +326,7 @@ fn proof_verify(
         let leaf_index = first_leaf_idx + i as u64;
         let proof = accumulator.get_proof(leaf_index).unwrap();
         assert!(
-            proof.verify(root_hash, *hash, leaf_index).unwrap(),
+            proof.verify(root_hash, *hash, leaf_index).is_ok(),
             "leaf_index:{}, proof:{:?} verify failed",
             leaf_index,
             proof

--- a/commons/accumulator/src/accumulator_test.rs
+++ b/commons/accumulator/src/accumulator_test.rs
@@ -79,7 +79,7 @@ fn test_error_on_bad_parameters() {
         0,
         Arc::new(mock_store),
     );
-    assert!(accumulator.get_proof(10).is_err());
+    assert!(accumulator.get_proof(10).unwrap().is_none());
 }
 
 #[test]

--- a/commons/accumulator/src/inmemory/accumulator_test.rs
+++ b/commons/accumulator/src/inmemory/accumulator_test.rs
@@ -138,7 +138,7 @@ fn test_proof() {
     assert!(
         proof
             .verify(root, leaves[leaf_index as usize], leaf_index)
-            .unwrap(),
+            .is_ok(),
         "leaf_index {}, proof: {:?} verify failed",
         leaf_index,
         proof

--- a/commons/accumulator/src/lib.rs
+++ b/commons/accumulator/src/lib.rs
@@ -168,7 +168,7 @@ impl Accumulator for MerkleAccumulator {
 
     fn get_proof(&self, leaf_index: u64) -> Result<Option<AccumulatorProof>> {
         let mut tree_guard = self.tree.lock();
-        if leaf_index < tree_guard.num_leaves as u64 {
+        if leaf_index > tree_guard.num_leaves as u64 {
             return Ok(None);
         }
 

--- a/commons/accumulator/src/lib.rs
+++ b/commons/accumulator/src/lib.rs
@@ -5,7 +5,7 @@ use crate::accumulator_info::AccumulatorInfo;
 use crate::node_index::NodeIndex;
 use crate::proof::AccumulatorProof;
 use crate::tree::AccumulatorTree;
-use anyhow::{ensure, format_err, Result};
+use anyhow::{format_err, Result};
 pub use node::AccumulatorNode;
 use parking_lot::Mutex;
 use starcoin_crypto::HashValue;
@@ -40,7 +40,7 @@ pub trait Accumulator {
     /// Get node by position.
     fn get_node_by_position(&self, position: u64) -> Result<Option<HashValue>>;
     /// Get proof by leaf index.
-    fn get_proof(&self, leaf_index: u64) -> Result<AccumulatorProof>;
+    fn get_proof(&self, leaf_index: u64) -> Result<Option<AccumulatorProof>>;
     /// Flush node to storage.
     fn flush(&self) -> Result<()>;
     /// Get current accumulator tree root hash.
@@ -166,17 +166,14 @@ impl Accumulator for MerkleAccumulator {
             .get_node_hash(NodeIndex::from_inorder_index(position))
     }
 
-    fn get_proof(&self, leaf_index: u64) -> Result<AccumulatorProof> {
+    fn get_proof(&self, leaf_index: u64) -> Result<Option<AccumulatorProof>> {
         let mut tree_guard = self.tree.lock();
-        ensure!(
-            leaf_index < tree_guard.num_leaves as u64,
-            "get proof invalid leaf_index {}, num_leaves {}",
-            leaf_index,
-            tree_guard.num_leaves
-        );
+        if leaf_index < tree_guard.num_leaves as u64 {
+            return Ok(None);
+        }
 
         let siblings = tree_guard.get_siblings(leaf_index, |_p| true)?;
-        Ok(AccumulatorProof::new(siblings))
+        Ok(Some(AccumulatorProof::new(siblings)))
     }
 
     fn flush(&self) -> Result<()> {

--- a/commons/accumulator/src/lib.rs
+++ b/commons/accumulator/src/lib.rs
@@ -18,7 +18,7 @@ mod accumulator_test;
 pub mod inmemory;
 pub mod node;
 pub mod node_index;
-mod proof;
+pub mod proof;
 mod tree;
 pub mod tree_store;
 

--- a/commons/accumulator/src/proof/mod.rs
+++ b/commons/accumulator/src/proof/mod.rs
@@ -33,7 +33,7 @@ impl AccumulatorProof {
         expected_root_hash: HashValue,
         element_hash: HashValue,
         element_index: u64,
-    ) -> Result<bool> {
+    ) -> Result<()> {
         ensure!(
             self.siblings.len() <= MAX_ACCUMULATOR_PROOF_DEPTH,
             "Accumulator proof has more than {} ({}) siblings.",
@@ -71,6 +71,12 @@ impl AccumulatorProof {
                 },
             )
             .0;
-        Ok(actual_root_hash == expected_root_hash)
+        ensure!(
+            actual_root_hash == expected_root_hash,
+            "Root hashes do not match. Actual root hash: {:x}. Expected root hash: {:x}.",
+            actual_root_hash,
+            expected_root_hash
+        );
+        Ok(())
     }
 }

--- a/contrib-contracts/src/starcoin_merkle_test.rs
+++ b/contrib-contracts/src/starcoin_merkle_test.rs
@@ -62,7 +62,7 @@ fn test_starcoin_merkle() -> Result<()> {
 
     {
         // change to previout state root.
-        let old_chain_state = chain_state.change_root(state_root);
+        let old_chain_state = chain_state.fork_at(state_root);
         // let state_root = chain_state.state_root();
         let _expected_root = MoveValue::vector_u8(state_root.to_vec());
 

--- a/state/api/src/chain_state.rs
+++ b/state/api/src/chain_state.rs
@@ -109,6 +109,11 @@ impl StateWithProof {
     pub fn get_state(&self) -> &Option<Vec<u8>> {
         &self.state
     }
+
+    pub fn verify(&self, expect_root: HashValue, access_path: AccessPath) -> Result<()> {
+        self.proof
+            .verify(expect_root, access_path, self.state.as_deref())
+    }
 }
 
 pub trait ChainStateReader: StateView {

--- a/state/service/src/service.rs
+++ b/state/service/src/service.rs
@@ -143,7 +143,7 @@ impl Inner {
     ) -> Result<Option<AccountStateSet>> {
         match state_root {
             Some(root) => {
-                let reader = self.state_db.change_root(root);
+                let reader = self.state_db.fork_at(root);
                 reader.get_account_state_set(&address)
             }
             None => self.get_account_state_set(&address),
@@ -155,7 +155,7 @@ impl Inner {
         access_path: AccessPath,
         state_root: HashValue,
     ) -> Result<StateWithProof> {
-        let reader = self.state_db.change_root(state_root);
+        let reader = self.state_db.fork_at(state_root);
         reader.get_with_proof(&access_path)
     }
 
@@ -164,12 +164,12 @@ impl Inner {
         account: AccountAddress,
         state_root: HashValue,
     ) -> Result<Option<AccountState>> {
-        let reader = self.state_db.change_root(state_root);
+        let reader = self.state_db.fork_at(state_root);
         reader.get_account_state(&account)
     }
 
     pub(crate) fn change_root(&mut self, state_root: HashValue) {
-        self.state_db = self.state_db.change_root(state_root);
+        self.state_db = self.state_db.fork_at(state_root);
         self.adjust_time();
     }
 

--- a/state/statedb/src/lib.rs
+++ b/state/statedb/src/lib.rs
@@ -235,11 +235,11 @@ impl ChainStateDB {
         Self::new(self.store.clone(), Some(self.state_root()))
     }
 
-    //TODO implements a change_root ChainStateReader
-    pub fn change_root(&self, root_hash: HashValue) -> Self {
+    /// Fork a new statedb at `root_hash`
+    pub fn fork_at(&self, state_root: HashValue) -> Self {
         Self {
             store: self.store.clone(),
-            state_tree: StateTree::new(self.store.clone(), Some(root_hash)),
+            state_tree: StateTree::new(self.store.clone(), Some(state_root)),
             cache: Mutex::new(LruCache::new(DEFAULT_CACHE_SIZE)),
             updates: RwLock::new(HashSet::new()),
         }

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -390,9 +390,9 @@ impl BlockTransactionInfoStore for Storage {
         txn_hash: HashValue,
     ) -> Result<Vec<BlockTransactionInfo>, Error> {
         let mut transaction_info_vec = vec![];
-        if let Ok(Some(transaction_info_ids)) = self.transaction_info_hash_storage.get(txn_hash) {
+        if let Some(transaction_info_ids) = self.transaction_info_hash_storage.get(txn_hash)? {
             for id in transaction_info_ids {
-                if let Ok(Some(transaction_info)) = self.get_transaction_info(id) {
+                if let Some(transaction_info) = self.get_transaction_info(id)? {
                     transaction_info_vec.push(transaction_info);
                 }
             }

--- a/storage/src/transaction_info/mod.rs
+++ b/storage/src/transaction_info/mod.rs
@@ -52,7 +52,7 @@ impl TransactionInfoHashStorage {
     ) -> Result<(), Error> {
         let mut batch = CodecWriteBatch::new();
         for txn_info in vec_txn_info {
-            if let Ok(Some(mut id_vec)) = self.get(txn_info.transaction_hash()) {
+            if let Some(mut id_vec) = self.get(txn_info.transaction_hash())? {
                 id_vec.push(txn_info.id());
                 batch.put(txn_info.transaction_hash(), id_vec)?;
             } else {

--- a/vm/types/src/contract_event.rs
+++ b/vm/types/src/contract_event.rs
@@ -124,6 +124,3 @@ impl std::fmt::Display for ContractEvent {
         write!(f, "{:?}", self)
     }
 }
-
-//TODO implement EventWithProof
-pub struct EventWithProof {}

--- a/vm/types/src/transaction/mod.rs
+++ b/vm/types/src/transaction/mod.rs
@@ -785,8 +785,8 @@ impl Sample for TransactionInfo {
 /// We cannot put the block_id into txn_info, because txn_info is accumulated into block header.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct BlockTransactionInfo {
-    block_id: HashValue,
-    txn_info: TransactionInfo,
+    pub block_id: HashValue,
+    pub txn_info: TransactionInfo,
 }
 
 impl Deref for BlockTransactionInfo {


### PR DESCRIPTION
base on pr #3039 


TODO,将在后面的一系列 pr 中完成. 

1. 定义获取 transaction info proof 的 RPC 接口.
2. 当前获取 transaction info proof 需要 transaction 在全局的 accumulator 中的 index, 但尚未提供获取 txn 全局 index 的方法, 需要提供.
3. transaction info proof 同时可以包含 event proof 和 state proof, 但 state proof 当前尚不可用.