### PR TITLE
add monitor for ci autoscaler

### DIFF
--- a/.github/workflows/ci_monitor_scaler.yml
+++ b/.github/workflows/ci_monitor_scaler.yml
@@ -1,0 +1,23 @@
+name: Monitor CI Scaler
+
+on:
+  # workflow_dispatch:
+  schedule:
+    - cron: '0 5,17 * * *'
+
+jobs:
+  MonitorCI:
+    name: monitor ci scaler
+    runs-on: self-hosted
+    steps:
+      - name: checkout
+        uses: actions/checkout@v1
+        with:
+          submodules: recursive
+      - name: setup environment
+        run: bash ./scripts/dev_setup.sh  -b -t -y
+      - name: check scaler
+        run: python3 ./scripts/monitor_autoscaler_recreate.py
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ci_monitor_scaler.yml
+++ b/.github/workflows/ci_monitor_scaler.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   MonitorCI:
     name: monitor ci scaler
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v1

--- a/scripts/monitor_autoscaler_recreate.py
+++ b/scripts/monitor_autoscaler_recreate.py
@@ -1,0 +1,35 @@
+import os
+import time
+
+from datetime import datetime
+
+
+def trigger_scale():
+    # get last scaler pod name
+    last_pod = ""
+    get_last_scaler_pod_cmd = "wget https://s3.ap-northeast-1.amazonaws.com/main.starcoin.org/main/last_scaler_pod.txt -O ./last_scaler_pod.txt"
+    os.system(get_last_scaler_pod_cmd)
+    with open('./last_scaler_pod.txt', 'r') as f:
+        last_pod = int(f.readline())
+
+    os.system(
+        "kubectl get pods -n kube-system | grep auto | awk -F ' ' '{print$1}' > tmp")
+    with open('tmp', 'r') as f:
+        lastest_scalerpod = f.read().strip()
+    print("current time is %s, last_pod is %s, lastest_scalerpod is %s" % (
+        datetime.now().strftime("%Y-%m-%d, %H:%M:%S"), last_pod, lastest_scalerpod))
+
+    if lastest_scalerpod != last_pod and lastest_scalerpod != "":
+        print("current time is %s, last_pod is %s, lastest_scalerpod is %s, we will trigger asg to scale one node up" % (
+            datetime.now().strftime("%Y-%m-%d, %H:%M:%S"), last_pod, lastest_scalerpod))
+        os.system(
+            "eksctl scale nodegroup --region=ap-northeast-1 --cluster=starcoin2 --nodes=1 ci-pool-200G")
+
+        # update last_scaler_pod.txt
+        last_pod = lastest_scalerpod
+        os.system("echo %s > ./last_scaler_pod.txt" % lastest_scalerpod)
+        os.system("aws s3api put-object --bucket main.starcoin.org --key main/last_scaler_pod.txt --body ./last_scaler_pod.txt")
+
+
+if __name__ == "__main__":
+    trigger_scale()


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

the autoscaler of ci nodes will not response the scale event, when it was recreated.

## What is the new behavior?

we monitor the ci node, if it had been recreated, trigger the scale event to 1 node, everything will be fine then. if the node idle for a while, it will be automaticlly scale to 0.

