### PR TITLE
[network] add version_string field to PeerInfo 

### DIFF
--- a/cmd/peer-watcher/src/main.rs
+++ b/cmd/peer-watcher/src/main.rs
@@ -28,11 +28,13 @@ fn main() {
                         info,
                         notif_protocols,
                         rpc_protocols,
+                        version_string,
                     } => Some(PeerInfo::new(
                         remote.into(),
                         *info,
                         notif_protocols,
                         rpc_protocols,
+                        version_string,
                     )),
                     _ => None,
                 }

--- a/network-p2p/src/protocol/event.rs
+++ b/network-p2p/src/protocol/event.rs
@@ -58,6 +58,7 @@ pub enum Event {
         info: Box<ChainInfo>,
         notif_protocols: Vec<Cow<'static, str>>,
         rpc_protocols: Vec<Cow<'static, str>>,
+        version_string: Option<String>,
     },
 
     /// Closed a substream with the given node. Always matches a corresponding previous

--- a/network-p2p/src/service.rs
+++ b/network-p2p/src/service.rs
@@ -1234,6 +1234,11 @@ impl Future for NetworkWorker {
                         info,
                         notif_protocols,
                         rpc_protocols,
+                        version_string: this
+                            .network_service
+                            .behaviour_mut()
+                            .node(&remote)
+                            .and_then(|i| i.client_version().map(|s| s.to_owned())),
                     });
                 }
                 Poll::Ready(SwarmEvent::Behaviour(BehaviourOut::NotificationStreamReplaced {

--- a/network-p2p/src/service_test.rs
+++ b/network-p2p/src/service_test.rs
@@ -570,6 +570,7 @@ fn test_support_protocol() {
         info: _,
         notif_protocols,
         rpc_protocols,
+        version_string: _,
     } = open_event1
     {
         assert_eq!(&remote, service2.peer_id());
@@ -594,6 +595,7 @@ fn test_support_protocol() {
         info: _,
         notif_protocols,
         rpc_protocols,
+        version_string: _,
     } = open_event2
     {
         assert_eq!(&remote, service1.peer_id());

--- a/network/api/src/tests.rs
+++ b/network/api/src/tests.rs
@@ -36,24 +36,28 @@ fn test_peer_selector() {
             ChainInfo::new(1.into(), HashValue::zero(), mock_chain_status(100.into())),
             vec![],
             vec![],
+            None,
         ),
         PeerInfo::new(
             PeerId::random(),
             ChainInfo::new(1.into(), HashValue::zero(), mock_chain_status(99.into())),
             vec![],
             vec![],
+            None,
         ),
         PeerInfo::new(
             PeerId::random(),
             ChainInfo::new(1.into(), HashValue::zero(), mock_chain_status(100.into())),
             vec![],
             vec![],
+            None,
         ),
         PeerInfo::new(
             PeerId::random(),
             ChainInfo::new(1.into(), HashValue::zero(), mock_chain_status(1.into())),
             vec![],
             vec![],
+            None,
         ),
     ];
 

--- a/network/src/service.rs
+++ b/network/src/service.rs
@@ -126,6 +126,7 @@ impl EventHandler<Self, Event> for NetworkActorService {
                 info,
                 notif_protocols,
                 rpc_protocols,
+                version_string,
             } => {
                 //TODO Refactor PeerEvent for handle protocol and substream.
                 // Currently, every notification stream open will trigger a PeerEvent, so it will trigger repeat event.
@@ -134,8 +135,13 @@ impl EventHandler<Self, Event> for NetworkActorService {
                     remote, protocol, notif_protocols, rpc_protocols
                 );
                 let peer_event = PeerEvent::Open(remote.into(), info.clone());
-                self.inner
-                    .on_peer_connected(remote.into(), *info, notif_protocols, rpc_protocols);
+                self.inner.on_peer_connected(
+                    remote.into(),
+                    *info,
+                    notif_protocols,
+                    rpc_protocols,
+                    version_string,
+                );
                 ctx.broadcast(peer_event);
             }
             Event::NotificationStreamClosed { remote, .. } => {
@@ -542,6 +548,7 @@ impl Inner {
         chain_info: ChainInfo,
         notif_protocols: Vec<Cow<'static, str>>,
         rpc_protocols: Vec<Cow<'static, str>>,
+        version_string: Option<String>,
     ) {
         self.peers
             .entry(peer_id.clone())
@@ -562,6 +569,7 @@ impl Inner {
                     chain_info,
                     notif_protocols,
                     rpc_protocols,
+                    version_string,
                 ))
             });
     }

--- a/network/src/worker.rs
+++ b/network/src/worker.rs
@@ -84,6 +84,7 @@ pub fn build_network_worker(
             .iter()
             .map(|config| config.name.clone())
             .collect(),
+        None,
     );
     let config = NetworkConfiguration {
         listen_addresses: vec![network_config.listen()],

--- a/rpc/api/src/types.rs
+++ b/rpc/api/src/types.rs
@@ -1153,6 +1153,7 @@ pub struct PeerInfoView {
     pub chain_info: ChainInfoView,
     pub notif_protocols: String,
     pub rpc_protocols: String,
+    pub version_string: Option<String>,
 }
 
 impl From<PeerInfo> for PeerInfoView {
@@ -1162,6 +1163,7 @@ impl From<PeerInfo> for PeerInfoView {
             chain_info: info.chain_info.into(),
             notif_protocols: info.notif_protocols.join(","),
             rpc_protocols: info.rpc_protocols.join(","),
+            version_string: info.version_string,
         }
     }
 }

--- a/rpc/generated_rpc_schema/node.json
+++ b/rpc/generated_rpc_schema/node.json
@@ -375,6 +375,12 @@
                 },
                 "rpc_protocols": {
                   "type": "string"
+                },
+                "version_string": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
                 }
               }
             },
