### PR TITLE
chore: remove deprecated ofast

### DIFF
--- a/consensus/cryptonight-rs/build.rs
+++ b/consensus/cryptonight-rs/build.rs
@@ -27,7 +27,8 @@ fn main() {
     }
     if target_os.contains("linux") || target_os.contains("macos") {
         config
-            .flag("-Ofast")
+            .flag("-O3")
+            .flag("-ffast-math")
             .flag("-fexceptions")
             .flag("-std=gnu99");
     }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
fix this
```
warning: cryptonight-rs@2.0.7: clang: warning: argument '-Ofast' is deprecated; use '-O3 -ffast-math' for the same behavior, or '-O3' to enable only conforming optimizations [-Wdeprecated-ofast]
```
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated compiler optimization settings for improved performance on Linux and macOS platforms. No changes to user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->