### PR TITLE
remove Ofast on ubuntu22

### DIFF
--- a/consensus/cryptonight-rs/build.rs
+++ b/consensus/cryptonight-rs/build.rs
@@ -27,7 +27,7 @@ fn main() {
     }
     if target_os.contains("linux") || target_os.contains("macos") {
         config
-            .flag("-Ofast")
+            // .flag("-Ofast")
             .flag("-fexceptions")
             .flag("-std=gnu99");
     }

--- a/consensus/cryptonight-rs/ext/slow-hash.c
+++ b/consensus/cryptonight-rs/ext/slow-hash.c
@@ -1313,6 +1313,8 @@ void cn_slow_hash(const void *data, size_t length, char *hash, int variant, int 
     memcpy(state.init, text, INIT_SIZE_BYTE);
     hash_permutation(&state.hs);
     extra_hashes[state.hs.b[0] & 3](&state, 200, hash);
+
+    cn_slow_hash_free_state();
 }
 #else /* aarch64 && crypto */
 

--- a/consensus/cryptonight-rs/src/tests.rs
+++ b/consensus/cryptonight-rs/src/tests.rs
@@ -20,11 +20,25 @@ fn test_slow4() {
 
 // add a test for amd ryzen cpu
 // add -Ofast in build.rs, this test will failed on amd ryzen cpu.
+// the data is run main net block2
 #[test]
 fn test_amd_ryzen() {
     let data = TestCase {
         input: "5f9f9874ec4def414b963687c4b17e00377150cc175f5c6d6e4182c6cb4378550000000000000079de00c0000000000000000000000000000000000000000000000000000000000000b1ec37".from_hex().unwrap(),
         output: "0000008e67af69c3c670dab325e8fc3a9dc045c6e339aa35f43b415604513742".from_hex().unwrap(),
+    };
+    let hash = cryptonight_r(&data.input[..], data.input.len());
+    assert_eq!(hash, data.output);
+}
+
+// add a test for ubuntu22
+// add -Ofast in build.rs, this test will failed on unbuntu22
+// the data is gen from verify_header_test_barnard_block3_ubuntu22
+#[test]
+fn test_barnard_block3_on_ubuntu22() {
+    let data = TestCase {
+        input: "40ff1c32b590d20637c8cc5857f48b8e732fb8884bb878da7d9893cd837e78a800000000000000e81a85ac0000000000000000000000000000000000000000000000000000000000000001de".from_hex().unwrap(),
+        output: "0019decf119ed0413f5ddebb791f323b8bbe739eeaf943f4ff367b8ba4d3120f".from_hex().unwrap(),
     };
     let hash = cryptonight_r(&data.input[..], data.input.len());
     assert_eq!(hash, data.output);

--- a/consensus/cryptonight-rs/src/tests.rs
+++ b/consensus/cryptonight-rs/src/tests.rs
@@ -18,6 +18,18 @@ fn test_slow4() {
     assert_eq!(hash, data.output);
 }
 
+// add a test for amd ryzen cpu
+// add -Ofast in build.rs, this test will failed on amd ryzen cpu.
+#[test]
+fn test_amd_ryzen() {
+    let mut data = TestCase {
+        input: "5f9f9874ec4def414b963687c4b17e00377150cc175f5c6d6e4182c6cb4378550000000000000079de00c0000000000000000000000000000000000000000000000000000000000000b1ec37".from_hex().unwrap(),
+        output: "0000008e67af69c3c670dab325e8fc3a9dc045c6e339aa35f43b415604513742".from_hex().unwrap(),
+    };
+    let hash = cryptonight_r(&data.input[..], data.input.len());
+    assert_eq!(hash, data.output);
+}
+
 #[test]
 #[ignore]
 fn test_with_spawn() {

--- a/consensus/cryptonight-rs/src/tests.rs
+++ b/consensus/cryptonight-rs/src/tests.rs
@@ -22,7 +22,7 @@ fn test_slow4() {
 // add -Ofast in build.rs, this test will failed on amd ryzen cpu.
 #[test]
 fn test_amd_ryzen() {
-    let mut data = TestCase {
+    let data = TestCase {
         input: "5f9f9874ec4def414b963687c4b17e00377150cc175f5c6d6e4182c6cb4378550000000000000079de00c0000000000000000000000000000000000000000000000000000000000000b1ec37".from_hex().unwrap(),
         output: "0000008e67af69c3c670dab325e8fc3a9dc045c6e339aa35f43b415604513742".from_hex().unwrap(),
     };

--- a/consensus/src/consensus_test.rs
+++ b/consensus/src/consensus_test.rs
@@ -7,9 +7,12 @@ use crate::consensus::Consensus;
 use crate::difficulty::{get_next_target_helper, BlockDiffInfo};
 use crate::{difficult_to_target, target_to_difficulty, G_CRYPTONIGHT};
 use starcoin_crypto::hash::PlainCryptoHash;
+use starcoin_crypto::HashValue;
 use starcoin_time_service::{duration_since_epoch, MockTimeService, TimeService, TimeServiceType};
-use starcoin_types::block::{BlockHeader, BlockHeaderBuilder, RawBlockHeader};
+use starcoin_types::account_address::AccountAddress;
+use starcoin_types::block::{BlockHeader, BlockHeaderBuilder, BlockHeaderExtra, RawBlockHeader};
 use starcoin_types::U256;
+use starcoin_vm_types::genesis_config::ChainId;
 use std::collections::VecDeque;
 
 #[stest::test]
@@ -53,6 +56,43 @@ fn test_get_next_target() {
     assert!((time_used as i64 - 20_000).abs() <= 1000);
     let time_used = simulate_blocks(5_000, 1000.into());
     assert!((time_used as i64 - 5_000).abs() <= 1000);
+}
+
+#[stest::test]
+fn verify_header_test_barnard_block3_ubuntu22() {
+    let header = BlockHeader::new(
+        HashValue::from_hex_literal(
+            "0xae1c7990f16e056bbaa7eb82ad0aec905a4ea0c559ca623f13c2a91403f81ecc",
+        )
+        .unwrap(),
+        1616847038282,
+        3,
+        AccountAddress::from_hex_literal("0x94e957321e7bb2d3eb08ff6be81a6fcd").unwrap(),
+        HashValue::from_hex_literal(
+            "0x3da1d80128ea59c683cd1ca88f77b239fb46afa28e9f4b25753b147ca0cefaba",
+        )
+        .unwrap(),
+        HashValue::from_hex_literal(
+            "0x3df88e7a7b0ae0064fa284f71a3777c76aa83b30f16e8875a5b3ba1d94ca83b1",
+        )
+        .unwrap(),
+        HashValue::from_hex_literal(
+            "0x610596802d69223d593b5f708e5803c53f1b5958a25097ae7f8fe8cd52ce6e51",
+        )
+        .unwrap(),
+        0,
+        478.into(),
+        HashValue::from_hex_literal(
+            "0xc01e0329de6d899348a8ef4bd51db56175b3fa0988e57c3dcec8eaf13a164d97",
+        )
+        .unwrap(),
+        ChainId::new(251),
+        2894404328,
+        BlockHeaderExtra::new([0u8; 4]),
+    );
+    G_CRYPTONIGHT
+        .verify_header_difficulty(header.difficulty(), &header)
+        .unwrap()
 }
 
 fn simulate_blocks(time_plan: u64, init_difficulty: U256) -> u64 {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
移除Ofast编译选项
需要在ubuntu18, ubuntu22上跑通所有历史区块才能合并到master
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
