### PR TITLE
[dev] fix dev sleep command do not update on chain timestamp

### DIFF
--- a/rpc/server/src/module/debug_rpc.rs
+++ b/rpc/server/src/module/debug_rpc.rs
@@ -12,7 +12,7 @@ use starcoin_rpc_api::debug::DebugApi;
 use starcoin_rpc_api::types::FactoryAction;
 use starcoin_service_registry::bus::{Bus, BusService};
 use starcoin_service_registry::ServiceRef;
-use starcoin_types::system_events::GenerateBlockEvent;
+use starcoin_types::system_events::GenerateSleepBlockEvent;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -74,7 +74,7 @@ impl DebugApi for DebugRpcImpl {
         }
         self.config.net().time_service().sleep(time);
         self.bus
-            .broadcast(GenerateBlockEvent::new(true))
+            .broadcast(GenerateSleepBlockEvent::new(true))
             .map_err(|_e| jsonrpc_core::Error::internal_error())?;
         Ok(())
     }

--- a/types/src/system_events.rs
+++ b/types/src/system_events.rs
@@ -39,6 +39,18 @@ impl GenerateBlockEvent {
     }
 }
 
+#[derive(Clone, Debug)]
+pub struct GenerateSleepBlockEvent {
+    /// Force break current minting, and Generate new block.
+    pub force: bool,
+}
+
+impl GenerateSleepBlockEvent {
+    pub fn new(force: bool) -> Self {
+        Self { force }
+    }
+}
+
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct MintBlockEvent {
     pub parent_hash: HashValue,

--- a/vm/types/src/time.rs
+++ b/vm/types/src/time.rs
@@ -76,7 +76,7 @@ impl TimeService for RealTimeService {
         let now = self.now_millis();
         if value.milliseconds > now && value.milliseconds - now > 150000 {
             warn!(
-                "Local time {} is behind on chain time {} too match.",
+                "Local time {} is behind on chain time {} too much.",
                 now / 1000,
                 value.seconds()
             );


### PR DESCRIPTION
Add `GenerateSleepBlockEvent` to generate empty block by `dev sleep` command without check `disable-mint-empty-block`. To fix `dev sleep` command didn't update on chain timestamp.


<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

As the `disable_mint_empty_block` flag is true in Dev network, and the `dev sleep` command just trigger it to update on chain timestamp, then eventually, the `dev sleep` command didn't update on chain timestamp.

Issue Number: #3329

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Add an new event `GenerateSleepBlockEvent` that will add block directly without check `disable_mint_empty_block`


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Result of `chain info` before `dev sleep`:

<details><summary>Click to expand/collapse</summary>

```json
{
  "ok": {
    "block_info": {
      "block_accumulator_info": {
        "accumulator_root": "0x155fff75365299de34f6c17a941936f4873ff6a6ce263a38d51cc49bcdd05002",
        "frozen_subtree_roots": [
          "0x155fff75365299de34f6c17a941936f4873ff6a6ce263a38d51cc49bcdd05002"
        ],
        "num_leaves": "1",
        "num_nodes": "1"
      },
      "block_hash": "0x155fff75365299de34f6c17a941936f4873ff6a6ce263a38d51cc49bcdd05002",
      "total_difficulty": "0x01",
      "txn_accumulator_info": {
        "accumulator_root": "0xd9d8bfad3b1d05486ff3b0831c4cbd94c6ede35598cd76a69c0e3879aaf12090",
        "frozen_subtree_roots": [
          "0xd9d8bfad3b1d05486ff3b0831c4cbd94c6ede35598cd76a69c0e3879aaf12090"
        ],
        "num_leaves": "1",
        "num_nodes": "1"
      }
    },
    "chain_id": 254,
    "genesis_hash": "0x155fff75365299de34f6c17a941936f4873ff6a6ce263a38d51cc49bcdd05002",
    "head": {
      "author": "0x00000000000000000000000000000001",
      "author_auth_key": null,
      "block_accumulator_root": "0x414343554d554c41544f525f504c414345484f4c4445525f4841534800000000",
      "block_hash": "0x155fff75365299de34f6c17a941936f4873ff6a6ce263a38d51cc49bcdd05002",
      "body_hash": "0xd54136a5c1455409ef22392f2b2451e730222fd2ff8297ab3e47db8dc6d7afab",
      "chain_id": 254,
      "difficulty": "0x01",
      "extra": "0x00000000",
      "gas_used": "0",
      "nonce": 0,
      "number": "0",
      "parent_hash": "0x3a9c4141b1893c28c96eda9dd937145fe3cee63c0160b91a391b9afe789c5fd5",
      "state_root": "0x1ee14fb341b111b6fcd822f97a6b718b88e6dcd930d69e7b7620e1f4f31a2afc",
      "timestamp": "0",
      "txn_accumulator_root": "0xd9d8bfad3b1d05486ff3b0831c4cbd94c6ede35598cd76a69c0e3879aaf12090"
    }
  }
}
```
</details>

After ran `dev sleep -t 1000` command:

<details><summary>Click to expand/collapse</summary>

```json
{
  "ok": {
    "block_info": {
      "block_accumulator_info": {
        "accumulator_root": "0xb1a362f2546aafaacb6a8cf11f4fa6a813652e9a488d016364960a250326a661",
        "frozen_subtree_roots": [
          "0xb1a362f2546aafaacb6a8cf11f4fa6a813652e9a488d016364960a250326a661"
        ],
        "num_leaves": "2",
        "num_nodes": "3"
      },
      "block_hash": "0xd504e1ebbde7c7dd20387d0bc5bd1b094c1d913b20b6121c5432aa6b1bb0a111",
      "total_difficulty": "0x2711",
      "txn_accumulator_info": {
        "accumulator_root": "0xee2ccdb3ffc30051d618cb8e35a07ada6a346ecdd784de59eb59942183a71aa6",
        "frozen_subtree_roots": [
          "0xee2ccdb3ffc30051d618cb8e35a07ada6a346ecdd784de59eb59942183a71aa6"
        ],
        "num_leaves": "2",
        "num_nodes": "3"
      }
    },
    "chain_id": 254,
    "genesis_hash": "0x155fff75365299de34f6c17a941936f4873ff6a6ce263a38d51cc49bcdd05002",
    "head": {
      "author": "0x631f393a37777058f4f0845d5555e57b",
      "author_auth_key": null,
      "block_accumulator_root": "0x155fff75365299de34f6c17a941936f4873ff6a6ce263a38d51cc49bcdd05002",
      "block_hash": "0xd504e1ebbde7c7dd20387d0bc5bd1b094c1d913b20b6121c5432aa6b1bb0a111",
      "body_hash": "0xc01e0329de6d899348a8ef4bd51db56175b3fa0988e57c3dcec8eaf13a164d97",
      "chain_id": 254,
      "difficulty": "0x2710",
      "extra": "0x00000000",
      "gas_used": "0",
      "nonce": 11011,
      "number": "1",
      "parent_hash": "0x155fff75365299de34f6c17a941936f4873ff6a6ce263a38d51cc49bcdd05002",
      "state_root": "0x601996d1cf89c0062caee8bb32197c5608e3b593346f38225ca12e00f24b520c",
      "timestamp": "1001",
      "txn_accumulator_root": "0xee2ccdb3ffc30051d618cb8e35a07ada6a346ecdd784de59eb59942183a71aa6"
    }
  }
}
```
</details>