### PR TITLE
add var and read_json in mpm integration-test

### DIFF
--- a/vm/starcoin-transactional-test-harness/src/lib.rs
+++ b/vm/starcoin-transactional-test-harness/src/lib.rs
@@ -211,7 +211,7 @@ pub struct DeploySub {
 #[clap(name = "var")]
 pub struct VarSub {
     #[clap(name="var",
-        parse(try_from_str = parse_env),
+        parse(try_from_str = parse_var),
         takes_value(true),
         multiple_values(true),
         multiple_occurrences(true)
@@ -297,7 +297,7 @@ pub enum StarcoinSubcommands {
     #[clap(name = "var")]
     Var {
         #[clap(name="var",
-            parse(try_from_str = parse_env),
+            parse(try_from_str = parse_var),
             takes_value(true),
             multiple_values(true),
             multiple_occurrences(true)
@@ -320,7 +320,7 @@ fn parse_params(params: &str) -> Result<Params> {
     Ok(params)
 }
 
-pub fn parse_env(s: &str) -> anyhow::Result<(String, String)> {
+pub fn parse_var(s: &str) -> anyhow::Result<(String, String)> {
     let before_after = s.split('=').collect::<Vec<_>>();
 
     if before_after.len() != 2 {
@@ -1008,12 +1008,12 @@ impl<'a> StarcoinTestAdapter<'a> {
         }
     }
 
-    fn handle_env(
+    fn handle_var(
         &mut self,
-        envs: Vec<(String, String)>,
+        vars: Vec<(String, String)>,
     ) -> Result<(Option<String>, Option<Value>)> {
-        let env_dict: HashMap<String, String> = envs.into_iter().collect();
-        Ok((None, Some(serde_json::to_value(&env_dict)?)))
+        let var_dict: HashMap<String, String> = vars.into_iter().collect();
+        Ok((None, Some(serde_json::to_value(&var_dict)?)))
     }
 
     fn handle_read_json(&mut self, file: &Path) -> Result<(Option<String>, Option<Value>)> {
@@ -1315,7 +1315,7 @@ impl<'a> MoveTestAdapter<'a> for StarcoinTestAdapter<'a> {
                 gas_budget,
                 mv_or_package_file,
             } => self.handle_deploy(signers, gas_budget, mv_or_package_file.as_path()),
-            StarcoinSubcommands::Var { var } => self.handle_env(var),
+            StarcoinSubcommands::Var { var } => self.handle_var(var),
             StarcoinSubcommands::ReadJson { file } => self.handle_read_json(file.as_path()),
         }?;
         if self.debug {

--- a/vm/starcoin-transactional-test-harness/tests/cases/content.json
+++ b/vm/starcoin-transactional-test-harness/tests/cases/content.json
@@ -1,0 +1,12 @@
+{
+    "name": "John Doe",
+    "age": 43,
+    "address": {
+        "street": "10 Downing Street",
+        "city": "London"
+    },
+    "phones": [
+        "+44 1234567",
+        "+44 2345678"
+    ]
+}

--- a/vm/starcoin-transactional-test-harness/tests/cases/content.json
+++ b/vm/starcoin-transactional-test-harness/tests/cases/content.json
@@ -1,12 +1,4 @@
 {
-    "name": "John Doe",
-    "age": 43,
-    "address": {
-        "street": "10 Downing Street",
-        "city": "London"
-    },
-    "phones": [
-        "+44 1234567",
-        "+44 2345678"
-    ]
+    "id": 253,
+    "name": "halley"
 }

--- a/vm/starcoin-transactional-test-harness/tests/cases/var.exp
+++ b/vm/starcoin-transactional-test-harness/tests/cases/var.exp
@@ -2,6 +2,6 @@ processed 5 tasks
 
 task 4 'run'. lines 9-16:
 {
-  "gas_used": 11943,
+  "gas_used": 8769,
   "status": "Executed"
 }

--- a/vm/starcoin-transactional-test-harness/tests/cases/var.exp
+++ b/vm/starcoin-transactional-test-harness/tests/cases/var.exp
@@ -1,0 +1,7 @@
+processed 5 tasks
+
+task 4 'run'. lines 9-16:
+{
+  "gas_used": 11943,
+  "status": "Executed"
+}

--- a/vm/starcoin-transactional-test-harness/tests/cases/var.move
+++ b/vm/starcoin-transactional-test-harness/tests/cases/var.move
@@ -6,11 +6,11 @@
 
 //# var a=123 addr={{$.faucet[0].txn.raw_txn.decoded_payload.ScriptFunction.args[0]}}
 
-//#run --signers creator --args {{$.var[0].a}}u64 --args {{$.var[0].addr}}
+//#run --signers creator --args {{$.var[0].a}}u64 --args {{$.var[0].addr}} --args {{$.read-json[0].id}}u64
 script {
-     use StarcoinFramework::Debug;
-     fun main(_sender: signer, number: u64, addr: address) {
-          Debug::print(&number);
-          Debug::print(&addr);
+     fun main(_sender: signer, number: u64, addr: address, id: u64) {
+          assert!(number == 123, 101);
+          assert!(addr == @creator, 102);
+          assert!(id == 253, 103);
      }
 }

--- a/vm/starcoin-transactional-test-harness/tests/cases/var.move
+++ b/vm/starcoin-transactional-test-harness/tests/cases/var.move
@@ -1,0 +1,16 @@
+//# init -n dev
+
+//# faucet --addr creator --amount 12345000000
+
+//# read-json tests/cases/content.json
+
+//# var a=123 addr={{$.faucet[0].txn.raw_txn.decoded_payload.ScriptFunction.args[0]}}
+
+//#run --signers creator --args {{$.var[0].a}}u64 --args {{$.var[0].addr}}
+script {
+     use StarcoinFramework::Debug;
+     fun main(_sender: signer, number: u64, addr: address) {
+          Debug::print(&number);
+          Debug::print(&addr);
+     }
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolve #3711

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- mpm integration-test add two new directives: `var` and `read-json`.
- `var` can be used to set global variable, cmd: `//# var <key1>=<value1> <key2>=<value2> ...`
- `read-json` can read json content from local file, cmd: `//# read-json <file_path>`
- usage example:
```
//# init -n dev

//# faucet --addr creator --amount 12345000000

//# read-json tests/cases/content.json

//# var a=123 addr={{$.faucet[0].txn.raw_txn.decoded_payload.ScriptFunction.args[0]}}

//#run --signers creator --args {{$.var[0].a}}u64 --args {{$.var[0].addr}}
script {
     use StarcoinFramework::Debug;
     fun main(_sender: signer, number: u64, addr: address) {
          Debug::print(&number);
          Debug::print(&addr);
     }
}
```

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
