### PR TITLE
upgrade ci node group for low ephemeral-storage

### DIFF
--- a/kube/manifest/runner/runner.yaml
+++ b/kube/manifest/runner/runner.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     spec:
       nodeSelector:
-        node-pool: ci-pool
+        node-pool: ci-pool-200g
       image: starcoin/starcoin-builder:sha-cbd4ad4
       repository: starcoinorg/starcoin
       ephemeral: true
@@ -22,9 +22,9 @@ spec:
           #memory: "64Gi"
           cpu: "15.0"
           memory: "32Gi"
-          ephemeral-storage: "40Gi"
+          ephemeral-storage: "80Gi"
         limits:
-          ephemeral-storage: "50Gi"
+          ephemeral-storage: "100Gi"
       # If set to false, there are no privileged container and you cannot use docker.
       dockerEnabled: true
       # If set to true, runner pod container only 1 container that's expected to be able to run docker, too.
@@ -37,9 +37,9 @@ spec:
           #memory: "64Gi"
           cpu: "15.0"
           memory: "32Gi"
-          ephemeral-storage: "40Gi"
+          ephemeral-storage: "80Gi"
         limits:
-          ephemeral-storage: "50Gi"
+          ephemeral-storage: "100Gi"
 
 ---
 apiVersion: actions.summerwind.dev/v1alpha1


### PR DESCRIPTION

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
it will be timeout when do the build&&test ci job