### PR TITLE
[rpc] Do not raise error when decode resource or resolve module failed

### DIFF
--- a/rpc/server/src/module/state_rpc.rs
+++ b/rpc/server/src/module/state_rpc.rs
@@ -243,10 +243,9 @@ where
                         .map(|(k, v)| {
                             let struct_tag = StructTag::decode(k.as_slice())?;
                             let decoded = if option.decode {
-                                Some(
-                                    view_resource(&statedb, struct_tag.clone(), v.as_slice())?
-                                        .into(),
-                                )
+                                view_resource(&statedb, struct_tag.clone(), v.as_slice())
+                                    .ok()
+                                    .map(Into::into)
                             } else {
                                 None
                             };
@@ -296,7 +295,8 @@ where
                             let identifier = Identifier::decode(k.as_slice())?;
                             let module_id = ModuleId::new(addr, identifier.clone());
                             let abi = if option.resolve {
-                                Some(ABIResolver::new(&statedb).resolve_module(&module_id)?)
+                                //ignore the resolve error
+                                ABIResolver::new(&statedb).resolve_module(&module_id).ok()
                             } else {
                                 None
                             };

--- a/rpc/server/src/module/state_rpc.rs
+++ b/rpc/server/src/module/state_rpc.rs
@@ -243,6 +243,7 @@ where
                         .map(|(k, v)| {
                             let struct_tag = StructTag::decode(k.as_slice())?;
                             let decoded = if option.decode {
+                                //ignore the resource decode error
                                 view_resource(&statedb, struct_tag.clone(), v.as_slice())
                                     .ok()
                                     .map(Into::into)


### PR DESCRIPTION
if the resource format is not compatible with the Struct, just ignore the error, and do not return decoded resource.