### PR TITLE
[move] Update move for fix StructTag json compatibility bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,7 +850,7 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -4975,7 +4975,7 @@ checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4992,7 +4992,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "mirai-annotations",
@@ -5009,7 +5009,7 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "mirai-annotations",
  "workspace-hack",
@@ -5018,7 +5018,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5035,7 +5035,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5048,7 +5048,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "mirai-annotations",
@@ -5062,7 +5062,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5080,7 +5080,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5123,7 +5123,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "difference",
@@ -5137,7 +5137,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5166,7 +5166,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.3"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5187,7 +5187,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5227,7 +5227,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "colored",
@@ -5246,7 +5246,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "codespan 0.11.1",
@@ -5266,7 +5266,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5281,7 +5281,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5301,7 +5301,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -5321,7 +5321,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "hex",
@@ -5335,7 +5335,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "hex",
@@ -5350,7 +5350,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "codespan 0.11.1",
@@ -5377,7 +5377,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5457,7 +5457,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5496,7 +5496,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5525,7 +5525,7 @@ dependencies = [
 [[package]]
 name = "move-prover-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "move-command-line-common",
@@ -5537,7 +5537,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5549,7 +5549,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5565,7 +5565,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "codespan 0.11.1",
  "codespan-reporting",
@@ -5593,7 +5593,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -5613,7 +5613,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "log 0.4.14",
  "move-binary-format",
@@ -5635,7 +5635,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "once_cell",
  "serde 1.0.136",
@@ -5645,7 +5645,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "colored",
@@ -5677,7 +5677,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "colored",
@@ -5702,7 +5702,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "fail",
  "mirai-annotations",
@@ -5720,7 +5720,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5732,7 +5732,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "bcs",
  "mirai-annotations",
@@ -7669,7 +7669,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7686,7 +7686,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -12747,7 +12747,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "arrayvec 0.5.2",
  "block-buffer 0.9.0",
@@ -12789,7 +12789,7 @@ dependencies = [
 [[package]]
 name = "x"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "anyhow",
  "camino",
@@ -12820,7 +12820,7 @@ dependencies = [
 [[package]]
 name = "x-core"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "camino",
  "debug-ignore",
@@ -12839,7 +12839,7 @@ dependencies = [
 [[package]]
 name = "x-lint"
 version = "0.1.0"
-source = "git+https://github.com/starcoinorg/move?rev=9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b#9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"
+source = "git+https://github.com/starcoinorg/move?rev=314436e8ab94f4cff2699d8cd0f62b96c1d2a6df#314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"
 dependencies = [
  "camino",
  "guppy 0.12.6",

--- a/abi/decoder/Cargo.toml
+++ b/abi/decoder/Cargo.toml
@@ -14,7 +14,7 @@ serde_bytes = "0.11"
 anyhow = "1.0.41"
 once_cell = "1.8.0"
 hex = "0.4.3"
-move-binary-format = {git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
+move-binary-format = {git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
 starcoin-resource-viewer = {path = "../../vm/resource-viewer"}
 starcoin-vm-types = { path = "../../vm/types" }
 starcoin-abi-types = {path = "../types"}

--- a/abi/resolver/Cargo.toml
+++ b/abi/resolver/Cargo.toml
@@ -11,7 +11,7 @@ starcoin-vm-types = {path = "../../vm/types"}
 starcoin-abi-types = {path = "../types"}
 anyhow="~1"
 starcoin-resource-viewer = {path = "../../vm/resource-viewer"}
-move-model = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
+move-model = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
 [dev-dependencies]
 stdlib = {path = "../../vm/stdlib"}
 serde_json = "1"

--- a/cmd/starcoin/Cargo.toml
+++ b/cmd/starcoin/Cargo.toml
@@ -49,13 +49,13 @@ starcoin-resource-viewer = { path = "../../vm/resource-viewer" }
 starcoin-service-registry = { path = "../../commons/service-registry" }
 starcoin-move-explain = { path = "../../vm/move-explain" }
 vm-status-translator = {path = "../../vm/vm-status-translator"}
-move-errmapgen = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
+move-errmapgen = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
 network-api = {path = "../../network/api", package="network-api"}
 starcoin-network-rpc-api = {path = "../../network-rpc/api"}
 starcoin-abi-decoder = {path = "../../abi/decoder"}
 starcoin-abi-resolver = {path = "../../abi/resolver"}
 starcoin-abi-types = {path = "../../abi/types"}
-move-command-line-common = {git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
+move-command-line-common = {git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
 
 [dev-dependencies]
 test-helper= {path = "../../test-helper"}

--- a/commons/proptest-helpers/Cargo.toml
+++ b/commons/proptest-helpers/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 crossbeam = "0.7.3"
-diem-proptest-helpers = { package="diem-proptest-helpers",  git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
+diem-proptest-helpers = { package="diem-proptest-helpers",  git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
 
 proptest = "1.0.0"
 proptest-derive = "0.3.0"

--- a/devtools/x/Cargo.toml
+++ b/devtools/x/Cargo.toml
@@ -24,7 +24,7 @@ regex = "1.5.4"
 rayon = "1.5.1"
 indexmap = "1.6.2"
 camino = { version = "1" }
-x-core = { package="x-core", git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
-x-lint = { package="x-lint", git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
-#diem-workspace-hack = { package="workspace-hack", git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
-x = { package="x", git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
+x-core = { package="x-core", git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
+x-lint = { package="x-lint", git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
+#diem-workspace-hack = { package="workspace-hack", git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
+x = { package="x", git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }

--- a/vm/compiler/Cargo.toml
+++ b/vm/compiler/Cargo.toml
@@ -11,9 +11,9 @@ anyhow = "1.0.41"
 once_cell = "1.8.0"
 tempfile = "3.1.0"
 regex = { version = "1.5.4", default-features = false, features = ["std", "perf"] }
-move-compiler = { package="move-compiler", git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
-move-command-line-common = {git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"}
-move-binary-format = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
+move-compiler = { package="move-compiler", git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
+move-command-line-common = {git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"}
+move-binary-format = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
 petgraph = "0.5.1"
 walkdir = "2.3"
 rayon = "1.5.1"

--- a/vm/move-coverage/Cargo.toml
+++ b/vm/move-coverage/Cargo.toml
@@ -17,10 +17,10 @@ codespan = { version = "0.8.0", features = ["serialization"] }
 colored = "2.0.0"
 bcs = "0.1.2"
 
-move-bytecode-source-map = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
-move-coverage = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
-move-binary-format = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
-move-command-line-common = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
+move-bytecode-source-map = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
+move-coverage = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
+move-binary-format = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
+move-command-line-common = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
 [features]
 default = []
 

--- a/vm/move-explain/Cargo.toml
+++ b/vm/move-explain/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 [dependencies]
 structopt = "0.3.26"
 stdlib = { package="stdlib", path = "../stdlib"}
-move-core-types = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
+move-core-types = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
 bcs-ext = { package="bcs-ext", path = "../../commons/bcs_ext" }
 
 [features]

--- a/vm/move-package-manager/Cargo.toml
+++ b/vm/move-package-manager/Cargo.toml
@@ -24,20 +24,20 @@ futures = "0.3"
 tokio = {version = "0.2", features = ["full"]}
 tempfile = "~3"
 
-move-cli = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
-move-package = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
-move-bytecode-verifier = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
-move-disassembler = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
-move-errmapgen = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
-workspace-hack = { package="workspace-hack", git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
-move-coverage =  { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
-move-binary-format = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"}
-move-compiler = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
-move-core-types = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
-move-vm-runtime = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
+move-cli = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
+move-package = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
+move-bytecode-verifier = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
+move-disassembler = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
+move-errmapgen = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
+workspace-hack = { package="workspace-hack", git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
+move-coverage =  { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
+move-binary-format = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"}
+move-compiler = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
+move-core-types = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
+move-vm-runtime = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
 resource-viewer = { path = "../resource-viewer", package = "starcoin-resource-viewer" }
-move-unit-test = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
-move-command-line-common = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
+move-unit-test = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
+move-command-line-common = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
 datatest-stable = {git = "https://github.com/starcoinorg/diem-devtools", branch="feature/pub-test-opts"}
 starcoin-vm-types = {path = "../../vm/types"}
 starcoin-logger = {path = "../../commons/logger"}

--- a/vm/move-prover/Cargo.toml
+++ b/vm/move-prover/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 
 [dependencies]
 ## move dependencies
-move-prover = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
+move-prover = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
 
 # external dependencies
 tempfile = "3.2.0"
@@ -18,8 +18,8 @@ anyhow = "1.0.41"
 
 [dev-dependencies]
 datatest-stable = "0.1.1"
-move-prover-test-utils = {git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
-move-command-line-common= {git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
+move-prover-test-utils = {git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
+move-command-line-common= {git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
 shell-words = "1.0.0"
 walkdir = "2.3"
 once_cell = "1.7.2"

--- a/vm/natives/Cargo.toml
+++ b/vm/natives/Cargo.toml
@@ -7,15 +7,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-move-errmapgen = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
-move-docgen = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
-move-command-line-common = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
-move-prover = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
-move-stdlib = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
-move-vm-types = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
-move-vm-runtime = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
-move-binary-format = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
-move-core-types = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
+move-errmapgen = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
+move-docgen = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
+move-command-line-common = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
+move-prover = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
+move-stdlib = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
+move-vm-types = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
+move-vm-runtime = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
+move-binary-format = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
+move-core-types = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
 starcoin-crypto = { git = "https://github.com/starcoinorg/starcoin-crypto", rev = "d871dfb4216f034ee334a575926c101574d9d6dc"}
 log = "0.4.14"
 walkdir = "2.3.1"

--- a/vm/resource-viewer/Cargo.toml
+++ b/vm/resource-viewer/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 
 [dependencies]
 starcoin-vm-types = { path = "../types" }
-move-binary-format = {git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
-move-core-types = {git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
+move-binary-format = {git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
+move-core-types = {git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
 serde_json = "1.0"
 serde = { version = "1.0.130", features = ["derive", "rc"] }
 anyhow = "1.0.41"

--- a/vm/starcoin-transactional-test-harness/Cargo.toml
+++ b/vm/starcoin-transactional-test-harness/Cargo.toml
@@ -22,11 +22,11 @@ dashmap = "~5"
 serde = { version = "1" }
 serde_json = { version = "1" }
 log = { version = "0.4.14" }
-move-transactional-test-runner = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
-move-compiler = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
-move-binary-format = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
-move-core-types = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
-move-command-line-common = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
+move-transactional-test-runner = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
+move-compiler = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
+move-binary-format = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
+move-core-types = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
+move-command-line-common = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
 
 bcs-ext = {path = "../../commons/bcs_ext"}
 starcoin-crypto = { git = "https://github.com/starcoinorg/starcoin-crypto", rev = "d871dfb4216f034ee334a575926c101574d9d6dc"}
@@ -41,7 +41,7 @@ starcoin-rpc-api = {path = "../../rpc/api"}
 starcoin-vm-runtime = {path = "../../vm/vm-runtime"}
 starcoin-dev = {path = "../dev"}
 starcoin-resource-viewer = {path = "../resource-viewer"}
-move-resource-viewer = {git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"}
+move-resource-viewer = {git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"}
 
 [dev-dependencies]
 datatest-stable = "0.1.1"

--- a/vm/stdlib/Cargo.toml
+++ b/vm/stdlib/Cargo.toml
@@ -9,13 +9,13 @@ edition = "2021"
 [dependencies]
 walkdir = "2.3"
 anyhow = "1.0.41"
-move-bytecode-verifier = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
+move-bytecode-verifier = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
 starcoin-crypto = { git = "https://github.com/starcoinorg/starcoin-crypto", rev = "d871dfb4216f034ee334a575926c101574d9d6dc"}
 starcoin-vm-types = { path = "../types"}
 bcs-ext = { package="bcs-ext", path = "../../commons/bcs_ext" }
 starcoin-move-compiler = { path = "../../vm/compiler"}
-move-prover = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
-move-compiler = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
+move-prover = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
+move-compiler = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
 once_cell = "1.8.0"
 include_dir = "0.6.2"
 sha2 = "0.9.1"

--- a/vm/transaction-builder-generator/Cargo.toml
+++ b/vm/transaction-builder-generator/Cargo.toml
@@ -19,7 +19,7 @@ serde-generate = {git="https://github.com/starcoinorg/serde-reflection" , rev="6
 serde-reflection = {git="https://github.com/starcoinorg/serde-reflection" , rev="694048797338ff7385006d968e786b6d9dbdeb8b"}
 
 starcoin-vm-types = { path = "../types"}
-move-core-types = {git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"  }
+move-core-types = {git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"  }
 bcs = "0.1.3"
 
 [dev-dependencies]

--- a/vm/types/Cargo.toml
+++ b/vm/types/Cargo.toml
@@ -23,11 +23,11 @@ bech32 = "0.8"
 
 proptest = { version = "1.0.0", default-features = false, optional = true }
 proptest-derive = { version = "0.3.0", default-features = false, optional = true }
-move-core-types = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
-move-vm-types = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
-move-bytecode-verifier = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
-vm = { package = "move-binary-format", git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b"}
-move-ir-types = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
+move-core-types = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
+move-vm-types = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
+move-bytecode-verifier = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
+vm = { package = "move-binary-format", git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df"}
+move-ir-types = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
 
 bcs-ext = { package = "bcs-ext", path = "../../commons/bcs_ext" }
 #starcoin-proptest-helpers = { path = "../../commons/proptest-helpers", optional = true }
@@ -38,7 +38,7 @@ schemars = {git = "https://github.com/starcoinorg/schemars", rev="6972da92f4360e
 [dev-dependencies]
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
-vm = { package = "move-binary-format", git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b", features = ["fuzzing"]}
+vm = { package = "move-binary-format", git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df", features = ["fuzzing"]}
 starcoin-crypto = { git = "https://github.com/starcoinorg/starcoin-crypto", rev = "d871dfb4216f034ee334a575926c101574d9d6dc"}
 #starcoin-proptest-helpers = { path = "../../commons/proptest-helpers"}
 

--- a/vm/vm-runtime/Cargo.toml
+++ b/vm/vm-runtime/Cargo.toml
@@ -11,9 +11,9 @@ anyhow = "1.0.41"
 once_cell = "1.8.0"
 
 starcoin-types = { path = "../../types"}
-move-core-types = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
-move-vm-runtime = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
-move-stdlib = { git = "https://github.com/starcoinorg/move", rev = "9d56913f8c0bf9188b4d10062f7c9c22ada7ee6b" }
+move-core-types = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
+move-vm-runtime = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
+move-stdlib = { git = "https://github.com/starcoinorg/move", rev = "314436e8ab94f4cff2699d8cd0f62b96c1d2a6df" }
 tracing = "0.1.30"
 starcoin-config = { path = "../../config"}
 starcoin-logger = {path = "../../commons/logger"}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

the Move changes at: 

https://github.com/starcoinorg/move/pull/2

Compatibility notes:

1. New CLI client can connect to old node RPC (json deserialize compatibility) 
2. But Old CLI client can not connect to the new RPC.

The following RPC APIs are mainly affected:

1. `account.sign_txn`
2. `txpool.submit_transaction`

The `scripts/import_net_block.sh` also affected, old data can be imported by new starcoin binary, but when exporting new json data, it can not be imported by old starcoin binary. 

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
