### PR TITLE
add backward compatibility for AccountProviderConfig

### DIFF
--- a/config/src/account_provider_config.rs
+++ b/config/src/account_provider_config.rs
@@ -17,6 +17,7 @@ pub struct AccountProviderConfig {
     pub account_dir: Option<PathBuf>,
 
     /// Path to the secret file storing the private key.
+    #[serde(skip_serializing_if = "Option::is_none")]
     #[clap(
         long = "secret-file",
         help = "file path of private key",

--- a/config/src/account_provider_config.rs
+++ b/config/src/account_provider_config.rs
@@ -25,6 +25,7 @@ pub struct AccountProviderConfig {
     pub secret_file: Option<PathBuf>,
 
     /// Read private from env variable `STARCOIN_PRIVATE_KEY`.
+    #[serde(default)]
     #[clap(long = "from-env")]
     pub from_env: bool,
 


### PR DESCRIPTION
add serde default for AccountProviderConfig's field named from_env

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/starcoinorg/starcoin/issues/3630

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
backward to old version of config.toml

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
