### PR TITLE
[devex] add Move syntax highlighting on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Best-effort syntax highlighting for Move: just use Rust highlighter
+*.move linguist-language=Rust


### PR DESCRIPTION
Should make it nicer to review PR's and browse Move code on GitHub.