### PR TITLE
[rpc] add RPC API contract.resolve_module_function_index

### DIFF
--- a/abi/resolver/src/lib.rs
+++ b/abi/resolver/src/lib.rs
@@ -419,6 +419,19 @@ mod tests {
             let func_abi = r.resolve_struct(&m, s.as_ident_str()).unwrap();
             println!("{}", serde_json::to_string_pretty(&func_abi).unwrap());
         }
+
+        // test resolve module function index
+        {
+            let m = ModuleId::new(genesis_address(), Identifier::new("Dao").unwrap());
+            let f = r.resolve_module_function_index(&m, 0).unwrap();
+            assert_eq!(f.name(), "cast_vote");
+        }
+
+        // test resolve module function index overflow
+        {
+            let m = ModuleId::new(genesis_address(), Identifier::new("Dao").unwrap());
+            assert!(r.resolve_module_function_index(&m, 31).is_err())
+        }
     }
 
     #[test]

--- a/rpc/api/src/contract_api.rs
+++ b/rpc/api/src/contract_api.rs
@@ -46,6 +46,12 @@ pub trait ContractApi {
 
     #[rpc(name = "contract.resolve_function")]
     fn resolve_function(&self, function_id: FunctionIdView) -> FutureResult<FunctionABI>;
+    #[rpc(name = "contract.resolve_module_function_index")]
+    fn resolve_module_function_index(
+        &self,
+        module_id: ModuleIdView,
+        function_index: u16,
+    ) -> FutureResult<FunctionABI>;
     #[rpc(name = "contract.resolve_struct")]
     fn resolve_struct(&self, struct_tag: StructTagView) -> FutureResult<StructInstantiation>;
     #[rpc(name = "contract.resolve_module")]

--- a/rpc/generated_rpc_schema/contract_api.json
+++ b/rpc/generated_rpc_schema/contract_api.json
@@ -3866,6 +3866,588 @@
       }
     },
     {
+      "name": "contract.resolve_module_function_index",
+      "params": [
+        {
+          "name": "module_id",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "move_core_types::language_storage::ModuleId",
+            "type": "string"
+          }
+        },
+        {
+          "name": "function_index",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "uint16",
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "FunctionABI",
+        "schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "title": "FunctionABI",
+          "type": "object",
+          "required": [
+            "args",
+            "doc",
+            "module_name",
+            "name",
+            "returns",
+            "ty_args"
+          ],
+          "properties": {
+            "args": {
+              "description": "The description of regular arguments.",
+              "type": "array",
+              "items": {
+                "description": "The description of a (regular) argument in a script.",
+                "type": "object",
+                "required": [
+                  "doc",
+                  "name",
+                  "type_tag"
+                ],
+                "properties": {
+                  "doc": {
+                    "description": "The doc of the arg.",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "The name of the argument.",
+                    "type": "string"
+                  },
+                  "type_tag": {
+                    "description": "The expected type. In Move scripts, this does contain generics type parameters.",
+                    "oneOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "Bool",
+                          "U8",
+                          "U64",
+                          "U128",
+                          "Address",
+                          "Signer"
+                        ]
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "Vector"
+                        ],
+                        "properties": {
+                          "Vector": {
+                            "$ref": "#/definitions/TypeInstantiation"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "Struct"
+                        ],
+                        "properties": {
+                          "Struct": {
+                            "type": "object",
+                            "required": [
+                              "abilities",
+                              "doc",
+                              "fields",
+                              "module_name",
+                              "name",
+                              "ty_args"
+                            ],
+                            "properties": {
+                              "abilities": {
+                                "type": "string"
+                              },
+                              "doc": {
+                                "description": "The doc of the struct",
+                                "type": "string"
+                              },
+                              "fields": {
+                                "description": "fields of the structs.",
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": [
+                                    "doc",
+                                    "name",
+                                    "type_abi"
+                                  ],
+                                  "properties": {
+                                    "doc": {
+                                      "description": "doc of the field",
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "field name",
+                                      "type": "string"
+                                    },
+                                    "type_abi": {
+                                      "description": "type of the field",
+                                      "allOf": [
+                                        {
+                                          "$ref": "#/definitions/TypeInstantiation"
+                                        }
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "module_name": {
+                                "description": "module contains the struct",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "name of the struct",
+                                "type": "string"
+                              },
+                              "ty_args": {
+                                "type": "array",
+                                "items": {
+                                  "description": "The description of a type argument in a script.",
+                                  "type": "object",
+                                  "required": [
+                                    "abilities",
+                                    "name",
+                                    "phantom",
+                                    "ty"
+                                  ],
+                                  "properties": {
+                                    "abilities": {
+                                      "type": "string"
+                                    },
+                                    "name": {
+                                      "description": "The name of the argument.",
+                                      "type": "string"
+                                    },
+                                    "phantom": {
+                                      "type": "boolean"
+                                    },
+                                    "ty": {
+                                      "$ref": "#/definitions/TypeInstantiation"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "TypeParameter"
+                        ],
+                        "properties": {
+                          "TypeParameter": {
+                            "type": "integer",
+                            "format": "uint",
+                            "minimum": 0.0
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "Reference"
+                        ],
+                        "properties": {
+                          "Reference": {
+                            "type": "array",
+                            "items": [
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "$ref": "#/definitions/TypeInstantiation"
+                              }
+                            ],
+                            "maxItems": 2,
+                            "minItems": 2
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "doc": {
+              "description": "Some text comment.",
+              "type": "string"
+            },
+            "module_name": {
+              "description": "The module name where the script lives.",
+              "type": "string"
+            },
+            "name": {
+              "description": "The public name of the script.",
+              "type": "string"
+            },
+            "returns": {
+              "description": "return types",
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "Bool",
+                      "U8",
+                      "U64",
+                      "U128",
+                      "Address",
+                      "Signer"
+                    ]
+                  },
+                  {
+                    "type": "object",
+                    "required": [
+                      "Vector"
+                    ],
+                    "properties": {
+                      "Vector": {
+                        "$ref": "#/definitions/TypeInstantiation"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "required": [
+                      "Struct"
+                    ],
+                    "properties": {
+                      "Struct": {
+                        "type": "object",
+                        "required": [
+                          "abilities",
+                          "doc",
+                          "fields",
+                          "module_name",
+                          "name",
+                          "ty_args"
+                        ],
+                        "properties": {
+                          "abilities": {
+                            "type": "string"
+                          },
+                          "doc": {
+                            "description": "The doc of the struct",
+                            "type": "string"
+                          },
+                          "fields": {
+                            "description": "fields of the structs.",
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "required": [
+                                "doc",
+                                "name",
+                                "type_abi"
+                              ],
+                              "properties": {
+                                "doc": {
+                                  "description": "doc of the field",
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "field name",
+                                  "type": "string"
+                                },
+                                "type_abi": {
+                                  "description": "type of the field",
+                                  "allOf": [
+                                    {
+                                      "$ref": "#/definitions/TypeInstantiation"
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "module_name": {
+                            "description": "module contains the struct",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "name of the struct",
+                            "type": "string"
+                          },
+                          "ty_args": {
+                            "type": "array",
+                            "items": {
+                              "description": "The description of a type argument in a script.",
+                              "type": "object",
+                              "required": [
+                                "abilities",
+                                "name",
+                                "phantom",
+                                "ty"
+                              ],
+                              "properties": {
+                                "abilities": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "description": "The name of the argument.",
+                                  "type": "string"
+                                },
+                                "phantom": {
+                                  "type": "boolean"
+                                },
+                                "ty": {
+                                  "$ref": "#/definitions/TypeInstantiation"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "required": [
+                      "TypeParameter"
+                    ],
+                    "properties": {
+                      "TypeParameter": {
+                        "type": "integer",
+                        "format": "uint",
+                        "minimum": 0.0
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "required": [
+                      "Reference"
+                    ],
+                    "properties": {
+                      "Reference": {
+                        "type": "array",
+                        "items": [
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "$ref": "#/definitions/TypeInstantiation"
+                          }
+                        ],
+                        "maxItems": 2,
+                        "minItems": 2
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            },
+            "ty_args": {
+              "description": "The names of the type arguments.",
+              "type": "array",
+              "items": {
+                "description": "The description of a type argument in a script.",
+                "type": "object",
+                "required": [
+                  "abilities",
+                  "name",
+                  "phantom"
+                ],
+                "properties": {
+                  "abilities": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "The name of the argument.",
+                    "type": "string"
+                  },
+                  "phantom": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          },
+          "definitions": {
+            "TypeInstantiation": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "Bool",
+                    "U8",
+                    "U64",
+                    "U128",
+                    "Address",
+                    "Signer"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "Vector"
+                  ],
+                  "properties": {
+                    "Vector": {
+                      "$ref": "#/definitions/TypeInstantiation"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "Struct"
+                  ],
+                  "properties": {
+                    "Struct": {
+                      "type": "object",
+                      "required": [
+                        "abilities",
+                        "doc",
+                        "fields",
+                        "module_name",
+                        "name",
+                        "ty_args"
+                      ],
+                      "properties": {
+                        "abilities": {
+                          "type": "string"
+                        },
+                        "doc": {
+                          "description": "The doc of the struct",
+                          "type": "string"
+                        },
+                        "fields": {
+                          "description": "fields of the structs.",
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "doc",
+                              "name",
+                              "type_abi"
+                            ],
+                            "properties": {
+                              "doc": {
+                                "description": "doc of the field",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "field name",
+                                "type": "string"
+                              },
+                              "type_abi": {
+                                "description": "type of the field",
+                                "allOf": [
+                                  {
+                                    "$ref": "#/definitions/TypeInstantiation"
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "module_name": {
+                          "description": "module contains the struct",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "name of the struct",
+                          "type": "string"
+                        },
+                        "ty_args": {
+                          "type": "array",
+                          "items": {
+                            "description": "The description of a type argument in a script.",
+                            "type": "object",
+                            "required": [
+                              "abilities",
+                              "name",
+                              "phantom",
+                              "ty"
+                            ],
+                            "properties": {
+                              "abilities": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "The name of the argument.",
+                                "type": "string"
+                              },
+                              "phantom": {
+                                "type": "boolean"
+                              },
+                              "ty": {
+                                "$ref": "#/definitions/TypeInstantiation"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "TypeParameter"
+                  ],
+                  "properties": {
+                    "TypeParameter": {
+                      "type": "integer",
+                      "format": "uint",
+                      "minimum": 0.0
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "Reference"
+                  ],
+                  "properties": {
+                    "Reference": {
+                      "type": "array",
+                      "items": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "$ref": "#/definitions/TypeInstantiation"
+                        }
+                      ],
+                      "maxItems": 2,
+                      "minItems": 2
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    {
       "name": "contract.resolve_struct",
       "params": [
         {

--- a/rpc/server/src/module/contract_rpc.rs
+++ b/rpc/server/src/module/contract_rpc.rs
@@ -236,6 +236,21 @@ where
         Box::pin(fut.boxed())
     }
 
+    fn resolve_module_function_index(
+        &self,
+        module_id: ModuleIdView,
+        function_idx: u16,
+    ) -> FutureResult<FunctionABI> {
+        let service = self.chain_state.clone();
+        let storage = self.storage.clone();
+        let fut = async move {
+            let state = ChainStateDB::new(storage, Some(service.state_root().await?));
+            ABIResolver::new(&state).resolve_module_function_index(&module_id.0, function_idx)
+        }
+        .map_err(map_err);
+        Box::pin(fut.boxed())
+    }
+
     fn resolve_struct(&self, struct_tag: StructTagView) -> FutureResult<StructInstantiation> {
         let service = self.chain_state.clone();
         let storage = self.storage.clone();


### PR DESCRIPTION
Related #3450.

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  #3450.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Add an new RPC API that could resolve function index from CompiledModule.
- Here is an example invocation in my own environment(deployed a toy [mycounter](https://github.com/starcoinorg/starcoin-cookbook/tree/main/examples/my-counter) contract)
    ```shell
    $ curl 'http://localhost:9850/' -X POST -H 'Content-Type: application/json' --data-raw '{"method":"contract.resolve_module_function_index","params":["0x43c83253e82b2667760caa005bfe4e36::MyCounter", 0],"id":56,"jsonrpc":"2.0"}'
    ```
- The result I got

    ```json
    {
      "jsonrpc": "2.0",
      "result": {
        "args": [
          {
            "doc": "",
            "name": "p0",
            "type_tag": {
              "Reference": [
                false,
                "Signer"
              ]
            }
          }
        ],
        "doc": "",
        "module_name": {
          "address": "0x43c83253e82b2667760caa005bfe4e36",
          "name": "MyCounter"
        },
        "name": "incr",
        "returns": [],
        "ty_args": []
      },
      "id": 56
    }

    ```

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
