### PR TITLE
[refactor] Improve variable naming convention

### DIFF
--- a/account/src/account_test.rs
+++ b/account/src/account_test.rs
@@ -187,15 +187,15 @@ pub fn test_wallet_account() -> Result<()> {
     let hash_value = HashValue::sha3_256_of(&public_key.to_bytes());
     let key = AuthenticationKey::new(*HashValue::sha3_256_of(&public_key.to_bytes()).as_ref());
 
-    let sign_bytes = vec![
+    let sign = vec![
         227, 94, 250, 168, 43, 200, 137, 74, 61, 254, 197, 71, 245, 135, 201, 43, 222, 190, 56,
         235, 247, 254, 56, 247, 108, 36, 250, 192, 143, 236, 101, 153, 61, 241, 129, 47, 38, 146,
         213, 9, 79, 56, 90, 210, 179, 53, 73, 208, 248, 231, 22, 9, 55, 177, 154, 212, 248, 2, 66,
         221, 67, 101, 152, 6,
     ];
-    let _sign = Ed25519Signature::try_from(&sign_bytes[..])?;
+    let _sign = Ed25519Signature::try_from(&sign[..])?;
 
-    let raw_txn_bytes = vec![
+    let raw_txn = vec![
         125, 67, 213, 38, 157, 219, 137, 205, 183, 247, 184, 18, 104, 155, 241, 53, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 161, 1, 161, 28, 235, 11, 1, 0, 0, 0, 6, 1, 0, 2, 3, 2, 17, 4, 19, 4, 5, 23,
         24, 7, 47, 42, 8, 89, 16, 0, 0, 0, 1, 0, 1, 1, 1, 0, 2, 2, 3, 0, 0, 3, 4, 1, 1, 1, 0, 6, 2,
@@ -210,7 +210,7 @@ pub fn test_wallet_account() -> Result<()> {
         0, 32, 78, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 13, 48, 120, 49, 58, 58, 83, 84, 67,
         58, 58, 83, 84, 67, 159, 150, 87, 95, 0, 0, 0, 0, 254,
     ];
-    let raw_txn = RawUserTransaction::decode(&raw_txn_bytes)?;
+    let raw_txn = RawUserTransaction::decode(&raw_txn)?;
 
     println!("raw txn hash is {:?}", raw_txn.hash());
 
@@ -243,7 +243,7 @@ pub fn test_wallet_account() -> Result<()> {
     };
     let access_path = AccessPath::resource_access_path(address, struct_tag);
     println!("access path is {:?}", access_path);
-    let stxn_bytes = vec![
+    let stxn = vec![
         125, 67, 213, 38, 157, 219, 137, 205, 183, 247, 184, 18, 104, 155, 241, 53, 7, 0, 0, 0, 0,
         0, 0, 0, 0, 161, 1, 161, 28, 235, 11, 1, 0, 0, 0, 6, 1, 0, 2, 3, 2, 17, 4, 19, 4, 5, 23,
         24, 7, 47, 42, 8, 89, 16, 0, 0, 0, 1, 0, 1, 1, 1, 0, 2, 2, 3, 0, 0, 3, 4, 1, 1, 1, 0, 6, 2,
@@ -263,7 +263,7 @@ pub fn test_wallet_account() -> Result<()> {
         253, 28, 178, 254, 244, 28, 94, 129, 152, 49, 111, 118, 238, 236, 36, 49, 239, 179, 197,
         211, 150, 199, 7, 37, 161, 6, 202, 7,
     ];
-    let stxn = SignedUserTransaction::decode(&stxn_bytes)?;
+    let stxn = SignedUserTransaction::decode(&stxn)?;
     println!("txn hash is {:?}", stxn.id());
     Ok(())
 }

--- a/cmd/merkle-generator/src/lib.rs
+++ b/cmd/merkle-generator/src/lib.rs
@@ -96,7 +96,7 @@ mod tests {
         let merkle_data = include_str!("../examples/merkle-example.json");
         let merkle_data: serde_json::Value = serde_json::from_str(merkle_data)?;
         let root = merkle_data["root"].as_str().unwrap();
-        let root_in_bytes = hex::decode(root.strip_prefix("0x").unwrap_or(root))?;
+        let raw_root = hex::decode(root.strip_prefix("0x").unwrap_or(root))?;
         let proofs: Vec<DataProof> = serde_json::from_value(merkle_data["proofs"].clone())?;
 
         let leaf = encode(proofs[0].index, proofs[0].address, proofs[0].amount).unwrap();
@@ -120,7 +120,7 @@ mod tests {
             };
             computed_hash = HashValue::sha3_256_of(joined.as_slice()).to_vec();
         }
-        assert_eq!(root_in_bytes, computed_hash);
+        assert_eq!(raw_root, computed_hash);
         Ok(())
     }
 }

--- a/cmd/miner_client/src/stratum_client_service.rs
+++ b/cmd/miner_client/src/stratum_client_service.rs
@@ -231,18 +231,18 @@ impl Inner {
                     request_id+=1;
                     match req {
                         Request::LoginRequest(login_req, s)=>{
-                            let req_str = build_request_string("login", &login_req, request_id).expect("build stratum login request failed never happen");
-                            debug!("stratum client send request:{}",req_str);
-                            if let Err(err) = self.sink.send(req_str).await{
+                            let message = build_request_string("login", &login_req, request_id).expect("build stratum login request failed never happen");
+                            debug!("stratum client send request:{}",message);
+                            if let Err(err) = self.sink.send(message).await{
                                 error!("stratum send request failed: {}", err);
                                 continue
                             }
                             self.pending_requests.insert(request_id, PendingRequest::LoginRequest(s));
                         }
                         Request::SubmitSealRequest(seal_req)=>{
-                            let req_str = build_request_string("submit", &seal_req, request_id).expect("build stratum login request failed never happen");
-                            debug!("stratum send request:{}",req_str);
-                            if let Err(err) = self.sink.send(req_str).await{
+                            let message = build_request_string("submit", &seal_req, request_id).expect("build stratum login request failed never happen");
+                            debug!("stratum send request:{}",message);
+                            if let Err(err) = self.sink.send(message).await{
                                 error!("stratum send request failed: {}", err);
                                 continue
                             }

--- a/commons/logger/src/lib.rs
+++ b/commons/logger/src/lib.rs
@@ -84,12 +84,12 @@ impl LogPattern {
 
 impl std::fmt::Display for LogPattern {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let display_str = match self {
+        let log_pattern = match self {
             LogPattern::Default => "default".to_owned(),
             LogPattern::WithLine => "withline".to_owned(),
             LogPattern::Custom(p) => format!("custom({})", p),
         };
-        write!(f, "{}", display_str)
+        write!(f, "{}", log_pattern)
     }
 }
 
@@ -315,8 +315,8 @@ fn rolling_file_append(
 /// read log level filters from `RUST_LOG` env.
 /// return global level filter and specified level filters.
 fn env_log_level(default_level: &str) -> (LevelFilter, Vec<(String, LevelFilter)>) {
-    let level_str = std::env::var("RUST_LOG").unwrap_or_default();
-    let level_filters = parse_spec(level_str.as_str());
+    let level = std::env::var("RUST_LOG").unwrap_or_default();
+    let level_filters = parse_spec(level.as_str());
     let default_level = level_filters.global_level.unwrap_or_else(|| {
         default_level
             .parse()

--- a/commons/metrics/src/op_counters.rs
+++ b/commons/metrics/src/op_counters.rs
@@ -47,24 +47,21 @@ pub struct OpMetrics {
 
 impl OpMetrics {
     pub fn new<S: Into<String>>(name: S) -> Result<OpMetrics> {
-        let name_str = name.into();
+        let name = name.into();
         Ok(OpMetrics {
-            module: name_str.clone(),
+            module: name.clone(),
             counters: IntCounterVec::new(
-                Opts::new(name_str.clone(), format!("Counters for {}", name_str)),
+                Opts::new(name.clone(), format!("Counters for {}", name)),
                 &["op"],
             )?,
             gauges: IntGaugeVec::new(
-                Opts::new(
-                    format!("{}_gauge", name_str),
-                    format!("Gauges for {}", name_str),
-                ),
+                Opts::new(format!("{}_gauge", name), format!("Gauges for {}", name)),
                 &["op"],
             )?,
             duration_histograms: HistogramVec::new(
                 HistogramOpts::new(
-                    format!("{}_duration", name_str),
-                    format!("Histogram values for {}", name_str),
+                    format!("{}_duration", name),
+                    format!("Histogram values for {}", name),
                 ),
                 &["op"],
             )?,

--- a/config/src/tests.rs
+++ b/config/src/tests.rs
@@ -72,11 +72,11 @@ fn test_example_config_compact() -> Result<()> {
         if net.is_dev() || net.is_test() || net.is_halley() || !net.genesis_config().is_ready() {
             continue;
         }
-        let net_str = net.to_string();
+        let net = net.to_string();
         let args = vec![
             "starcoin",
             "-n",
-            net_str.as_str(),
+            net.as_str(),
             "-d",
             example_dir.to_str().unwrap(),
             //Network

--- a/contrib-contracts/src/merkle_distributor_test.rs
+++ b/contrib-contracts/src/merkle_distributor_test.rs
@@ -30,7 +30,7 @@ fn test_merkle_distributor() -> Result<()> {
     let merkle_data = include_str!("merkle-test.json");
     let merkle_data: serde_json::Value = serde_json::from_str(merkle_data)?;
     let root = merkle_data["root"].as_str().unwrap();
-    let root_in_bytes = hex::decode(root.strip_prefix("0x").unwrap_or(root))?;
+    let raw_root = hex::decode(root.strip_prefix("0x").unwrap_or(root))?;
     let proofs: Vec<DataProof> = serde_json::from_value(merkle_data["proofs"].clone())?;
 
     // deploy the module
@@ -48,7 +48,7 @@ fn test_merkle_distributor() -> Result<()> {
 
     // association: create the merkle distributor.
     {
-        let merkle_root = MoveValue::vector_u8(root_in_bytes);
+        let merkle_root = MoveValue::vector_u8(raw_root);
 
         let rewards_total = MoveValue::U128(proofs.iter().map(|p| p.amount).sum());
         let leafs = MoveValue::U64(proofs.len() as u64);

--- a/rpc/client/src/lib.rs
+++ b/rpc/client/src/lib.rs
@@ -815,11 +815,11 @@ impl RpcClient {
             raw_txn,
             public_key,
         } = txn;
-        let raw_txn_str = hex::encode(raw_txn.encode()?);
+        let raw_txn = hex::encode(raw_txn.encode()?);
         self.call_rpc_blocking(|inner| {
             inner
                 .contract_client
-                .dry_run_raw(raw_txn_str, StrView(public_key))
+                .dry_run_raw(raw_txn, StrView(public_key))
         })
         .map_err(map_err)
     }

--- a/rpc/middleware/src/lib.rs
+++ b/rpc/middleware/src/lib.rs
@@ -23,12 +23,12 @@ enum CallType {
 
 impl fmt::Display for CallType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let type_str = match self {
+        let call_type = match self {
             CallType::MethodCall => "method",
             CallType::Notification => "notification",
             CallType::Invalid => "invalid",
         };
-        write!(f, "{}", type_str)
+        write!(f, "{}", call_type)
     }
 }
 

--- a/state/state-tree/src/state_tree.rs
+++ b/state/state-tree/src/state_tree.rs
@@ -419,8 +419,8 @@ impl Iterator for AccountStateSetIterator {
         if let Some(item) = item {
             let item = item.ok()?;
             let account_address = item.0;
-            let account_state_bytes = Vec::from(item.1);
-            let account_state: AccountState = account_state_bytes.as_slice().try_into().ok()?;
+            let account_state = Vec::from(item.1);
+            let account_state: AccountState = account_state.as_slice().try_into().ok()?;
             let mut state_sets = vec![];
             for (idx, storage_root) in account_state.storage_roots().iter().enumerate() {
                 let state_set = match storage_root {

--- a/storage/src/tests/test_block.rs
+++ b/storage/src/tests/test_block.rs
@@ -155,9 +155,9 @@ fn test_old_failed_block_decode() {
     let block = Block::new(block_header, block_body);
 
     let old_failed_block: OldFailedBlock = (block, None, "test decode".to_string()).into();
-    let encode_str = old_failed_block.encode();
-    assert!(encode_str.is_ok());
-    let result = FailedBlock::decode(encode_str.unwrap().as_slice());
+    let encoded = old_failed_block.encode();
+    assert!(encoded.is_ok());
+    let result = FailedBlock::decode(encoded.unwrap().as_slice());
     assert!(result.is_err());
 }
 

--- a/sync/src/block_connector/write_block_chain.rs
+++ b/sync/src/block_connector/write_block_chain.rs
@@ -75,7 +75,7 @@ where
         let result = self.connect_inner(block);
 
         if let Some(metrics) = self.metrics.as_ref() {
-            let result_str = match result.as_ref() {
+            let result = match result.as_ref() {
                 Ok(connect) => format!("Ok_{}", connect),
                 Err(err) => {
                     if let Some(connect_err) = err.downcast_ref::<ConnectBlockError>() {
@@ -87,7 +87,7 @@ where
             };
             metrics
                 .chain_block_connect_total
-                .with_label_values(&[result_str.as_str()])
+                .with_label_values(&[result.as_str()])
                 .inc();
         }
         result.map(|_| ())

--- a/sync/src/tasks/mod.rs
+++ b/sync/src/tasks/mod.rs
@@ -478,9 +478,9 @@ where
     F: SyncFetcher + 'static,
 {
     fn handle(&self, error: Error) {
-        let peer_str = error.to_string();
-        debug!("[sync]sync task peer_str: {:?}", peer_str);
-        if let Ok(peer_id) = PeerId::from_str(&peer_str) {
+        let peer = error.to_string();
+        debug!("[sync]sync task peer_str: {:?}", peer);
+        if let Ok(peer_id) = PeerId::from_str(&peer) {
             if let Ok(prc_error) = error.downcast::<NetRpcError>() {
                 match &prc_error.error_code() {
                     RpcErrorCode::Forbidden

--- a/types/src/block.rs
+++ b/types/src/block.rs
@@ -230,12 +230,12 @@ impl BlockHeader {
         let mut blob = Vec::new();
         let raw_header: RawBlockHeader = self.to_owned().into();
         let raw_header_hash = raw_header.crypto_hash();
-        let mut diff_bytes = [0u8; 32];
-        raw_header.difficulty.to_big_endian(&mut diff_bytes);
+        let mut diff = [0u8; 32];
+        raw_header.difficulty.to_big_endian(&mut diff);
         let extend_and_nonce = [0u8; 12];
         blob.extend_from_slice(raw_header_hash.to_vec().as_slice());
         blob.extend_from_slice(&extend_and_nonce);
-        blob.extend_from_slice(&diff_bytes);
+        blob.extend_from_slice(&diff);
         blob
     }
 

--- a/vm/move-coverage/src/bin/coverage-summaries.rs
+++ b/vm/move-coverage/src/bin/coverage-summaries.rs
@@ -58,9 +58,9 @@ fn get_modules(args: &Args) -> Vec<CompiledModule> {
     }
 
     if let Some(module_binary_path) = &args.module_binary_path {
-        let bytecode_bytes = fs::read(module_binary_path).expect("Unable to read bytecode file");
-        let compiled_module = CompiledModule::deserialize(&bytecode_bytes)
-            .expect("Module blob can't be deserialized");
+        let bytecode = fs::read(module_binary_path).expect("Unable to read bytecode file");
+        let compiled_module =
+            CompiledModule::deserialize(&bytecode).expect("Module blob can't be deserialized");
         modules.push(compiled_module);
     }
 

--- a/vm/move-coverage/src/bin/source-coverage.rs
+++ b/vm/move-coverage/src/bin/source-coverage.rs
@@ -47,9 +47,9 @@ fn main() {
         CoverageMap::from_binary_file(&args.input_trace_path).unwrap()
     };
 
-    let bytecode_bytes = fs::read(&args.module_binary_path).expect("Unable to read bytecode file");
+    let bytecode = fs::read(&args.module_binary_path).expect("Unable to read bytecode file");
     let compiled_module =
-        CompiledModule::deserialize(&bytecode_bytes).expect("Module blob can't be deserialized");
+        CompiledModule::deserialize(&bytecode).expect("Module blob can't be deserialized");
 
     let source_map = source_map_from_file(
         &Path::new(&args.module_binary_path).with_extension(source_map_extension),

--- a/vm/move-package-manager/src/releasement.rs
+++ b/vm/move-package-manager/src/releasement.rs
@@ -99,7 +99,7 @@ pub fn handle_release(
     };
 
     let p = Package::new(ms, init_script)?;
-    let package_bytes = bcs_ext::to_bytes(&p)?;
+    let blob = bcs_ext::to_bytes(&p)?;
     let release_path = {
         std::fs::create_dir_all(&release_dir)?;
         release_dir.push(format!(
@@ -108,7 +108,7 @@ pub fn handle_release(
         ));
         release_dir
     };
-    std::fs::write(&release_path, package_bytes)?;
+    std::fs::write(&release_path, blob)?;
     println!(
         "Release done: {}, package hash: {}",
         release_path.display(),

--- a/vm/move-prover/tests/testsuite.rs
+++ b/vm/move-prover/tests/testsuite.rs
@@ -102,24 +102,24 @@ fn get_features() -> &'static [Feature] {
         ]
     })
 }
-fn cvc4_deny_listed(path_str: &str) -> bool {
-    if path_str == "../stdlib/transaction_scripts/queue_proposal_action.move"
-        || path_str == "../stdlib/transaction_scripts/destroy_terminated_proposal.move"
-        || path_str == "../stdlib/transaction_scripts/execute_modify_dao_config_proposal.move"
-        || path_str == "../stdlib/transaction_scripts/propose_modify_dao_config.move"
-        || path_str == "../stdlib/transaction_scripts/submit_module_upgrade_plan.move"
-        || path_str == "../stdlib/transaction_scripts/propose_module_upgrade.move"
-        || path_str == "../stdlib/transaction_scripts/cast_vote.move"
-        || path_str == "../stdlib/transaction_scripts/unstake_vote.move"
-        || path_str == "../stdlib/transaction_scripts/revoke_vote.move"
-        || path_str == "../stdlib/sources/TransactionPublishOption.move"
-        || path_str == "../stdlib/sources/OnChainConfigDao.move"
-        || path_str == "../stdlib/sources/Authenticator.move"
-        || path_str == "../stdlib/sources/MintDaoProposal.move"
-        || path_str == "../stdlib/sources/Dao.move"
-        || path_str == "../stdlib/sources/ConsensusConfig.move"
-        || path_str == "../stdlib/sources/UpgradeModuleDaoProposal.move"
-        || path_str == "../stdlib/sources/ModifyDaoConfigProposal.move"
+fn cvc4_deny_listed(path: &str) -> bool {
+    if path == "../stdlib/transaction_scripts/queue_proposal_action.move"
+        || path == "../stdlib/transaction_scripts/destroy_terminated_proposal.move"
+        || path == "../stdlib/transaction_scripts/execute_modify_dao_config_proposal.move"
+        || path == "../stdlib/transaction_scripts/propose_modify_dao_config.move"
+        || path == "../stdlib/transaction_scripts/submit_module_upgrade_plan.move"
+        || path == "../stdlib/transaction_scripts/propose_module_upgrade.move"
+        || path == "../stdlib/transaction_scripts/cast_vote.move"
+        || path == "../stdlib/transaction_scripts/unstake_vote.move"
+        || path == "../stdlib/transaction_scripts/revoke_vote.move"
+        || path == "../stdlib/sources/TransactionPublishOption.move"
+        || path == "../stdlib/sources/OnChainConfigDao.move"
+        || path == "../stdlib/sources/Authenticator.move"
+        || path == "../stdlib/sources/MintDaoProposal.move"
+        || path == "../stdlib/sources/Dao.move"
+        || path == "../stdlib/sources/ConsensusConfig.move"
+        || path == "../stdlib/sources/UpgradeModuleDaoProposal.move"
+        || path == "../stdlib/sources/ModifyDaoConfigProposal.move"
         || false
     {
         return true;
@@ -210,9 +210,9 @@ fn get_flags_and_baseline(
     feature: &Feature,
 ) -> anyhow::Result<(Vec<String>, Option<PathBuf>)> {
     // Determine the way how to configure tests based on directory of the path.
-    let path_str = path.to_string_lossy();
+    let dir_path = path.to_string_lossy();
 
-    let (base_flags, baseline_path) = if path_str.contains("stdlib/") {
+    let (base_flags, baseline_path) = if dir_path.contains("stdlib/") {
         (REGULAR_TEST_FLAGS, None)
     } else {
         let feature_name = feature.name.to_string();
@@ -285,17 +285,17 @@ fn collect_enabled_tests(reqs: &mut Vec<Requirements>, group: &str, feature: &Fe
                     .unwrap_or_default()
                     .is_empty();
         }
-        let root_str = p.to_string_lossy().to_string();
-        let path_str = path.to_string_lossy().to_string();
+        let root = p.to_string_lossy().to_string();
+        let path = path.to_string_lossy().to_string();
         if included {
-            included = (feature.enabling_condition)(group, &path_str);
+            included = (feature.enabling_condition)(group, &path);
         }
         if included {
             reqs.push(Requirements::new(
                 feature.runner,
                 format!("prover {}[{}]", group, feature.name),
-                root_str,
-                path_str,
+                root,
+                path,
             ));
         }
     }

--- a/vm/natives/src/bcs.rs
+++ b/vm/natives/src/bcs.rs
@@ -26,17 +26,17 @@ pub fn native_to_address(
     debug_assert!(_ty_args.is_empty());
     debug_assert!(args.len() == 1);
 
-    let key_bytes = pop_arg!(args, Vec<u8>);
+    let key = pop_arg!(args, Vec<u8>);
     let cost = native_gas(
         context.cost_table(),
         NativeCostIndex::BCS_TO_ADDRESS as u8,
-        key_bytes.len(),
+        key.len(),
     );
-    if key_bytes.len() != AccountAddress::LENGTH {
+    if key.len() != AccountAddress::LENGTH {
         return Ok(NativeResult::err(cost, NFE_BCS_TO_ADDRESS_FAILURE));
     }
 
-    let address = match AccountAddress::try_from(&key_bytes[..AccountAddress::LENGTH]) {
+    let address = match AccountAddress::try_from(&key[..AccountAddress::LENGTH]) {
         Ok(addr) => addr,
         Err(_) => return Ok(NativeResult::err(cost, NFE_BCS_TO_ADDRESS_FAILURE)),
     };

--- a/vm/natives/src/signature.rs
+++ b/vm/natives/src/signature.rs
@@ -22,16 +22,16 @@ pub fn native_ed25519_publickey_validation(
     debug_assert!(_ty_args.is_empty());
     debug_assert!(arguments.len() == 1);
 
-    let key_bytes = pop_arg!(arguments, Vec<u8>);
+    let key = pop_arg!(arguments, Vec<u8>);
 
     let cost = native_gas(
         context.cost_table(),
         NativeCostIndex::ED25519_VALIDATE_KEY as u8,
-        key_bytes.len(),
+        key.len(),
     );
 
     // This deserialization performs point-on-curve and small subgroup checks
-    let valid = ed25519::Ed25519PublicKey::try_from(&key_bytes[..]).is_ok();
+    let valid = ed25519::Ed25519PublicKey::try_from(&key[..]).is_ok();
     Ok(NativeResult::ok(cost, smallvec![Value::bool(valid)]))
 }
 

--- a/vm/types/src/event.rs
+++ b/vm/types/src/event.rs
@@ -44,10 +44,10 @@ impl EventKey {
 
     /// Get the account address part in this event key
     pub fn get_creator_address(&self) -> AccountAddress {
-        let mut arr_bytes = [0u8; AccountAddress::LENGTH];
-        arr_bytes.copy_from_slice(&self.0[EventKey::LENGTH - AccountAddress::LENGTH..]);
+        let mut arr = [0u8; AccountAddress::LENGTH];
+        arr.copy_from_slice(&self.0[EventKey::LENGTH - AccountAddress::LENGTH..]);
 
-        AccountAddress::new(arr_bytes)
+        AccountAddress::new(arr)
     }
 
     /// If this is the `ith` EventKey` created by `get_creator_address()`, return `i`
@@ -65,11 +65,11 @@ impl EventKey {
 
     /// Create a unique handle by using an AccountAddress and a counter.
     pub fn new_from_address(addr: &AccountAddress, salt: u64) -> Self {
-        let mut output_bytes = [0; Self::LENGTH];
-        let (lhs, rhs) = output_bytes.split_at_mut(8);
+        let mut output = [0; Self::LENGTH];
+        let (lhs, rhs) = output.split_at_mut(8);
         lhs.copy_from_slice(&salt.to_le_bytes());
         rhs.copy_from_slice(addr.as_ref());
-        EventKey(output_bytes)
+        EventKey(output)
     }
 }
 

--- a/vm/types/src/token/token_code.rs
+++ b/vm/types/src/token/token_code.rs
@@ -60,8 +60,8 @@ impl TryFrom<TypeTag> for TokenCode {
 }
 impl From<StructTag> for TokenCode {
     fn from(struct_tag: StructTag) -> Self {
-        let tag_str = struct_tag.to_string();
-        let s: Vec<_> = tag_str.splitn(3, "::").collect();
+        let tag = struct_tag.to_string();
+        let s: Vec<_> = tag.splitn(3, "::").collect();
         //this should not happen
         assert_eq!(s.len(), 3, "invalid struct tag format");
         Self::new(

--- a/vm/types/src/token/token_value.rs
+++ b/vm/types/src/token/token_value.rs
@@ -88,9 +88,9 @@ where
         if p2 == 0 {
             write!(f, "{}{}", p1, self.unit.symbol())
         } else {
-            let p2_str = padding_zero(p2.to_string().as_str(), self.unit.scale(), true);
-            let p2_str = p2_str.trim_end_matches('0');
-            write!(f, "{}.{}{}", p1, p2_str, self.unit.symbol())
+            let p2 = padding_zero(p2.to_string().as_str(), self.unit.scale(), true);
+            let p2 = p2.trim_end_matches('0');
+            write!(f, "{}.{}{}", p1, p2, self.unit.symbol())
         }
     }
 }

--- a/vm/types/src/transaction/tests.rs
+++ b/vm/types/src/transaction/tests.rs
@@ -17,10 +17,10 @@ fn test_transaction_argument_to_json() {
             TransactionArgument::U8Vector(vec![0u8]),
         ]),
     );
-    let json_str = serde_json::to_string(&script).expect("json to_string should success.");
-    let script2 = serde_json::from_str(json_str.as_str()).expect("json from_str should success.");
-    assert_eq!(script, script2);
-    let json_value = serde_json::to_value(&script).expect("json to_value should success.");
-    let script3 = serde_json::from_value(json_value).expect("json from_value should success.");
-    assert_eq!(script, script3);
+    let raw_json = serde_json::to_string(&script).expect("json to_string should success.");
+    let value = serde_json::from_str(raw_json.as_str()).expect("json from_str should success.");
+    assert_eq!(script, value);
+    let serialized = serde_json::to_value(&script).expect("json to_value should success.");
+    let deserialized = serde_json::from_value(serialized).expect("json from_value should success.");
+    assert_eq!(script, deserialized);
 }

--- a/vm/types/src/unit_tests/access_path_test.rs
+++ b/vm/types/src/unit_tests/access_path_test.rs
@@ -63,16 +63,14 @@ fn test_access_path_str_invalid() {
 
 #[test]
 fn test_bad_case_from_protest() {
-    let access_path_str =
-        "0x00000000000000000000000000000001/1/0x00000000000000000000000000000001::a::A_";
-    let access_path = AccessPath::from_str(access_path_str);
+    let raw_path = "0x00000000000000000000000000000001/1/0x00000000000000000000000000000001::a::A_";
+    let access_path = AccessPath::from_str(raw_path);
     assert!(access_path.is_ok());
 
     //The module name start with '_' will will encounter parse error
     //This may be the parser error, or the identity's arbitrary error
-    let access_path_str =
-        "0x00000000000000000000000000000001/1/0x00000000000000000000000000000001::_a::A";
-    let access_path = AccessPath::from_str(access_path_str);
+    let raw_path = "0x00000000000000000000000000000001/1/0x00000000000000000000000000000001::_a::A";
+    let access_path = AccessPath::from_str(raw_path);
     assert!(access_path.is_err());
 }
 
@@ -80,15 +78,15 @@ proptest! {
         //TODO enable this test, when test_bad_case_from_protest is fixed.
         #[ignore]
         #[test]
-        fn test_access_path(access_path in any::<AccessPath>()){
-           let bytes = bcs_ext::to_bytes(&access_path).expect("access_path serialize should ok.");
-           let access_path2 = bcs_ext::from_bytes::<AccessPath>(bytes.as_slice()).expect("access_path deserialize should ok.");
-           prop_assert_eq!(&access_path, &access_path2);
-           let access_path_str = access_path.to_string();
-           let access_path3 = AccessPath::from_str(access_path_str.as_str()).expect("access_path from str should ok");
-           prop_assert_eq!(&access_path, &access_path3);
-           let json_str = serde_json::to_string(&access_path).expect("access_path to json str should ok");
-           let access_path4 = serde_json::from_str::<AccessPath>(json_str.as_str()).expect("access_path from json str should ok");
-            prop_assert_eq!(&access_path, &access_path4);
+        fn test_access_path(raw_access_path in any::<AccessPath>()){
+           let bytes = bcs_ext::to_bytes(&raw_access_path).expect("access_path serialize should ok.");
+           let access_path = bcs_ext::from_bytes::<AccessPath>(bytes.as_slice()).expect("access_path deserialize should ok.");
+           prop_assert_eq!(&raw_access_path, &access_path);
+           let access_path = raw_access_path.to_string();
+           let access_path = AccessPath::from_str(access_path.as_str()).expect("access_path from str should ok");
+           prop_assert_eq!(&raw_access_path, &access_path);
+           let raw_json = serde_json::to_string(&raw_access_path).expect("access_path to json str should ok");
+           let access_path = serde_json::from_str::<AccessPath>(raw_json.as_str()).expect("access_path from json str should ok");
+            prop_assert_eq!(&raw_access_path, &access_path);
         }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3336

## What is the new behavior?

N/A

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

### Motivation

[P.NAM.08 避免在变量的命名中添加类型标识](https://rust-coding-guidelines.github.io/rust-coding-guidelines-zh/safe-guides/code_style/naming/P.NAM.08.html#pnam08--%E9%81%BF%E5%85%8D%E5%9C%A8%E5%8F%98%E9%87%8F%E7%9A%84%E5%91%BD%E5%90%8D%E4%B8%AD%E6%B7%BB%E5%8A%A0%E7%B1%BB%E5%9E%8B%E6%A0%87%E8%AF%86)

Variable naming containing `bytes` and `str` still exists in the project. Mainly because the Rust Analyzer code refactoring tool did not work properly in these cases, and I myself was not familiar with the code context, so I decided not to make changes for now.
