### PR TITLE
Broadcast dag block in any condition

### DIFF
--- a/sync/src/block_connector/block_connector_service.rs
+++ b/sync/src/block_connector/block_connector_service.rs
@@ -267,7 +267,14 @@ where
         debug!("try connect mined block: {}", id);
 
         match self.chain_service.try_connect(new_block.as_ref().clone()) {
-            std::result::Result::Ok(()) => debug!("Process mined block {} success.", id),
+            std::result::Result::Ok(()) => {
+                debug!("Process mined block {} success.", id);
+
+                match self.chain_service.broadcast_new_dag_block(id) {
+                    std::result::Result::Ok(_) => (),
+                    Err(e) => warn!("Process mined block {} fail, error: {:?}", id, e),
+                }
+            }
             Err(e) => {
                 warn!("Process mined block {} fail, error: {:?}", id, e);
             }

--- a/sync/src/block_connector/write_block_chain.rs
+++ b/sync/src/block_connector/write_block_chain.rs
@@ -21,7 +21,8 @@ use starcoin_service_registry::bus::{Bus, BusService};
 use starcoin_service_registry::{ServiceContext, ServiceRef};
 use starcoin_storage::Store;
 use starcoin_txpool_api::TxPoolSyncService;
-use starcoin_types::block::BlockInfo;
+use starcoin_types::block::{BlockInfo, DagHeaderType};
+use starcoin_types::system_events::NewDagBlock;
 #[cfg(test)]
 use starcoin_types::{account::Account, block::BlockNumber};
 use starcoin_types::{
@@ -508,7 +509,7 @@ where
         Ok(blocks)
     }
 
-    fn broadcast_new_head(&self, block: ExecutedBlock) {
+    pub fn broadcast_new_head(&self, block: ExecutedBlock) {
         if let Some(metrics) = self.metrics.as_ref() {
             metrics
                 .chain_select_head_total
@@ -521,6 +522,49 @@ where
         }) {
             error!("Broadcast NewHeadBlock error: {:?}", e);
         }
+    }
+
+    // In dag chain, the new block minted by the node itself may have the less total difficulty than other nodes'.
+    // Hence, the new block may not be the new head of the chain.
+    // But it still needs to be broadcasted to other nodes.
+    pub fn broadcast_new_dag_block(&self, block_id: HashValue) -> Result<()> {
+        if let Some(metrics) = self.metrics.as_ref() {
+            metrics
+                .chain_select_head_total
+                .with_label_values(&["new_head"])
+                .inc()
+        }
+
+        let chain = self.get_main();
+
+        // the execution process broadcast the block already
+        if chain.current_header().id() == block_id {
+            return Ok(());
+        }
+
+        // the single chain no need to broadcast the block, it is only for dag
+        if chain.check_dag_type(chain.status().head())? == DagHeaderType::Single {
+            return Ok(());
+        }
+
+        let block = chain.get_block(block_id)?.ok_or_else(|| {
+            format_err!(
+                "failed to get the block after executing the block: {:?}",
+                block_id
+            )
+        })?;
+        let block_info = chain.get_block_info(Some(block_id))?.ok_or_else(|| {
+            format_err!(
+                "failed to get the block info after executing the block: {:?}",
+                block_id
+            )
+        })?;
+
+        self.bus
+            .broadcast(NewDagBlock {
+                executed_block: Arc::new(ExecutedBlock { block, block_info }),
+            })
+            .map_err(|e| format_err!("Broadcast NewDagBlock error: {:?}", e))
     }
 
     fn broadcast_new_branch(&self, block: ExecutedBlock) {

--- a/types/src/system_events.rs
+++ b/types/src/system_events.rs
@@ -12,7 +12,11 @@ use std::sync::Arc;
 #[derive(Clone, Debug)]
 pub struct NewHeadBlock {
     pub executed_block: Arc<ExecutedBlock>,
-    // pub tips: Option<Vec<HashValue>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct NewDagBlock {
+    pub executed_block: Arc<ExecutedBlock>,
 }
 
 /// may be uncle block


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

The dag block will not be broadcast if its block info's total difficulty is less than the header of the main, leading to an error: a new block that uses it as its one of parents will fail to be executed until the sync pull it.

```rust
  pub fn select_head(&mut self, new_branch: BlockChain) -> Result<()> {
        let executed_block = new_branch.head_block();
        let main_total_difficulty = self.main.get_total_difficulty()?;
        let branch_total_difficulty = new_branch.get_total_difficulty()?;
        let parent_is_main_head = self.is_main_head(&executed_block.header().parent_hash());

        if branch_total_difficulty > main_total_difficulty {
            let (enacted_count, enacted_blocks, retracted_count, retracted_blocks) =
                if !parent_is_main_head {
                    self.find_ancestors_from_accumulator(&new_branch)?
                } else {
                    (1, vec![executed_block.block.clone()], 0, vec![])
                };
            self.main = new_branch;

            self.do_new_head(
                executed_block,
                enacted_count,
                enacted_blocks,
                retracted_count,
                retracted_blocks,
            )?;
        } else {
            //send new branch event
            self.broadcast_new_branch(executed_block);
        }
        Ok(())
    }
```
The problem is in line: ` let executed_block = new_branch.head_block();`. The executed_block will be the header not the latest mined block. This results that minded block will not be broadcast!

The solution is to broadcast any dag block in any condition. See the modified files.