### PR TITLE
modify sync blocks timing

### DIFF
--- a/.github/workflows/sync_blocks.yml
+++ b/.github/workflows/sync_blocks.yml
@@ -3,7 +3,7 @@ name: Sync Blocks Cron
 on:
   # workflow_dispatch:
   schedule:
-    - cron: '0 17 * * *'
+    - cron: '0 5,17 * * *'
 
 jobs:
   syncBlocks:


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the new behavior?

Once a day is not enough for sync blocks task while block gap is set to 10k.
Twice a day should be ok.