### PR TITLE
[cli] dry run at cli side and print warn log when transaction execute failed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9346,11 +9346,13 @@ dependencies = [
  "starcoin-crypto",
  "starcoin-logger",
  "starcoin-resource-viewer",
+ "starcoin-rpc-api",
  "starcoin-state-api",
  "starcoin-statedb",
  "starcoin-vm-runtime",
  "starcoin-vm-types",
  "thiserror",
+ "vm-status-translator",
 ]
 
 [[package]]

--- a/cmd/starcoin/src/cli_state.rs
+++ b/cmd/starcoin/src/cli_state.rs
@@ -287,7 +287,7 @@ impl CliState {
                 TransactionStatusView::Executed
             )
         {
-            eprintln!("txn dry run failed");
+            eprintln!("txn dry run result:");
             return Ok(execute_result);
         }
 

--- a/cmd/starcoin/src/cli_state.rs
+++ b/cmd/starcoin/src/cli_state.rs
@@ -19,10 +19,11 @@ use bcs_ext::BCSCodec;
 use starcoin_abi_decoder::{decode_txn_payload, DecodedTransactionPayload};
 use starcoin_account_api::{AccountInfo, AccountProvider};
 use starcoin_config::{ChainNetworkID, DataDirPath};
+use starcoin_dev::playground;
 use starcoin_node::NodeHandle;
 use starcoin_rpc_api::chain::GetEventOption;
 use starcoin_rpc_api::types::{
-    RawUserTransactionView, SignedUserTransactionView, TransactionStatusView,
+    DryRunOutputView, RawUserTransactionView, SignedUserTransactionView, TransactionStatusView,
 };
 use starcoin_rpc_client::{RpcClient, StateRootOption};
 use starcoin_state_api::StateReaderExt;
@@ -258,6 +259,11 @@ impl CliState {
         ))
     }
 
+    pub fn dry_run_transaction(&self, txn: DryRunTransaction) -> Result<DryRunOutputView> {
+        let state_reader = self.client().state_reader(StateRootOption::Latest)?;
+        playground::dry_run_explain(&state_reader, txn, None)
+    }
+
     pub fn execute_transaction(
         &self,
         raw_txn: RawUserTransaction,
@@ -266,7 +272,7 @@ impl CliState {
     ) -> Result<ExecuteResultView> {
         let sender = self.get_account(raw_txn.sender())?;
         let public_key = sender.public_key;
-        let dry_output = self.client.dry_run_raw(DryRunTransaction {
+        let dry_output = self.dry_run_transaction(DryRunTransaction {
             public_key: public_key.clone(),
             raw_txn: raw_txn.clone(),
         })?;

--- a/vm/dev/Cargo.toml
+++ b/vm/dev/Cargo.toml
@@ -1,22 +1,24 @@
 [package]
-name = "starcoin-dev"
-version = "1.11.11"
 authors = ["Starcoin Core Dev <dev@starcoin.org>"]
-license = "Apache-2.0"
-publish = false
 edition = "2021"
+license = "Apache-2.0"
+name = "starcoin-dev"
+publish = false
+version = "1.11.11"
 
 [dependencies]
 anyhow = "1.0.41"
-thiserror = "1.0"
-starcoin-crypto = { git = "https://github.com/starcoinorg/starcoin-crypto", rev = "d871dfb4216f034ee334a575926c101574d9d6dc"}
-starcoin-vm-types = { path = "../types" }
-starcoin-vm-runtime = { path = "../vm-runtime"}
-starcoin-logger = {path = "../../commons/logger"}
-starcoin-state-api = { path = "../../state/api"}
-starcoin-statedb = { path = "../../state/statedb"}
-starcoin-resource-viewer = {path = "../resource-viewer"}
-starcoin-abi-resolver = {path = "../../abi/resolver"}
+bcs-ext = {path = "../../commons/bcs_ext"}
 starcoin-abi-decoder = {path = "../../abi/decoder"}
+starcoin-abi-resolver = {path = "../../abi/resolver"}
 starcoin-abi-types = {path = "../../abi/types"}
-bcs-ext = {path  = "../../commons/bcs_ext" }
+starcoin-crypto = {git = "https://github.com/starcoinorg/starcoin-crypto", rev = "d871dfb4216f034ee334a575926c101574d9d6dc"}
+starcoin-logger = {path = "../../commons/logger"}
+starcoin-resource-viewer = {path = "../resource-viewer"}
+starcoin-rpc-api = {path = "../../rpc/api"}
+starcoin-state-api = {path = "../../state/api"}
+starcoin-statedb = {path = "../../state/statedb"}
+starcoin-vm-runtime = {path = "../vm-runtime"}
+starcoin-vm-types = {path = "../types"}
+thiserror = "1.0"
+vm-status-translator = {path = "../vm-status-translator"}

--- a/vm/vm-runtime/src/starcoin_vm.rs
+++ b/vm/vm-runtime/src/starcoin_vm.rs
@@ -498,7 +498,10 @@ impl StarcoinVM {
                         only_new_module,
                     },
                 )
-                .map_err(|e| e.into_vm_status())?;
+                .map_err(|e| {
+                    warn!("[VM] execute_package error, status_type: {:?}, status_code:{:?}, message:{:?}, location:{:?}", e.status_type(), e.major_status(), e.message(), e.location());
+                    e.into_vm_status()
+                })?;
 
             // after publish the modules, we need to clear loader cache, to make init script function and
             // epilogue use the new modules.
@@ -599,7 +602,11 @@ impl StarcoinVM {
                     return Err(VMStatus::Error(StatusCode::UNREACHABLE));
                 }
             }
-            .map_err(|e| e.into_vm_status())?;
+            .map_err(|e|
+                {
+                    warn!("[VM] execute_script_function error, status_type: {:?}, status_code:{:?}, message:{:?}, location:{:?}", e.status_type(), e.major_status(), e.message(), e.location());
+                    e.into_vm_status()
+                })?;
 
             charge_global_write_gas_usage(cost_strategy, &session, &txn_data.sender())?;
 


### PR DESCRIPTION
Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):



## What is the new behavior?


1. 在 cli 中执行 dry run，状态通过 remote state reader 获取，虚拟机在 cli 中执行，方便 debug。
2. 交易执行失败后打印 WARN 日志，但方便排查问题。

```
starcoin --connect ws://barnard.seed.starcoin.org:9870 --local-account-dir ~/.starcoin/barnard/account_vaults  dev deploy --dry-run package.blob
```