### PR TITLE
starcoin cli supports subscribing NewMintBlock event

### DIFF
--- a/cmd/starcoin/src/dev/subscribe_cmd.rs
+++ b/cmd/starcoin/src/dev/subscribe_cmd.rs
@@ -98,6 +98,29 @@ impl CommandAction for SubscribeBlockCommand {
         Ok(())
     }
 }
+
+#[derive(Debug, Parser)]
+#[clap(name = "new_mint_block")]
+pub struct SubscribeNewMintBlockOpt {}
+pub struct SubscribeNewMintBlockCommand;
+impl CommandAction for SubscribeNewMintBlockCommand {
+    type State = CliState;
+    type GlobalOpt = StarcoinOpt;
+    type Opt = SubscribeNewMintBlockOpt;
+    type ReturnItem = ();
+    fn run(
+        &self,
+        ctx: &ExecContext<Self::State, Self::GlobalOpt, Self::Opt>,
+    ) -> Result<Self::ReturnItem> {
+        let event_stream = ctx.state().client().subscribe_new_mint_blocks()?;
+        println!("Subscribe successful, Press `q` and Enter to quit");
+        blocking_display_notification(event_stream, |evt| {
+            serde_json::to_string(&evt).expect("should never fail")
+        });
+        Ok(())
+    }
+}
+
 #[derive(Debug, Parser)]
 #[clap(name = "new_pending_txn")]
 pub struct SubscribeNewTxnOpt {}

--- a/cmd/starcoin/src/lib.rs
+++ b/cmd/starcoin/src/lib.rs
@@ -128,6 +128,7 @@ pub fn add_command(
                 .subcommand(
                     CustomCommand::with_name("subscribe")
                         .with_about("Subscribe the chain events")
+                        .subcommand(dev::SubscribeNewMintBlockCommand)
                         .subcommand(dev::SubscribeBlockCommand)
                         .subcommand(dev::SubscribeEventCommand)
                         .subcommand(dev::SubscribeNewTxnCommand),


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:  #2188 
## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- add new subcommand to `starcoin dev subscribe` cli
```
starcoin% dev subscribe -h
dev-subscribe
Subscribe the chain events

USAGE:
    dev subscribe [SUBCOMMAND]

OPTIONS:
    -h, --help    Print help information

SUBCOMMANDS:
    new_mint_block
    new_block
    event              Subscribe chain event
    new_pending_txn
    help               Print this message or the help of the given subcommand(s)

starcoin% dev subscribe new_mint_block
Subscribe successful, Press `q` and Enter to quit
{"parent_hash":"0xca6e753bf6f62531c7946f5b01d6e96c34fba2ecaaec975370eb0cdcbd44d13c","strategy":{"type":"CryptoNight"},"minti                                     ng_blob":"17c420f505b88d3c21a8d7b36bf633f807fd1c88c5f0e921cbaeb47e30fef20400000000000000000000000000000000000000000000000000                                     000000000000000000000000000000000001ff","difficulty":"0x01ff","block_number":843}
```

-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
