### PR TITLE
[mpm] change the `spectest` to `integration-test`

### DIFF
--- a/vm/move-package-manager/src/compatibility_check_cmd.rs
+++ b/vm/move-package-manager/src/compatibility_check_cmd.rs
@@ -1,12 +1,12 @@
+// Copyright (c) The Starcoin Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::releasement::module;
-
+use clap::Parser;
 use itertools::Itertools;
-
 use move_binary_format::CompiledModule;
 use move_cli::sandbox::utils::PackageContext;
 use move_cli::Move;
-
-use clap::Parser;
 use move_core_types::resolver::ModuleResolver;
 use starcoin_config::BuiltinNetworkID;
 use starcoin_move_compiler::check_compiled_module_compat;

--- a/vm/move-package-manager/src/main.rs
+++ b/vm/move-package-manager/src/main.rs
@@ -10,7 +10,7 @@ use move_package_manager::compatibility_check_cmd::{
     handle_compatibility_check, CompatibilityCheckCommand,
 };
 use move_package_manager::releasement::{handle_release, Releasement};
-use move_package_manager::{run_transactional_test, TransactionalTestCommand};
+use move_package_manager::{run_integration_test, IntegrationTestCommand};
 use starcoin_config::genesis_config;
 use starcoin_vm_runtime::natives::starcoin_natives;
 use std::path::PathBuf;
@@ -56,9 +56,10 @@ pub enum Commands {
         #[clap(subcommand)]
         cmd: experimental::cli::ExperimentalCommand,
     },
-    /// Run transaction tests in spectests dir.
-    #[clap(name = "spectest")]
-    TransactionalTest(TransactionalTestCommand),
+    /// Run integration tests in tests dir.
+    #[clap(name = "integration-test", alias = "spectest")]
+    IntegrationTest(IntegrationTestCommand),
+
     /// Check compatibility of modules comparing with remote chain chate.
     #[clap(name = "check-compatibility")]
     CompatibilityCheck(CompatibilityCheckCommand),
@@ -71,7 +72,7 @@ fn main() -> Result<()> {
     let move_args = &args.move_args;
     let natives = starcoin_natives();
     match args.cmd {
-        Commands::TransactionalTest(cmd) => run_transactional_test(args.move_args, cmd),
+        Commands::IntegrationTest(cmd) => run_integration_test(args.move_args, cmd),
         Commands::Package { cmd } => handle_package_commands(
             &move_args.package_path,
             move_args.build_config.clone(),


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolve #3308  fix #3229 

## What is the new behavior?

Use `mpm integration-test` to replace `mpm spectest`, and use the `tests` as tests files dir.
The `mpm spectest` command is still available for compatibility.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
