### PR TITLE
fix: stdlib U256 native function verification workaround

### DIFF
--- a/vm/stdlib/compiled/latest/doc/U256.md
+++ b/vm/stdlib/compiled/latest/doc/U256.md
@@ -32,6 +32,14 @@ Implementation u256.
 -  [Function `native_rem`](#0x1_U256_native_rem)
 -  [Function `native_pow`](#0x1_U256_native_pow)
 -  [Specification](#@Specification_1)
+    -  [Function `from_u128`](#@Specification_1_from_u128)
+    -  [Function `to_u128`](#@Specification_1_to_u128)
+    -  [Function `add`](#@Specification_1_add)
+    -  [Function `sub`](#@Specification_1_sub)
+    -  [Function `mul`](#@Specification_1_mul)
+    -  [Function `div`](#@Specification_1_div)
+    -  [Function `rem`](#@Specification_1_rem)
+    -  [Function `pow`](#@Specification_1_pow)
 
 
 <pre><code><b>use</b> <a href="U256.md#0x1_Arith">0x1::Arith</a>;
@@ -733,4 +741,160 @@ move implementation of native_sub.
 
 
 <pre><code><b>pragma</b> verify = <b>false</b>;
+</code></pre>
+
+
+
+
+<a name="0x1_U256_value_of_U256"></a>
+
+
+<pre><code><b>fun</b> <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(a: <a href="U256.md#0x1_U256">U256</a>): num {
+   ( a.bits[0]             // 0 * 64
+     + a.bits[1] &lt;&lt; 64     // 1 * 64
+     + a.bits[2] &lt;&lt; 128    // 2 * 64
+     + a.bits[3] &lt;&lt; 192    // 3 * 64
+   )
+}
+</code></pre>
+
+
+
+<a name="@Specification_1_from_u128"></a>
+
+### Function `from_u128`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="U256.md#0x1_U256_from_u128">from_u128</a>(v: u128): <a href="U256.md#0x1_U256_U256">U256::U256</a>
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>ensures</b> <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(result) == v;
+</code></pre>
+
+
+
+<a name="@Specification_1_to_u128"></a>
+
+### Function `to_u128`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="U256.md#0x1_U256_to_u128">to_u128</a>(v: &<a href="U256.md#0x1_U256_U256">U256::U256</a>): u128
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(v) &gt;= (1 &lt;&lt; 128);
+<b>ensures</b> <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(v) == result;
+</code></pre>
+
+
+
+<a name="@Specification_1_add"></a>
+
+### Function `add`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="U256.md#0x1_U256_add">add</a>(a: <a href="U256.md#0x1_U256_U256">U256::U256</a>, b: <a href="U256.md#0x1_U256_U256">U256::U256</a>): <a href="U256.md#0x1_U256_U256">U256::U256</a>
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(a) + <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(b) &gt;= (1 &lt;&lt; 256);
+<b>ensures</b> <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(result) == <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(a) + <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(b);
+</code></pre>
+
+
+
+<a name="@Specification_1_sub"></a>
+
+### Function `sub`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="U256.md#0x1_U256_sub">sub</a>(a: <a href="U256.md#0x1_U256_U256">U256::U256</a>, b: <a href="U256.md#0x1_U256_U256">U256::U256</a>): <a href="U256.md#0x1_U256_U256">U256::U256</a>
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(a) &gt; <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(b);
+<b>ensures</b> <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(result) == <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(a) - <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(b);
+</code></pre>
+
+
+
+<a name="@Specification_1_mul"></a>
+
+### Function `mul`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="U256.md#0x1_U256_mul">mul</a>(a: <a href="U256.md#0x1_U256_U256">U256::U256</a>, b: <a href="U256.md#0x1_U256_U256">U256::U256</a>): <a href="U256.md#0x1_U256_U256">U256::U256</a>
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(a) * <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(b) &gt;= (1 &lt;&lt; 256);
+<b>ensures</b> <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(result) == <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(a) * <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(b);
+</code></pre>
+
+
+
+<a name="@Specification_1_div"></a>
+
+### Function `div`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="U256.md#0x1_U256_div">div</a>(a: <a href="U256.md#0x1_U256_U256">U256::U256</a>, b: <a href="U256.md#0x1_U256_U256">U256::U256</a>): <a href="U256.md#0x1_U256_U256">U256::U256</a>
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(b) == 0;
+<b>ensures</b> <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(result) == <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(a) / <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(b);
+</code></pre>
+
+
+
+<a name="@Specification_1_rem"></a>
+
+### Function `rem`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="U256.md#0x1_U256_rem">rem</a>(a: <a href="U256.md#0x1_U256_U256">U256::U256</a>, b: <a href="U256.md#0x1_U256_U256">U256::U256</a>): <a href="U256.md#0x1_U256_U256">U256::U256</a>
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>aborts_if</b> <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(b) == 0;
+<b>ensures</b> <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(result) == <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(a) % <a href="U256.md#0x1_U256_value_of_U256">value_of_U256</a>(b);
+</code></pre>
+
+
+
+<a name="@Specification_1_pow"></a>
+
+### Function `pow`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="U256.md#0x1_U256_pow">pow</a>(a: <a href="U256.md#0x1_U256_U256">U256::U256</a>, b: <a href="U256.md#0x1_U256_U256">U256::U256</a>): <a href="U256.md#0x1_U256_U256">U256::U256</a>
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
 </code></pre>

--- a/vm/stdlib/sources/U256.move
+++ b/vm/stdlib/sources/U256.move
@@ -292,5 +292,66 @@ module U256 {
     native fun native_div(a: &mut U256, b: &U256);
     native fun native_rem(a: &mut U256, b: &U256);
     native fun native_pow(a: &mut U256, b: &U256);
+
+    spec fun value_of_U256(a: U256): num {
+        ( a.bits[0]             // 0 * 64
+          + a.bits[1] << 64     // 1 * 64
+          + a.bits[2] << 128    // 2 * 64
+          + a.bits[3] << 192    // 3 * 64
+        )
+    }
+
+    spec from_u128 {
+        pragma opaque;
+        ensures value_of_U256(result) == v;
+    }
+
+    spec to_u128 {
+        pragma opaque;
+        aborts_if value_of_U256(v) >= (1 << 128);
+        ensures value_of_U256(v) == result;
+    }
+
+    spec add {
+        pragma opaque;
+        // TODO: mvp doesn't seem to be using these specs
+        aborts_if value_of_U256(a) + value_of_U256(b) >= (1 << 256);
+        ensures value_of_U256(result) == value_of_U256(a) + value_of_U256(b);
+    }
+
+    spec sub {
+        pragma opaque;
+        // TODO: mvp doesn't seem to be using these specs
+        aborts_if value_of_U256(a) > value_of_U256(b);
+        ensures value_of_U256(result) == value_of_U256(a) - value_of_U256(b);
+    }
+
+    spec mul {
+        pragma opaque;
+        // TODO: mvp doesn't seem to be using these specs
+        aborts_if value_of_U256(a) * value_of_U256(b) >= (1 << 256);
+        ensures value_of_U256(result) == value_of_U256(a) * value_of_U256(b);
+    }
+
+    spec div {
+        pragma opaque;
+        // TODO: mvp doesn't seem to be using these specs
+        aborts_if value_of_U256(b) == 0;
+        ensures value_of_U256(result) == value_of_U256(a) / value_of_U256(b);
+    }
+
+    spec rem {
+        pragma opaque;
+        // TODO: mvp doesn't seem to be using these specs
+        aborts_if value_of_U256(b) == 0;
+        ensures value_of_U256(result) == value_of_U256(a) % value_of_U256(b);
+    }
+
+    spec pow {
+        pragma opaque;
+        // TODO: mvp doesn't seem to be using these specs
+        // aborts_if value_of_U256(a) * value_of_U256(b) >= (1 << 256);
+        // ensures value_of_U256(result) == value_of_U256(a) / value_of_U256(b);
+    }
 }
 }


### PR DESCRIPTION
- Add `pragma opaque` to arithmetic functions that invoke native functions;
- Specification for them added (TODO: but doesn't seem to be used by MVP);
- `U256.md` updated.