### PR TITLE
add mpm deploy subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5344,6 +5344,8 @@ dependencies = [
  "move-unit-test",
  "move-vm-runtime",
  "once_cell",
+ "starcoin-account-provider",
+ "starcoin-cmd",
  "starcoin-config",
  "starcoin-crypto",
  "starcoin-logger",
@@ -8893,6 +8895,7 @@ dependencies = [
  "starcoin-account",
  "starcoin-account-api",
  "starcoin-config",
+ "starcoin-crypto",
  "starcoin-rpc-client",
  "starcoin-types",
 ]

--- a/account/api/src/provider.rs
+++ b/account/api/src/provider.rs
@@ -9,6 +9,7 @@ use starcoin_types::transaction::{RawUserTransaction, SignedUserTransaction};
 pub enum AccountProviderStrategy {
     RPC,
     Local,
+    PrivateKey,
 }
 
 impl Default for AccountProviderStrategy {

--- a/account/provider/Cargo.toml
+++ b/account/provider/Cargo.toml
@@ -12,3 +12,4 @@ starcoin-account-api = { path = "../api", features = ["mock"] }
 starcoin-types = { path = "../../types" }
 starcoin-rpc-client = { path = "../../rpc/client" }
 starcoin-config = { path = "../../config" }
+starcoin-crypto = { git = "https://github.com/starcoinorg/starcoin-crypto", rev = "d871dfb4216f034ee334a575926c101574d9d6dc"}

--- a/account/provider/src/lib.rs
+++ b/account/provider/src/lib.rs
@@ -1,5 +1,5 @@
 mod local_provider;
-mod provider;
 mod private_key_provider;
+mod provider;
 mod rpc_provider;
 pub use provider::ProviderFactory;

--- a/account/provider/src/lib.rs
+++ b/account/provider/src/lib.rs
@@ -1,4 +1,5 @@
 mod local_provider;
 mod provider;
+mod private_key_provider;
 mod rpc_provider;
 pub use provider::ProviderFactory;

--- a/account/provider/src/private_key_provider.rs
+++ b/account/provider/src/private_key_provider.rs
@@ -1,13 +1,13 @@
 use anyhow::Result;
 use starcoin_account::{account_storage::AccountStorage, AccountManager};
-use starcoin_account_api::{AccountInfo, AccountProvider, AccountPrivateKey};
+use starcoin_account_api::{AccountInfo, AccountPrivateKey, AccountProvider};
 use starcoin_crypto::{ValidCryptoMaterial, ValidCryptoMaterialStringExt};
 use starcoin_types::account_address::AccountAddress;
 use starcoin_types::account_config::token_code::TokenCode;
 use starcoin_types::genesis_config::ChainId;
 use starcoin_types::sign_message::{SignedMessage, SigningMessage};
 use starcoin_types::transaction::{RawUserTransaction, SignedUserTransaction};
-use std::path::{Path};
+use std::path::Path;
 use std::time::Duration;
 
 pub struct AccountPrivateKeyProvider {
@@ -18,16 +18,15 @@ impl AccountPrivateKeyProvider {
     pub fn create(
         secret_file: &Path,
         address: Option<AccountAddress>,
-        chain_id: ChainId
+        chain_id: ChainId,
     ) -> Result<Self> {
         let storage = AccountStorage::mock();
         let manager = AccountManager::new(storage, chain_id)?;
 
-        let data = std::fs::read_to_string(secret_file)?.replace("\n", "");
+        let data = std::fs::read_to_string(secret_file)?.replace('\n', "");
         let private_key = AccountPrivateKey::from_encoded_string(data.as_str())?;
         let address = address.unwrap_or_else(|| private_key.public_key().derived_address());
-        let _account = manager
-            .import_account(address, private_key.to_bytes().to_vec(), "")?;
+        let _account = manager.import_account(address, private_key.to_bytes().to_vec(), "")?;
         Ok(Self { manager })
     }
 }
@@ -79,7 +78,7 @@ impl AccountProvider for AccountPrivateKeyProvider {
         duration: Duration,
     ) -> anyhow::Result<AccountInfo> {
         self.manager
-            .unlock_account(address, &"", duration)
+            .unlock_account(address, "", duration)
             .map_err(|e| e.into())
     }
 
@@ -104,7 +103,11 @@ impl AccountProvider for AccountPrivateKeyProvider {
         unimplemented!()
     }
 
-    fn export_account(&self, _address: AccountAddress, _password: String) -> anyhow::Result<Vec<u8>> {
+    fn export_account(
+        &self,
+        _address: AccountAddress,
+        _password: String,
+    ) -> anyhow::Result<Vec<u8>> {
         unimplemented!()
     }
 

--- a/account/provider/src/private_key_provider.rs
+++ b/account/provider/src/private_key_provider.rs
@@ -1,0 +1,130 @@
+use anyhow::Result;
+use starcoin_account::{account_storage::AccountStorage, AccountManager};
+use starcoin_account_api::{AccountInfo, AccountProvider, AccountPrivateKey};
+use starcoin_crypto::{ValidCryptoMaterial, ValidCryptoMaterialStringExt};
+use starcoin_types::account_address::AccountAddress;
+use starcoin_types::account_config::token_code::TokenCode;
+use starcoin_types::genesis_config::ChainId;
+use starcoin_types::sign_message::{SignedMessage, SigningMessage};
+use starcoin_types::transaction::{RawUserTransaction, SignedUserTransaction};
+use std::path::{Path};
+use std::time::Duration;
+
+pub struct AccountPrivateKeyProvider {
+    manager: AccountManager,
+}
+
+impl AccountPrivateKeyProvider {
+    pub fn create(
+        secret_file: &Path,
+        address: Option<AccountAddress>,
+        chain_id: ChainId
+    ) -> Result<Self> {
+        let storage = AccountStorage::mock();
+        let manager = AccountManager::new(storage, chain_id)?;
+
+        let data = std::fs::read_to_string(secret_file)?.replace("\n", "");
+        let private_key = AccountPrivateKey::from_encoded_string(data.as_str())?;
+        let address = address.unwrap_or_else(|| private_key.public_key().derived_address());
+        let _account = manager
+            .import_account(address, private_key.to_bytes().to_vec(), "")?;
+        Ok(Self { manager })
+    }
+}
+impl AccountProvider for AccountPrivateKeyProvider {
+    fn create_account(&self, _password: String) -> anyhow::Result<AccountInfo> {
+        unimplemented!()
+    }
+
+    fn get_default_account(&self) -> anyhow::Result<Option<AccountInfo>> {
+        self.manager.default_account_info().map_err(|e| e.into())
+    }
+
+    fn set_default_account(&self, _address: AccountAddress) -> anyhow::Result<AccountInfo> {
+        unimplemented!()
+    }
+
+    fn get_accounts(&self) -> anyhow::Result<Vec<AccountInfo>> {
+        self.manager.list_account_infos().map_err(|e| e.into())
+    }
+
+    fn get_account(&self, address: AccountAddress) -> anyhow::Result<Option<AccountInfo>> {
+        self.manager.account_info(address).map_err(|e| e.into())
+    }
+
+    fn sign_message(
+        &self,
+        address: AccountAddress,
+        message: SigningMessage,
+    ) -> anyhow::Result<SignedMessage> {
+        self.manager
+            .sign_message(address, message)
+            .map_err(|e| e.into())
+    }
+
+    fn sign_txn(
+        &self,
+        raw_txn: RawUserTransaction,
+        signer_address: AccountAddress,
+    ) -> anyhow::Result<SignedUserTransaction> {
+        self.manager
+            .sign_txn(signer_address, raw_txn)
+            .map_err(|e| e.into())
+    }
+
+    fn unlock_account(
+        &self,
+        address: AccountAddress,
+        _password: String,
+        duration: Duration,
+    ) -> anyhow::Result<AccountInfo> {
+        self.manager
+            .unlock_account(address, &"", duration)
+            .map_err(|e| e.into())
+    }
+
+    fn lock_account(&self, _address: AccountAddress) -> anyhow::Result<AccountInfo> {
+        unimplemented!()
+    }
+
+    fn import_account(
+        &self,
+        _address: AccountAddress,
+        _private_key: Vec<u8>,
+        _password: String,
+    ) -> anyhow::Result<AccountInfo> {
+        unimplemented!()
+    }
+
+    fn import_readonly_account(
+        &self,
+        _address: AccountAddress,
+        _public_key: Vec<u8>,
+    ) -> anyhow::Result<AccountInfo> {
+        unimplemented!()
+    }
+
+    fn export_account(&self, _address: AccountAddress, _password: String) -> anyhow::Result<Vec<u8>> {
+        unimplemented!()
+    }
+
+    fn accepted_tokens(&self, address: AccountAddress) -> anyhow::Result<Vec<TokenCode>> {
+        self.manager.accepted_tokens(address).map_err(|e| e.into())
+    }
+
+    fn change_account_password(
+        &self,
+        _address: AccountAddress,
+        _new_password: String,
+    ) -> anyhow::Result<AccountInfo> {
+        unimplemented!()
+    }
+
+    fn remove_account(
+        &self,
+        _address: AccountAddress,
+        _password: Option<String>,
+    ) -> anyhow::Result<AccountInfo> {
+        unimplemented!()
+    }
+}

--- a/account/provider/src/provider/mod.rs
+++ b/account/provider/src/provider/mod.rs
@@ -1,4 +1,4 @@
-use crate::local_provider::AccountLocalProvider;
+use crate::{local_provider::AccountLocalProvider, private_key_provider::AccountPrivateKeyProvider};
 use crate::rpc_provider::AccountRpcProvider;
 use anyhow::{anyhow, Result};
 use starcoin_account_api::{AccountProvider, AccountProviderStrategy};
@@ -22,6 +22,18 @@ impl ProviderFactory {
                     .account_dir
                     .as_ref()
                     .ok_or_else(|| anyhow!("expect dir for local account"))?,
+                chain_id,
+            ) {
+                Ok(p) => Ok(Box::new(p)),
+                Err(e) => Err(e),
+            },
+            AccountProviderStrategy::PrivateKey => match AccountPrivateKeyProvider::create(
+                config
+                    .secret_file
+                    .as_ref()
+                    .ok_or_else(|| anyhow!("expect secret file for private key account"))?,
+                config
+                    .account_address,
                 chain_id,
             ) {
                 Ok(p) => Ok(Box::new(p)),

--- a/account/provider/src/provider/mod.rs
+++ b/account/provider/src/provider/mod.rs
@@ -1,5 +1,7 @@
-use crate::{local_provider::AccountLocalProvider, private_key_provider::AccountPrivateKeyProvider};
 use crate::rpc_provider::AccountRpcProvider;
+use crate::{
+    local_provider::AccountLocalProvider, private_key_provider::AccountPrivateKeyProvider,
+};
 use anyhow::{anyhow, Result};
 use starcoin_account_api::{AccountProvider, AccountProviderStrategy};
 use starcoin_config::account_provider_config::AccountProviderConfig;
@@ -32,8 +34,7 @@ impl ProviderFactory {
                     .secret_file
                     .as_ref()
                     .ok_or_else(|| anyhow!("expect secret file for private key account"))?,
-                config
-                    .account_address,
+                config.account_address,
                 chain_id,
             ) {
                 Ok(p) => Ok(Box::new(p)),

--- a/account/provider/src/provider/mod.rs
+++ b/account/provider/src/provider/mod.rs
@@ -30,11 +30,9 @@ impl ProviderFactory {
                 Err(e) => Err(e),
             },
             AccountProviderStrategy::PrivateKey => match AccountPrivateKeyProvider::create(
-                config
-                    .secret_file
-                    .as_ref()
-                    .ok_or_else(|| anyhow!("expect secret file for private key account"))?,
+                config.secret_file.clone(),
                 config.account_address,
+                config.from_env,
                 chain_id,
             ) {
                 Ok(p) => Ok(Box::new(p)),

--- a/cmd/starcoin/src/account/import_cmd.rs
+++ b/cmd/starcoin/src/account/import_cmd.rs
@@ -51,7 +51,9 @@ impl CommandAction for ImportCommand {
         let private_key = match (opt.from_input.as_ref(), opt.from_file.as_ref()) {
             (Some(p), _) => AccountPrivateKey::from_encoded_string(p)?,
             (None, Some(p)) => {
-                let data = std::fs::read_to_string(p)?.replace('\n', "");
+                let data = std::fs::read_to_string(p)?
+                    .replace('\n', "")
+                    .replace('\r', "");
                 AccountPrivateKey::from_encoded_string(data.as_str())?
             }
             (None, None) => {

--- a/cmd/starcoin/src/account/import_cmd.rs
+++ b/cmd/starcoin/src/account/import_cmd.rs
@@ -51,7 +51,7 @@ impl CommandAction for ImportCommand {
         let private_key = match (opt.from_input.as_ref(), opt.from_file.as_ref()) {
             (Some(p), _) => AccountPrivateKey::from_encoded_string(p)?,
             (None, Some(p)) => {
-                let data = std::fs::read_to_string(p)?;
+                let data = std::fs::read_to_string(p)?.replace("\n", "");
                 AccountPrivateKey::from_encoded_string(data.as_str())?
             }
             (None, None) => {

--- a/cmd/starcoin/src/account/import_cmd.rs
+++ b/cmd/starcoin/src/account/import_cmd.rs
@@ -51,7 +51,7 @@ impl CommandAction for ImportCommand {
         let private_key = match (opt.from_input.as_ref(), opt.from_file.as_ref()) {
             (Some(p), _) => AccountPrivateKey::from_encoded_string(p)?,
             (None, Some(p)) => {
-                let data = std::fs::read_to_string(p)?.replace("\n", "");
+                let data = std::fs::read_to_string(p)?.replace('\n', "");
                 AccountPrivateKey::from_encoded_string(data.as_str())?
             }
             (None, None) => {

--- a/cmd/starcoin/src/dev/mod.rs
+++ b/cmd/starcoin/src/dev/mod.rs
@@ -17,7 +17,7 @@ pub(crate) mod call_api_cmd;
 mod call_contract_cmd;
 mod compile_cmd;
 mod deploy_cmd;
-pub(crate) mod dev_helper;
+pub mod dev_helper;
 pub(crate) mod gen_block_cmd;
 mod get_coin_cmd;
 pub(crate) mod log_cmd;

--- a/config/src/account_provider_config.rs
+++ b/config/src/account_provider_config.rs
@@ -14,9 +14,10 @@ pub struct AccountProviderConfig {
     #[clap(long = "local-account-dir", parse(from_os_str))]
     pub account_dir: Option<PathBuf>,
 
-    #[clap(long = "secret-file",
+    #[clap(
+        long = "secret-file",
         help = "file path of private key",
-        parse(from_os_str),
+        parse(from_os_str)
     )]
     pub secret_file: Option<PathBuf>,
 
@@ -35,7 +36,7 @@ impl ConfigModule for AccountProviderConfig {
         }
         if opt.account_provider.secret_file.is_some() {
             self.secret_file = opt.account_provider.secret_file.clone();
-            self.account_address = opt.account_provider.account_address.clone();
+            self.account_address = opt.account_provider.account_address;
         }
         assert!(
             !(self.account_dir.is_some() && self.secret_file.is_some()),
@@ -62,13 +63,16 @@ impl AccountProviderConfig {
         }
     }
 
-    pub fn new_private_key_provider_config(secret_file: PathBuf, account_address: Option<AccountAddress>) -> Self {
+    pub fn new_private_key_provider_config(
+        secret_file: PathBuf,
+        account_address: Option<AccountAddress>,
+    ) -> Self {
         Self {
             account_dir: None,
             secret_file: Some(secret_file),
             account_address,
             provider_strategy: AccountProviderStrategy::PrivateKey,
-        }    
+        }
     }
 
     pub fn get_strategy(&self) -> AccountProviderStrategy {

--- a/config/src/account_provider_config.rs
+++ b/config/src/account_provider_config.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 use starcoin_account_api::AccountProviderStrategy;
+use starcoin_types::account_address::AccountAddress;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -12,6 +13,16 @@ pub struct AccountProviderConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[clap(long = "local-account-dir", parse(from_os_str))]
     pub account_dir: Option<PathBuf>,
+
+    #[clap(long = "secret-file",
+        help = "file path of private key",
+        parse(from_os_str),
+    )]
+    pub secret_file: Option<PathBuf>,
+
+    #[clap(long = "account-address", requires("secret-file"))]
+    pub account_address: Option<AccountAddress>,
+
     #[serde(skip)]
     #[clap(skip)]
     provider_strategy: AccountProviderStrategy,
@@ -22,8 +33,18 @@ impl ConfigModule for AccountProviderConfig {
         if opt.account_provider.account_dir.is_some() {
             self.account_dir = opt.account_provider.account_dir.clone()
         }
+        if opt.account_provider.secret_file.is_some() {
+            self.secret_file = opt.account_provider.secret_file.clone();
+            self.account_address = opt.account_provider.account_address.clone();
+        }
+        assert!(
+            !(self.account_dir.is_some() && self.secret_file.is_some()),
+            "LocalDB account provider and private key account provider conflict.",
+        );
         if self.account_dir.is_some() {
             self.provider_strategy = AccountProviderStrategy::Local
+        } else if self.secret_file.is_some() {
+            self.provider_strategy = AccountProviderStrategy::PrivateKey
         } else {
             self.provider_strategy = AccountProviderStrategy::RPC
         }
@@ -35,12 +56,27 @@ impl AccountProviderConfig {
     pub fn new_local_provider_config(account_dir: PathBuf) -> Self {
         Self {
             account_dir: Some(account_dir),
+            secret_file: None,
+            account_address: None,
             provider_strategy: AccountProviderStrategy::Local,
         }
     }
+
+    pub fn new_private_key_provider_config(secret_file: PathBuf, account_address: Option<AccountAddress>) -> Self {
+        Self {
+            account_dir: None,
+            secret_file: Some(secret_file),
+            account_address,
+            provider_strategy: AccountProviderStrategy::PrivateKey,
+        }    
+    }
+
     pub fn get_strategy(&self) -> AccountProviderStrategy {
+        debug_assert!(!(self.account_dir.is_some() && self.secret_file.is_some()));
         if self.account_dir.is_some() {
             AccountProviderStrategy::Local
+        } else if self.secret_file.is_some() {
+            AccountProviderStrategy::PrivateKey
         } else {
             AccountProviderStrategy::RPC
         }
@@ -51,6 +87,8 @@ impl Default for AccountProviderConfig {
     fn default() -> Self {
         Self {
             account_dir: None,
+            secret_file: None,
+            account_address: None,
             provider_strategy: AccountProviderStrategy::RPC,
         }
     }

--- a/config/src/account_provider_config.rs
+++ b/config/src/account_provider_config.rs
@@ -32,6 +32,12 @@ impl ConfigModule for AccountProviderConfig {
 }
 
 impl AccountProviderConfig {
+    pub fn new_local_provider_config(account_dir: PathBuf) -> Self {
+        Self {
+            account_dir: Some(account_dir),
+            provider_strategy: AccountProviderStrategy::Local,
+        }
+    }
     pub fn get_strategy(&self) -> AccountProviderStrategy {
         if self.account_dir.is_some() {
             AccountProviderStrategy::Local

--- a/vm/move-package-manager/Cargo.toml
+++ b/vm/move-package-manager/Cargo.toml
@@ -50,6 +50,8 @@ starcoin-crypto = { git = "https://github.com/starcoinorg/starcoin-crypto", rev 
 starcoin-rpc-client = {path = "../../rpc/client"}
 starcoin-rpc-api = {path = "../../rpc/api"}
 starcoin-transactional-test-harness = {path = "../starcoin-transactional-test-harness"}
+starcoin-account-provider = {path = "../../account/provider"}
+starcoin-cmd = {path = "../../cmd/starcoin"}
 bcs-ext = { package="bcs-ext", path = "../../commons/bcs_ext" }
 
 [dev-dependencies]

--- a/vm/move-package-manager/src/deployment.rs
+++ b/vm/move-package-manager/src/deployment.rs
@@ -72,10 +72,10 @@ pub fn handle_deployment(_move_args: &Move, cmd: DeploymentCommand) -> anyhow::R
     let provider = if cmd.account_provider.account_dir.is_some() {
         let local_provider = ProviderFactory::create_provider(
             client.clone(),
-            node_info.net.chain_id(),    
+            node_info.net.chain_id(),
             &AccountProviderConfig::new_local_provider_config(
-                cmd.account_provider.account_dir.clone().unwrap()
-            )
+                cmd.account_provider.account_dir.clone().unwrap(),
+            ),
         )?;
         if cmd.account_provider.account_dir.is_some() {
             local_provider.unlock_account(
@@ -92,9 +92,12 @@ pub fn handle_deployment(_move_args: &Move, cmd: DeploymentCommand) -> anyhow::R
             &AccountProviderConfig::new_private_key_provider_config(
                 cmd.account_provider.secret_file.clone().unwrap(),
                 cmd.account_provider.account_address,
-            )
+            ),
         )?;
-        let sender = cmd.account_provider.account_address.unwrap_or(package_address);
+        let sender = cmd
+            .account_provider
+            .account_address
+            .unwrap_or(package_address);
         ensure!(
             sender == package_address,
             "please use package address({}) account to deploy package, currently sender is {}.",
@@ -109,13 +112,7 @@ pub fn handle_deployment(_move_args: &Move, cmd: DeploymentCommand) -> anyhow::R
         private_key_provider
     };
 
-    let state = CliState::new(
-        node_info.net,
-        client,
-        None,
-        node_handle,
-        provider,
-    );
+    let state = CliState::new(node_info.net, client, None, node_handle, provider);
 
     let transaction_opts = TransactionOptions {
         sender: Some(package_address),
@@ -134,7 +131,7 @@ pub fn handle_deployment(_move_args: &Move, cmd: DeploymentCommand) -> anyhow::R
         Err(e) => {
             println!("The deployment is failed. Reason: ");
             println!("{:?}", e);
-        },
+        }
     }
     Ok(())
 }

--- a/vm/move-package-manager/src/deployment.rs
+++ b/vm/move-package-manager/src/deployment.rs
@@ -43,7 +43,9 @@ pub fn handle_deployment(_move_args: &Move, cmd: DeploymentCommand) -> anyhow::R
     let node_handle = None;
 
     assert!(
-        cmd.account_provider.account_dir.is_some() || cmd.account_provider.secret_file.is_some(),
+        cmd.account_provider.account_dir.is_some()
+            || cmd.account_provider.secret_file.is_some()
+            || cmd.account_provider.from_env,
         "Please provide an account provider."
     );
     let package = dev_helper::load_package_from_file(cmd.mv_or_package_file.as_path())?;
@@ -51,7 +53,7 @@ pub fn handle_deployment(_move_args: &Move, cmd: DeploymentCommand) -> anyhow::R
 
     let mut txn_opts = cmd.txn_opts.clone();
     if txn_opts.sender.is_none() {
-        eprintln!(
+        println!(
             "Use package address ({}) as transaction sender",
             package_address
         );
@@ -69,7 +71,10 @@ pub fn handle_deployment(_move_args: &Move, cmd: DeploymentCommand) -> anyhow::R
         if cmd.account_provider.account_dir.is_some() {
             local_provider.unlock_account(
                 package_address,
-                cmd.account_passwd.unwrap(),
+                cmd.account_passwd.unwrap_or_else(|| {
+                    println!("No password given, use empty String.");
+                    String::from("")
+                }),
                 Duration::from_secs(300),
             )?;
         }

--- a/vm/move-package-manager/src/deployment.rs
+++ b/vm/move-package-manager/src/deployment.rs
@@ -1,0 +1,120 @@
+// Copyright (c) The Starcoin Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use anyhow::ensure;
+use clap::Parser;
+use move_cli::Move;
+use starcoin_account_provider::ProviderFactory;
+use starcoin_cmd::dev::dev_helper;
+use starcoin_cmd::view::TransactionOptions;
+use starcoin_cmd::CliState;
+use starcoin_config::account_provider_config::AccountProviderConfig;
+use starcoin_logger::prelude::info;
+use starcoin_rpc_client::RpcClient;
+use starcoin_vm_types::transaction::TransactionPayload;
+use std::path::PathBuf;
+use std::time::Duration;
+
+#[derive(Parser)]
+pub struct DeploymentCommand {
+    #[clap(name = "rpc", long)]
+    /// use remote starcoin rpc as initial state.
+    rpc: String,
+
+    #[clap(long = "block-number", requires("rpc"))]
+    /// block number to read state from. default to latest block number.
+    block_number: Option<u64>,
+
+    #[clap(long = "watch-timeout")]
+    /// Watch timeout in seconds
+    pub watch_timeout: Option<u64>,
+
+    #[clap(long = "local-account-dir", parse(from_os_str))]
+    pub account_dir: Option<PathBuf>,
+
+    #[clap(long = "password")]
+    pub account_passwd: Option<String>,
+
+    #[clap(long = "secret-file",
+        help = "file path of private key",
+        parse(from_os_str),
+        conflicts_with("local-account-dir")
+    )]
+    pub secret: Option<PathBuf>,
+
+    #[clap(name = "mv-or-package-file")]
+    /// move bytecode file path or package binary path
+    mv_or_package_file: PathBuf,
+}
+
+pub fn handle_deployment(_move_args: &Move, cmd: DeploymentCommand) -> anyhow::Result<()> {
+    info!("Try to connect node by websocket: {:?}", cmd.rpc);
+    let client = RpcClient::connect_websocket(&cmd.rpc)?;
+
+    let node_info = client.node_info()?;
+    let client = Arc::new(client);
+    let node_handle = None;
+    let account_config = AccountProviderConfig::new_local_provider_config(cmd.account_dir.unwrap());
+    let provider = ProviderFactory::create_provider(
+        client.clone(),
+        node_info.net.chain_id(),
+        &account_config,
+    )?;
+
+    let package = dev_helper::load_package_from_file(cmd.mv_or_package_file.as_path())?;
+    let package_address = package.package_address();
+
+    if cmd.account_passwd.is_some() {
+        provider.unlock_account(
+            package_address,
+            cmd.account_passwd.unwrap(),
+            Duration::from_secs(300),
+        )?;
+    }
+    let state = CliState::new(
+        node_info.net,
+        client,
+        cmd.watch_timeout.map(Duration::from_secs),
+        node_handle,
+        provider,
+    );
+
+    let mut transaction_opts = TransactionOptions {
+        sender: Some(package_address),
+        sequence_number: None,
+        max_gas_amount: None,
+        gas_unit_price: None,
+        expiration_time_secs: None,
+        blocking: true,
+        dry_run: false,
+    };
+    match transaction_opts.sender.as_ref() {
+        Some(sender) => {
+            ensure!(
+                *sender == package_address,
+                "please use package address({}) account to deploy package, currently sender is {}.",
+                package_address,
+                sender
+            );
+        }
+        None => {
+            eprintln!(
+                "Use package address ({}) as transaction sender",
+                package_address
+            );
+            transaction_opts.sender = Some(package_address);
+        }
+    };
+
+    let item =
+        state.build_and_execute_transaction(transaction_opts, TransactionPayload::Package(package));
+    println!("{:?}", item);
+    if item.is_ok() {
+        println!("Deploy successed.");
+    } else {
+        println!("Deploy failed.");
+    };
+    Ok(())
+}

--- a/vm/move-package-manager/src/deployment.rs
+++ b/vm/move-package-manager/src/deployment.rs
@@ -11,7 +11,6 @@ use starcoin_cmd::dev::dev_helper;
 use starcoin_cmd::view::TransactionOptions;
 use starcoin_cmd::CliState;
 use starcoin_config::account_provider_config::AccountProviderConfig;
-use starcoin_logger::prelude::info;
 use starcoin_rpc_client::RpcClient;
 use starcoin_vm_types::transaction::TransactionPayload;
 use std::path::PathBuf;
@@ -23,26 +22,33 @@ pub struct DeploymentCommand {
     /// use remote starcoin rpc as initial state.
     rpc: String,
 
-    #[clap(long = "block-number", requires("rpc"))]
-    /// block number to read state from. default to latest block number.
-    block_number: Option<u64>,
-
-    #[clap(long = "watch-timeout")]
-    /// Watch timeout in seconds
-    pub watch_timeout: Option<u64>,
-
-    #[clap(long = "local-account-dir", parse(from_os_str))]
-    pub account_dir: Option<PathBuf>,
+    #[clap(flatten)]
+    pub account_provider: AccountProviderConfig,
 
     #[clap(long = "password")]
     pub account_passwd: Option<String>,
 
-    #[clap(long = "secret-file",
-        help = "file path of private key",
-        parse(from_os_str),
-        conflicts_with("local-account-dir")
-    )]
-    pub secret: Option<PathBuf>,
+    #[clap(long = "sequence-number")]
+    /// transaction's sequence_number
+    /// if a transaction in the pool, you want to replace it, can use this option to set transaction's sequence_number
+    /// otherwise please let cli to auto get sequence_number from onchain and txpool.
+    pub sequence_number: Option<u64>,
+
+    #[clap(long = "max-gas-amount")]
+    /// max gas used to deploy the module
+    pub max_gas_amount: Option<u64>,
+
+    #[clap(long = "gas-price", name = "price of gas unit")]
+    /// gas price used to deploy the module
+    pub gas_unit_price: Option<u64>,
+
+    #[clap(name = "expiration-time-secs", long = "expiration-time-secs")]
+    /// how long(in seconds) the txn stay alive from now
+    pub expiration_time_secs: Option<u64>,
+
+    #[clap(short = 'b', name = "blocking-mode", long = "blocking")]
+    /// blocking wait transaction(txn) mined
+    pub blocking: bool,
 
     #[clap(name = "mv-or-package-file")]
     /// move bytecode file path or package binary path
@@ -50,71 +56,85 @@ pub struct DeploymentCommand {
 }
 
 pub fn handle_deployment(_move_args: &Move, cmd: DeploymentCommand) -> anyhow::Result<()> {
-    info!("Try to connect node by websocket: {:?}", cmd.rpc);
     let client = RpcClient::connect_websocket(&cmd.rpc)?;
 
     let node_info = client.node_info()?;
     let client = Arc::new(client);
     let node_handle = None;
-    let account_config = AccountProviderConfig::new_local_provider_config(cmd.account_dir.unwrap());
-    let provider = ProviderFactory::create_provider(
-        client.clone(),
-        node_info.net.chain_id(),
-        &account_config,
-    )?;
 
+    assert!(
+        cmd.account_provider.account_dir.is_some() || cmd.account_provider.secret_file.is_some(),
+        "Please provide an account provider."
+    );
     let package = dev_helper::load_package_from_file(cmd.mv_or_package_file.as_path())?;
     let package_address = package.package_address();
 
-    if cmd.account_passwd.is_some() {
-        provider.unlock_account(
+    let provider = if cmd.account_provider.account_dir.is_some() {
+        let local_provider = ProviderFactory::create_provider(
+            client.clone(),
+            node_info.net.chain_id(),    
+            &AccountProviderConfig::new_local_provider_config(
+                cmd.account_provider.account_dir.clone().unwrap()
+            )
+        )?;
+        if cmd.account_provider.account_dir.is_some() {
+            local_provider.unlock_account(
+                package_address,
+                cmd.account_passwd.unwrap(),
+                Duration::from_secs(300),
+            )?;
+        }
+        local_provider
+    } else {
+        let private_key_provider = ProviderFactory::create_provider(
+            client.clone(),
+            node_info.net.chain_id(),
+            &AccountProviderConfig::new_private_key_provider_config(
+                cmd.account_provider.secret_file.clone().unwrap(),
+                cmd.account_provider.account_address,
+            )
+        )?;
+        let sender = cmd.account_provider.account_address.unwrap_or(package_address);
+        ensure!(
+            sender == package_address,
+            "please use package address({}) account to deploy package, currently sender is {}.",
             package_address,
-            cmd.account_passwd.unwrap(),
+            sender
+        );
+        private_key_provider.unlock_account(
+            package_address,
+            "".to_string(),
             Duration::from_secs(300),
         )?;
-    }
+        private_key_provider
+    };
+
     let state = CliState::new(
         node_info.net,
         client,
-        cmd.watch_timeout.map(Duration::from_secs),
+        None,
         node_handle,
         provider,
     );
 
-    let mut transaction_opts = TransactionOptions {
+    let transaction_opts = TransactionOptions {
         sender: Some(package_address),
-        sequence_number: None,
-        max_gas_amount: None,
-        gas_unit_price: None,
-        expiration_time_secs: None,
-        blocking: true,
+        sequence_number: cmd.sequence_number,
+        max_gas_amount: cmd.max_gas_amount,
+        gas_unit_price: cmd.gas_unit_price,
+        expiration_time_secs: cmd.expiration_time_secs,
+        blocking: cmd.blocking,
         dry_run: false,
-    };
-    match transaction_opts.sender.as_ref() {
-        Some(sender) => {
-            ensure!(
-                *sender == package_address,
-                "please use package address({}) account to deploy package, currently sender is {}.",
-                package_address,
-                sender
-            );
-        }
-        None => {
-            eprintln!(
-                "Use package address ({}) as transaction sender",
-                package_address
-            );
-            transaction_opts.sender = Some(package_address);
-        }
     };
 
     let item =
         state.build_and_execute_transaction(transaction_opts, TransactionPayload::Package(package));
-    println!("{:?}", item);
-    if item.is_ok() {
-        println!("Deploy successed.");
-    } else {
-        println!("Deploy failed.");
-    };
+    match item {
+        Ok(_) => println!("The deployment is successful."),
+        Err(e) => {
+            println!("The deployment is failed. Reason: ");
+            println!("{:?}", e);
+        },
+    }
     Ok(())
 }

--- a/vm/move-package-manager/src/deployment.rs
+++ b/vm/move-package-manager/src/deployment.rs
@@ -3,7 +3,6 @@
 
 use std::sync::Arc;
 
-use anyhow::ensure;
 use clap::Parser;
 use move_cli::Move;
 use starcoin_account_provider::ProviderFactory;
@@ -28,27 +27,8 @@ pub struct DeploymentCommand {
     #[clap(long = "password")]
     pub account_passwd: Option<String>,
 
-    #[clap(long = "sequence-number")]
-    /// transaction's sequence_number
-    /// if a transaction in the pool, you want to replace it, can use this option to set transaction's sequence_number
-    /// otherwise please let cli to auto get sequence_number from onchain and txpool.
-    pub sequence_number: Option<u64>,
-
-    #[clap(long = "max-gas-amount")]
-    /// max gas used to deploy the module
-    pub max_gas_amount: Option<u64>,
-
-    #[clap(long = "gas-price", name = "price of gas unit")]
-    /// gas price used to deploy the module
-    pub gas_unit_price: Option<u64>,
-
-    #[clap(name = "expiration-time-secs", long = "expiration-time-secs")]
-    /// how long(in seconds) the txn stay alive from now
-    pub expiration_time_secs: Option<u64>,
-
-    #[clap(short = 'b', name = "blocking-mode", long = "blocking")]
-    /// blocking wait transaction(txn) mined
-    pub blocking: bool,
+    #[clap(flatten)]
+    txn_opts: TransactionOptions,
 
     #[clap(name = "mv-or-package-file")]
     /// move bytecode file path or package binary path
@@ -69,13 +49,22 @@ pub fn handle_deployment(_move_args: &Move, cmd: DeploymentCommand) -> anyhow::R
     let package = dev_helper::load_package_from_file(cmd.mv_or_package_file.as_path())?;
     let package_address = package.package_address();
 
+    let mut txn_opts = cmd.txn_opts.clone();
+    if txn_opts.sender.is_none() {
+        eprintln!(
+            "Use package address ({}) as transaction sender",
+            package_address
+        );
+        txn_opts.sender = Some(package_address);
+    };
+
     let provider = if cmd.account_provider.account_dir.is_some() {
         let local_provider = ProviderFactory::create_provider(
             client.clone(),
             node_info.net.chain_id(),
             &AccountProviderConfig::new_local_provider_config(
                 cmd.account_provider.account_dir.clone().unwrap(),
-            ),
+            )?,
         )?;
         if cmd.account_provider.account_dir.is_some() {
             local_provider.unlock_account(
@@ -90,22 +79,13 @@ pub fn handle_deployment(_move_args: &Move, cmd: DeploymentCommand) -> anyhow::R
             client.clone(),
             node_info.net.chain_id(),
             &AccountProviderConfig::new_private_key_provider_config(
-                cmd.account_provider.secret_file.clone().unwrap(),
-                cmd.account_provider.account_address,
-            ),
+                cmd.account_provider.secret_file.clone(),
+                txn_opts.sender,
+                cmd.account_provider.from_env,
+            )?,
         )?;
-        let sender = cmd
-            .account_provider
-            .account_address
-            .unwrap_or(package_address);
-        ensure!(
-            sender == package_address,
-            "please use package address({}) account to deploy package, currently sender is {}.",
-            package_address,
-            sender
-        );
         private_key_provider.unlock_account(
-            package_address,
+            txn_opts.sender.unwrap(),
             "".to_string(),
             Duration::from_secs(300),
         )?;
@@ -114,18 +94,8 @@ pub fn handle_deployment(_move_args: &Move, cmd: DeploymentCommand) -> anyhow::R
 
     let state = CliState::new(node_info.net, client, None, node_handle, provider);
 
-    let transaction_opts = TransactionOptions {
-        sender: Some(package_address),
-        sequence_number: cmd.sequence_number,
-        max_gas_amount: cmd.max_gas_amount,
-        gas_unit_price: cmd.gas_unit_price,
-        expiration_time_secs: cmd.expiration_time_secs,
-        blocking: cmd.blocking,
-        dry_run: false,
-    };
-
     let item =
-        state.build_and_execute_transaction(transaction_opts, TransactionPayload::Package(package));
+        state.build_and_execute_transaction(cmd.txn_opts, TransactionPayload::Package(package));
     match item {
         Ok(_) => println!("The deployment is successful."),
         Err(e) => {

--- a/vm/move-package-manager/src/lib.rs
+++ b/vm/move-package-manager/src/lib.rs
@@ -21,6 +21,7 @@ use std::str::FromStr;
 use std::sync::Mutex;
 
 pub mod compatibility_check_cmd;
+pub mod deployment;
 pub mod releasement;
 
 // use `integration-tests` rather than `tests`, for avoid conflict with `mpm package test`

--- a/vm/move-package-manager/src/main.rs
+++ b/vm/move-package-manager/src/main.rs
@@ -9,6 +9,7 @@ use move_core_types::errmap::ErrorMapping;
 use move_package_manager::compatibility_check_cmd::{
     handle_compatibility_check, CompatibilityCheckCommand,
 };
+use move_package_manager::deployment::{handle_deployment, DeploymentCommand};
 use move_package_manager::releasement::{handle_release, Releasement};
 use move_package_manager::{run_integration_test, IntegrationTestCommand};
 use starcoin_config::genesis_config;
@@ -64,6 +65,10 @@ pub enum Commands {
     /// Check compatibility of modules comparing with remote chain state.
     #[clap(name = "check-compatibility")]
     CompatibilityCheck(CompatibilityCheckCommand),
+
+    /// Deploy package to chain
+    #[clap(name = "deploy")]
+    Deploy(DeploymentCommand),
 }
 
 fn main() -> Result<()> {
@@ -91,5 +96,6 @@ fn main() -> Result<()> {
         Commands::Experimental { storage_dir, cmd } => cmd.handle_command(move_args, &storage_dir),
         Commands::Release(releasement) => handle_release(move_args, releasement),
         Commands::CompatibilityCheck(cmd) => handle_compatibility_check(move_args, cmd),
+        Commands::Deploy(cmd) => handle_deployment(move_args, cmd),
     }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3462 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Add `mpm deploy` subcommand.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Draft 版本，目前已经将 `starcoin dev deploy` 命令的功能移植到 `mpm deploy`。 使用命令如下：

```
mpm deploy --rpc ws://127.0.0.1:9871 --local-account-dir ~/.starcoin/main/account_vaults/ --password xxxx /path/to/package
```
考虑到 mpm 不应该过度依赖 starcoin node，因此只支持 rpc 链接； 因为需要签名，所以需要 account 已经 password 来unlock 账号。也许将这些 rpc 参数放到一个配置文件， 将密码参数放到一个 .secret 文件中更方便一点？

是否有其他的需求和建议？ @jolestar @WGB5445