@@ -611,6 +617,12 @@
               },
               "rpc_protocols": {
                 "type": "string"
+              },
+              "version_string": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             }
           }

--- a/sync/src/tasks/mock.rs
+++ b/sync/src/tasks/mock.rs
@@ -151,6 +151,7 @@ impl SyncNodeMocker {
             chain.chain_info(),
             NotificationMessage::protocols(),
             G_RPC_INFO.clone().into_protocols(),
+            None,
         );
         let peer_selector = PeerSelector::new(vec![peer_info], PeerStrategy::default(), None);
         Ok(Self::new_inner(
@@ -169,7 +170,7 @@ impl SyncNodeMocker {
     ) -> Result<Self> {
         let chain = MockChain::new(net)?;
         let peer_id = PeerId::random();
-        let peer_info = PeerInfo::new(peer_id.clone(), chain.chain_info(), vec![], vec![]);
+        let peer_info = PeerInfo::new(peer_id.clone(), chain.chain_info(), vec![], vec![], None);
         let peer_selector = PeerSelector::new(vec![peer_info], PeerStrategy::default(), None);
         Ok(Self::new_inner(
             peer_id,
@@ -217,6 +218,7 @@ impl SyncNodeMocker {
             self.chain_mocker.chain_info(),
             vec![],
             vec![],
+            None,
         )
     }
 

--- a/sync/src/tasks/tests.rs
+++ b/sync/src/tasks/tests.rs
@@ -944,6 +944,7 @@ async fn test_sync_target() {
         low_chain_info.clone(),
         vec![],
         vec![],
+        None,
     ));
     node1.produce_block(10).unwrap();
     let high_chain_info = node1.peer_info().chain_info().clone();
@@ -952,6 +953,7 @@ async fn test_sync_target() {
         high_chain_info.clone(),
         vec![],
         vec![],
+        None,
     ));
 
     let net2 = ChainNetwork::new_builtin(BuiltinNetworkID::Test);

--- a/types/src/peer_info.rs
+++ b/types/src/peer_info.rs
@@ -157,6 +157,7 @@ pub struct PeerInfo {
     pub chain_info: ChainInfo,
     pub notif_protocols: Vec<Cow<'static, str>>,
     pub rpc_protocols: Vec<Cow<'static, str>>,
+    pub version_string: Option<String>,
 }
 
 impl PeerInfo {
@@ -165,12 +166,14 @@ impl PeerInfo {
         chain_info: ChainInfo,
         notif_protocols: Vec<Cow<'static, str>>,
         rpc_protocols: Vec<Cow<'static, str>>,
+        version_string: Option<String>,
     ) -> Self {
         Self {
             peer_id,
             chain_info,
             notif_protocols,
             rpc_protocols,
+            version_string,
         }
     }
 
@@ -234,6 +237,7 @@ impl PeerInfo {
             chain_info: ChainInfo::random(),
             notif_protocols: vec![],
             rpc_protocols: vec![],
+            version_string: None,
         }
     }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3439 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Retrieve `client_version` and set it to a field `version_string` of `PeerInfo` while handshaking in `network-p2p`.
- Add a field `version_string` to `PeerInfoView` to return `version_string` in `node.peers` RPC invocation.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
