### PR TITLE
[test] larger timeout on `full_sync` test

### DIFF
--- a/sync/src/tasks/tests.rs
+++ b/sync/src/tasks/tests.rs
@@ -289,7 +289,7 @@ pub async fn test_full_sync_fork() -> Result<()> {
     Ok(())
 }
 
-#[stest::test]
+#[stest::test(timeout = 120)]
 pub async fn test_full_sync_fork_from_genesis() -> Result<()> {
     let net1 = ChainNetwork::new_builtin(BuiltinNetworkID::Test);
     let mut node1 = SyncNodeMocker::new(net1, 1, 50)?;
@@ -342,7 +342,7 @@ pub async fn test_full_sync_fork_from_genesis() -> Result<()> {
     Ok(())
 }
 
-#[stest::test]
+#[stest::test(timeout = 120)]
 pub async fn test_full_sync_continue() -> Result<()> {
     let net1 = ChainNetwork::new_builtin(BuiltinNetworkID::Test);
     let mut node1 = SyncNodeMocker::new(net1, 10, 50)?;


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/starcoinorg/starcoin/pull/3741#issuecomment-1250615387

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
single threaded test time on local machine：
test_full_sync_continue 78.52s
test_full_sync_fork_from_genesis 64.57s
