### PR TITLE
Remove redundant sync_done() call in SystemStarted event handler

### DIFF
--- a/sync/src/sync.rs
+++ b/sync/src/sync.rs
@@ -804,8 +804,6 @@ impl EventHandler<Self, CheckSyncEvent> for SyncService {
 
 impl EventHandler<Self, SystemStarted> for SyncService {
     fn handle_event(&mut self, _msg: SystemStarted, ctx: &mut ServiceContext<Self>) {
-        // change from prepare to Synchronized
-        self.sync_status.sync_done();
         ctx.notify(CheckSyncEvent::default());
         ctx.broadcast(SyncStatusChangeEvent(self.sync_status.clone()));
     }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Adjusted the synchronization behavior on system startup so that the system no longer immediately indicates that synchronization is complete.
	- Maintained the existing notifications and event broadcasts to ensure smooth, consistent operation post-startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->