### PR TITLE
delete all dag block in sync dag store to protect the blocks not int …

### DIFF
--- a/sync/src/store/sync_absent_ancestor.rs
+++ b/sync/src/store/sync_absent_ancestor.rs
@@ -45,6 +45,7 @@ pub trait AbsentDagBlockStoreReader {
 pub trait AbsentDagBlockStoreWriter {
     fn save_absent_block(&self, blocks: Vec<DagSyncBlock>) -> anyhow::Result<()>;
     fn delete_absent_block(&self, number: BlockNumber, block_id: HashValue) -> anyhow::Result<()>;
+    fn delete_all_absent_block(&self) -> anyhow::Result<()>;
 }
 
 pub(crate) const SYNC_ABSENT_BLOCK_CF: &str = "sync-absent-block";
@@ -186,5 +187,11 @@ impl AbsentDagBlockStoreWriter for SyncAbsentBlockStore {
             )?;
         }
         Ok(())
+    }
+
+    fn delete_all_absent_block(&self) -> anyhow::Result<()> {
+        self.cache_access
+            .delete_all(DirectDbWriter::new(&self.db))
+            .map_err(|e| format_err!("failed to delete all absent block: {:?}", e))
     }
 }

--- a/sync/src/store/sync_dag_store.rs
+++ b/sync/src/store/sync_dag_store.rs
@@ -149,4 +149,8 @@ impl SyncDagStore {
                 e
             })
     }
+
+    pub(crate) fn delete_all_dag_sync_block(&self) -> anyhow::Result<()> {
+        self.absent_dag_store.delete_all_absent_block()
+    }
 }

--- a/sync/src/store/tests.rs
+++ b/sync/src/store/tests.rs
@@ -184,5 +184,13 @@ fn test_write_read_in_order() -> anyhow::Result<()> {
 
     assert_eq!(expect_order, db_order);
 
+    let mut iter_to_see_empty = sync_dag_store.iter_at_first()?;
+    assert!(iter_to_see_empty.next().is_some());
+
+    sync_dag_store.delete_all_dag_sync_block()?;
+
+    iter_to_see_empty = sync_dag_store.iter_at_first()?;
+    assert!(iter_to_see_empty.next().is_none());
+
     Ok(())
 }

--- a/sync/src/tasks/inner_sync_task.rs
+++ b/sync/src/tasks/inner_sync_task.rs
@@ -186,6 +186,8 @@ where
                     }
                 }
             }
+            // clear the dag sync if fork happened
+            self.sync_dag_store.delete_all_dag_sync_block()?;
 
             Ok(TaskGenerator::new(
                 block_sync_task,


### PR DESCRIPTION
…he blue fork

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a method to delete all absent blocks from the block store, enhancing data management capabilities.
	- Introduced a new method for the `SyncDagStore` to clear all absent blocks, improving data integrity.
	- Implemented a mechanism to clear the DAG synchronization store upon detecting a fork, ensuring synchronization accuracy.

- **Tests**
	- Enhanced testing logic to verify the successful deletion of all entries from the `sync_dag_store`, confirming the functionality of the new deletion methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->