### PR TITLE
Remove async std dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
  "pin-project-lite 0.2.16",
  "smallvec 1.10.0",
  "tokio",
- "tokio-util 0.7.7",
+ "tokio-util 0.7.16",
 ]
 
 [[package]]
@@ -806,27 +806,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e22d1f4b888c298a027c99dc9048015fac177587de20fc30232a057dfbe24a21"
 
 [[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote 1.0.36",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
-dependencies = [
- "concurrent-queue",
- "event-listener",
- "futures-core",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,36 +815,6 @@ dependencies = [
  "futures-core",
  "memchr",
  "pin-project-lite 0.2.16",
- "tokio",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17adb73da160dfb475c183343c8cccd80721ea5a605d3eb57125f0a7b7a92d0b"
-dependencies = [
- "async-lock",
- "async-task",
- "concurrent-queue",
- "fastrand 1.9.0",
- "futures-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
-dependencies = [
- "async-channel",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
  "tokio",
 ]
 
@@ -898,39 +847,6 @@ dependencies = [
  "event-listener",
  "futures-lite",
 ]
-
-[[package]]
-name = "async-std"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
-dependencies = [
- "async-attributes",
- "async-channel",
- "async-global-executor",
- "async-io",
- "async-lock",
- "crossbeam-utils 0.8.21",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log 0.4.27",
- "memchr",
- "once_cell",
- "pin-project-lite 0.2.16",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "async-task"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
@@ -1368,20 +1284,6 @@ name = "block-padding"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
-
-[[package]]
-name = "blocking"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c67b173a56acffd6d2326fb7ab938ba0b00a71480e14902b2591c87bc5741e8"
-dependencies = [
- "async-channel",
- "async-lock",
- "async-task",
- "atomic-waker",
- "fastrand 1.9.0",
- "futures-lite",
-]
 
 [[package]]
 name = "blst"
@@ -4060,18 +3962,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gloo-timers"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "goldenfile"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4137,7 +4027,7 @@ dependencies = [
  "indexmap 2.7.1",
  "slab",
  "tokio",
- "tokio-util 0.7.7",
+ "tokio-util 0.7.16",
  "tracing",
 ]
 
@@ -5102,15 +4992,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log 0.4.27",
-]
-
-[[package]]
 name = "language-tags"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5521,7 +5402,7 @@ dependencies = [
  "thiserror",
  "tinytemplate",
  "tokio",
- "tokio-util 0.7.7",
+ "tokio-util 0.7.16",
  "webrtc",
 ]
 
@@ -5725,7 +5606,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 dependencies = [
  "serde 1.0.205",
- "value-bag",
 ]
 
 [[package]]
@@ -7706,7 +7586,6 @@ name = "network-p2p"
 version = "2.1.1"
 dependencies = [
  "anyhow",
- "async-std",
  "async-trait",
  "asynchronous-codec 0.5.0",
  "bcs-ext",
@@ -7743,6 +7622,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-util 0.7.16",
  "unsigned-varint 0.6.0",
  "void",
  "wasm-timer",
@@ -9861,7 +9741,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.7.7",
+ "tokio-util 0.7.16",
  "tower-service",
  "url 2.3.1",
  "wasm-bindgen",
@@ -12275,7 +12155,6 @@ dependencies = [
  "actix",
  "actix-rt",
  "anyhow",
- "async-std",
  "async-trait",
  "byteorder",
  "clap 4.5.47",
@@ -12463,7 +12342,6 @@ name = "starcoin-network"
 version = "2.1.1"
 dependencies = [
  "anyhow",
- "async-std",
  "async-trait",
  "bcs-ext",
  "bitflags 1.3.2",
@@ -12559,7 +12437,6 @@ dependencies = [
  "actix",
  "actix-rt",
  "anyhow",
- "async-std",
  "async-trait",
  "backtrace",
  "chrono",
@@ -12774,7 +12651,6 @@ dependencies = [
  "actix",
  "actix-rt",
  "anyhow",
- "async-std",
  "bcs-ext",
  "futures 0.3.31",
  "futures-timer",
@@ -12970,7 +12846,6 @@ dependencies = [
  "actix",
  "actix-rt",
  "anyhow",
- "async-std",
  "async-trait",
  "futures 0.3.31",
  "futures-timer",
@@ -13145,7 +13020,6 @@ name = "starcoin-sync"
 version = "2.1.1"
 dependencies = [
  "anyhow",
- "async-std",
  "async-trait",
  "bcs-ext",
  "byteorder",
@@ -14148,7 +14022,6 @@ name = "stream-task"
 version = "2.1.1"
 dependencies = [
  "anyhow",
- "async-std",
  "futures 0.3.31",
  "futures-retry",
  "futures-timer",
@@ -15063,9 +14936,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.7"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes 1.6.1",
  "futures-core",
@@ -15073,7 +14946,6 @@ dependencies = [
  "futures-sink",
  "pin-project-lite 0.2.16",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -15650,12 +15522,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "value-bag"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
 
 [[package]]
 name = "variant_count"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -281,7 +281,6 @@ arc-swap = "1.5.1"
 arr_macro = "0.2.1"
 arrayref = "0.3"
 ascii = "1.0.0"
-async-std = { version = "1.12", features = ["attributes", "tokio1"] }
 async-trait = "0.1.53"
 asynchronous-codec = "0.5"
 atomic-counter = "1.0.1"
@@ -594,7 +593,7 @@ starcoin-vm2-vm-runtime = { path = "vm2/vm-runtime", package = "starcoin-vm-runt
 starcoin-vm2-types = { path = "vm2/types", package = "starcoin-types" }
 starcoin-vm2-vm-types = { path = "vm2/vm-types", package = "starcoin-vm-types" }
 starcoin-vm2-framework = { path = "vm2/framework", package = "starcoin-framework" }
-starcoin-vm2-transactional-test-harness = { path = "vm2/starcoin-transactional-test-harness"}
+starcoin-vm2-transactional-test-harness = { path = "vm2/starcoin-transactional-test-harness" }
 starcoin-vm2-cached-packages = { path = "vm2/framework/cached-packages", package = "starcoin-cached-packages" }
 starcoin-vm2-gas-algebra = { path = "vm2/framework/gas-algebra", package = "starcoin-gas-algebra" }
 starcoin-vm2-gas-schedule = { path = "vm2/framework/gas-schedule", package = "starcoin-gas-schedule" }
@@ -635,6 +634,7 @@ timeout-join-handler = { path = "commons/timeout-join-handler" }
 tiny-keccak = { version = "2", features = ["keccak"] }
 tiny_http = "0.8.2"
 tokio = { version = "^1", features = ["full"] }
+tokio-util = "0.7.16"
 tokio-executor = { version = "0.2.0-alpha.6", features = ["blocking"] }
 toml = "0.5.9"
 trace-time = "0.1"

--- a/cmd/miner_client/Cargo.toml
+++ b/cmd/miner_client/Cargo.toml
@@ -6,7 +6,6 @@ path = "src/main.rs"
 actix = { workspace = true }
 actix-rt = { workspace = true }
 anyhow = { workspace = true }
-async-std = { workspace = true }
 starcoin-consensus = { workspace = true }
 starcoin-crypto = { workspace = true }
 futures = { workspace = true }

--- a/cmd/miner_client/src/stratum_client.rs
+++ b/cmd/miner_client/src/stratum_client.rs
@@ -1,7 +1,6 @@
 use crate::stratum_client_service::{ShareRequest, StratumClientService, SubmitSealRequest};
 use crate::{ConsensusStrategy, JobClient, SealEvent};
 use anyhow::Result;
-use async_std::sync::Arc;
 use async_trait::async_trait;
 use byteorder::{LittleEndian, WriteBytesExt};
 use futures::future;
@@ -12,6 +11,7 @@ use starcoin_stratum::rpc::LoginRequest;
 use starcoin_stratum::target_hex_to_difficulty;
 use starcoin_time_service::TimeService;
 use starcoin_types::system_events::{MintBlockEvent, MintEventExtra};
+use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct StratumJobClient {

--- a/cmd/peer-watcher/Cargo.toml
+++ b/cmd/peer-watcher/Cargo.toml
@@ -4,7 +4,6 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-async-std = { workspace = true }
 clap = { features = ["derive"], workspace = true }
 futures = { workspace = true }
 network-p2p = { workspace = true }

--- a/cmd/peer-watcher/src/main.rs
+++ b/cmd/peer-watcher/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
     let (peer_info, worker) = build_lighting_network(config.net(), &config.network).unwrap();
     println!("Self peer_info: {:?}", peer_info);
     let service = worker.service().clone();
-    async_std::task::spawn(worker);
+    tokio::spawn(worker);
     let stream = service.event_stream("peer_watcher");
     futures::executor::block_on(async move {
         stream

--- a/commons/service-registry/Cargo.toml
+++ b/commons/service-registry/Cargo.toml
@@ -13,7 +13,6 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
-async-std = { workspace = true }
 stest = { workspace = true }
 
 [package]

--- a/commons/service-registry/src/bus/sys_bus.rs
+++ b/commons/service-registry/src/bus/sys_bus.rs
@@ -237,9 +237,9 @@ impl SysBus {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use async_std::task;
     use futures_timer::Delay;
     use std::time::Duration;
+    use tokio::task;
 
     #[derive(Debug, Clone)]
     struct Message {}

--- a/commons/stream-task/Cargo.toml
+++ b/commons/stream-task/Cargo.toml
@@ -1,6 +1,5 @@
 [dependencies]
 anyhow = { workspace = true }
-async-std = { workspace = true }
 futures = { workspace = true }
 futures-retry = { workspace = true }
 futures-timer = { workspace = true }

--- a/commons/stream-task/src/collector.rs
+++ b/commons/stream-task/src/collector.rs
@@ -3,7 +3,6 @@
 
 use crate::{TaskError, TaskEventHandle};
 use anyhow::{Error, Result};
-use async_std::task::JoinHandle;
 use futures::channel::mpsc::{channel, Sender};
 use futures::task::{Context, Poll};
 use futures::{Sink, StreamExt};
@@ -14,6 +13,7 @@ use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use thiserror::Error;
+use tokio::task::JoinHandle;
 
 #[derive(Clone, Copy, Debug)]
 pub enum CollectorState {
@@ -157,7 +157,7 @@ impl<Item, Output> FutureTaskSink<Item, Output> {
         C: TaskResultCollector<Item, Output = Output> + 'static,
     {
         let (sender, receiver) = channel(buffer_size);
-        let task_handle = async_std::task::spawn(async move {
+        let task_handle = tokio::spawn(async move {
             let mut receiver = receiver.fuse();
             while let Some(item) = receiver.next().await {
                 event_handle.on_item();
@@ -178,7 +178,9 @@ impl<Item, Output> FutureTaskSink<Item, Output> {
     }
 
     pub async fn wait_output(self) -> Result<Output, TaskError> {
-        self.task_handle.await
+        self.task_handle
+            .await
+            .map_err(|e| TaskError::BreakError(anyhow::anyhow!("Task join error: {}", e)))?
     }
 }
 

--- a/commons/stream-task/src/tests.rs
+++ b/commons/stream-task/src/tests.rs
@@ -235,7 +235,7 @@ async fn test_task_cancel() {
     )
     .generate();
     let (fut, task_handle) = fut.with_handle();
-    let join_handle = async_std::task::spawn(fut);
+    let join_handle = tokio::spawn(fut);
     Delay::new(Duration::from_millis(delay_time * 5)).await;
     assert!(!task_handle.is_done());
     task_handle.cancel();
@@ -245,7 +245,7 @@ async fn test_task_cancel() {
     assert!(task_handle.is_done());
 
     let task_err = result.err().unwrap();
-    assert!(task_err.is_canceled());
+    assert!(task_err.is_cancelled());
     let processed_messages = counter.load(Ordering::SeqCst);
     debug!("processed_messages before cancel: {}", processed_messages);
     assert!(processed_messages > 0 && processed_messages < max);

--- a/network-p2p/Cargo.toml
+++ b/network-p2p/Cargo.toml
@@ -6,7 +6,6 @@ bitflags = { workspace = true }
 bytes = { workspace = true }
 once_cell = { workspace = true }
 bcs-ext = { workspace = true }
-async-std = { workspace = true }
 bs58 = { workspace = true }
 derive_more = { workspace = true }
 either = { workspace = true }
@@ -41,7 +40,8 @@ void = { workspace = true }
 wasm-timer = { workspace = true }
 zeroize = { workspace = true }
 libp2p = { workspace = true, features = ["identify", "kad", "macros"] }
-tokio={ workspace = true}
+tokio = { workspace = true }
+tokio-util = { workspace = true, features = ["compat"] }
 
 [dev-dependencies]
 stest = { workspace = true }

--- a/network-p2p/src/protocol/generic_proto/upgrade/notifications.rs
+++ b/network-p2p/src/protocol/generic_proto/upgrade/notifications.rs
@@ -461,8 +461,8 @@ mod tests {
     use tokio::net::{TcpListener, TcpStream};
     use tokio_util::compat::TokioAsyncReadCompatExt;
 
-    #[test]
-    fn basic_works() {
+    #[tokio::test]
+    async fn basic_works() {
         const PROTO_NAME: Cow<'static, str> = Cow::Borrowed("/test/proto/1");
         let (listener_addr_tx, listener_addr_rx) = oneshot::channel();
 
@@ -482,32 +482,30 @@ mod tests {
             substream.send(b"test message".to_vec()).await.unwrap();
         });
 
-        tokio::runtime::Handle::current().block_on(async move {
-            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-            listener_addr_tx
-                .send(listener.local_addr().unwrap())
-                .unwrap();
-
-            let (socket, _) = listener.accept().await.unwrap();
-            let (initial_message, mut substream) = upgrade::apply_inbound(
-                socket.compat(),
-                NotificationsIn::new(PROTO_NAME, 1024 * 1024),
-            )
-            .await
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        listener_addr_tx
+            .send(listener.local_addr().unwrap())
             .unwrap();
 
-            assert_eq!(initial_message, b"initial message");
-            substream.send_handshake(&b"hello world"[..]);
+        let (socket, _) = listener.accept().await.unwrap();
+        let (initial_message, mut substream) = upgrade::apply_inbound(
+            socket.compat(),
+            NotificationsIn::new(PROTO_NAME, 1024 * 1024),
+        )
+        .await
+        .unwrap();
 
-            let msg = substream.next().await.unwrap().unwrap();
-            assert_eq!(msg.as_ref(), b"test message");
-        });
+        assert_eq!(initial_message, b"initial message");
+        substream.send_handshake(&b"hello world"[..]);
 
-        let _ = tokio::runtime::Handle::current().block_on(client);
+        let msg = substream.next().await.unwrap().unwrap();
+        assert_eq!(msg.as_ref(), b"test message");
+
+        let _ = client.await;
     }
 
-    #[test]
-    fn empty_handshake() {
+    #[tokio::test]
+    async fn empty_handshake() {
         // Check that everything still works when the handshake messages are empty.
 
         const PROTO_NAME: Cow<'static, str> = Cow::Borrowed("/test/proto/1");
@@ -529,7 +527,7 @@ mod tests {
             substream.send(Default::default()).await.unwrap();
         });
 
-        tokio::runtime::Handle::current().block_on(async move {
+        {
             let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
             listener_addr_tx
                 .send(listener.local_addr().unwrap())
@@ -548,13 +546,13 @@ mod tests {
 
             let msg = substream.next().await.unwrap().unwrap();
             assert!(msg.as_ref().is_empty());
-        });
+        }
 
-        let _ = tokio::runtime::Handle::current().block_on(client);
+        let _ = client.await;
     }
 
-    #[test]
-    fn refused() {
+    #[tokio::test]
+    async fn refused() {
         const PROTO_NAME: Cow<'static, str> = Cow::Borrowed("/test/proto/1");
         let (listener_addr_tx, listener_addr_rx) = oneshot::channel();
 
@@ -575,7 +573,7 @@ mod tests {
             assert!(outcome.is_err());
         });
 
-        tokio::runtime::Handle::current().block_on(async move {
+        {
             let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
             listener_addr_tx
                 .send(listener.local_addr().unwrap())
@@ -593,13 +591,13 @@ mod tests {
 
             // We successfully upgrade to the protocol, but then close the substream.
             drop(substream);
-        });
+        }
 
-        let _ = tokio::runtime::Handle::current().block_on(client);
+        let _ = client.await;
     }
 
-    #[test]
-    fn large_initial_message_refused() {
+    #[tokio::test]
+    async fn large_initial_message_refused() {
         const PROTO_NAME: Cow<'static, str> = Cow::Borrowed("/test/proto/1");
         let (listener_addr_tx, listener_addr_rx) = oneshot::channel();
 
@@ -621,7 +619,7 @@ mod tests {
             assert!(ret.is_err());
         });
 
-        tokio::runtime::Handle::current().block_on(async move {
+        {
             let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
             listener_addr_tx
                 .send(listener.local_addr().unwrap())
@@ -634,13 +632,13 @@ mod tests {
             )
             .await;
             assert!(ret.is_err());
-        });
+        }
 
-        let _ = tokio::runtime::Handle::current().block_on(client);
+        let _ = client.await;
     }
 
-    #[test]
-    fn large_handshake_refused() {
+    #[tokio::test]
+    async fn large_handshake_refused() {
         const PROTO_NAME: Cow<'static, str> = Cow::Borrowed("/test/proto/1");
         let (listener_addr_tx, listener_addr_rx) = oneshot::channel();
 
@@ -657,7 +655,7 @@ mod tests {
             assert!(ret.is_err());
         });
 
-        tokio::runtime::Handle::current().block_on(async move {
+        {
             let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
             listener_addr_tx
                 .send(listener.local_addr().unwrap())
@@ -675,8 +673,8 @@ mod tests {
             // We check that a handshake that is too large gets refused.
             substream.send_handshake((0..32768).map(|_| 0).collect::<Vec<_>>());
             let _ = substream.next().await;
-        });
+        }
 
-        let _ = tokio::runtime::Handle::current().block_on(client);
+        let _ = client.await;
     }
 }

--- a/network-p2p/src/protocol/generic_proto/upgrade/notifications.rs
+++ b/network-p2p/src/protocol/generic_proto/upgrade/notifications.rs
@@ -455,22 +455,23 @@ pub enum NotificationsOutError {
 mod tests {
     use super::{NotificationsIn, NotificationsOut};
 
-    use async_std::net::{TcpListener, TcpStream};
     use futures::{channel::oneshot, prelude::*};
     use libp2p::core::upgrade;
     use std::borrow::Cow;
+    use tokio::net::{TcpListener, TcpStream};
+    use tokio_util::compat::TokioAsyncReadCompatExt;
 
     #[test]
     fn basic_works() {
         const PROTO_NAME: Cow<'static, str> = Cow::Borrowed("/test/proto/1");
         let (listener_addr_tx, listener_addr_rx) = oneshot::channel();
 
-        let client = async_std::task::spawn(async move {
+        let client = tokio::spawn(async move {
             let socket = TcpStream::connect(listener_addr_rx.await.unwrap())
                 .await
                 .unwrap();
             let (handshake, mut substream) = upgrade::apply_outbound(
-                socket,
+                socket.compat(),
                 NotificationsOut::new(PROTO_NAME, &b"initial message"[..], 1024 * 1024),
                 upgrade::Version::V1,
             )
@@ -481,17 +482,19 @@ mod tests {
             substream.send(b"test message".to_vec()).await.unwrap();
         });
 
-        async_std::task::block_on(async move {
+        tokio::runtime::Handle::current().block_on(async move {
             let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
             listener_addr_tx
                 .send(listener.local_addr().unwrap())
                 .unwrap();
 
             let (socket, _) = listener.accept().await.unwrap();
-            let (initial_message, mut substream) =
-                upgrade::apply_inbound(socket, NotificationsIn::new(PROTO_NAME, 1024 * 1024))
-                    .await
-                    .unwrap();
+            let (initial_message, mut substream) = upgrade::apply_inbound(
+                socket.compat(),
+                NotificationsIn::new(PROTO_NAME, 1024 * 1024),
+            )
+            .await
+            .unwrap();
 
             assert_eq!(initial_message, b"initial message");
             substream.send_handshake(&b"hello world"[..]);
@@ -500,7 +503,7 @@ mod tests {
             assert_eq!(msg.as_ref(), b"test message");
         });
 
-        async_std::task::block_on(client);
+        let _ = tokio::runtime::Handle::current().block_on(client);
     }
 
     #[test]
@@ -510,12 +513,12 @@ mod tests {
         const PROTO_NAME: Cow<'static, str> = Cow::Borrowed("/test/proto/1");
         let (listener_addr_tx, listener_addr_rx) = oneshot::channel();
 
-        let client = async_std::task::spawn(async move {
+        let client = tokio::spawn(async move {
             let socket = TcpStream::connect(listener_addr_rx.await.unwrap())
                 .await
                 .unwrap();
             let (handshake, mut substream) = upgrade::apply_outbound(
-                socket,
+                socket.compat(),
                 NotificationsOut::new(PROTO_NAME, vec![], 1024 * 1024),
                 upgrade::Version::V1,
             )
@@ -526,17 +529,19 @@ mod tests {
             substream.send(Default::default()).await.unwrap();
         });
 
-        async_std::task::block_on(async move {
+        tokio::runtime::Handle::current().block_on(async move {
             let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
             listener_addr_tx
                 .send(listener.local_addr().unwrap())
                 .unwrap();
 
             let (socket, _) = listener.accept().await.unwrap();
-            let (initial_message, mut substream) =
-                upgrade::apply_inbound(socket, NotificationsIn::new(PROTO_NAME, 1024 * 1024))
-                    .await
-                    .unwrap();
+            let (initial_message, mut substream) = upgrade::apply_inbound(
+                socket.compat(),
+                NotificationsIn::new(PROTO_NAME, 1024 * 1024),
+            )
+            .await
+            .unwrap();
 
             assert!(initial_message.is_empty());
             substream.send_handshake(vec![]);
@@ -545,7 +550,7 @@ mod tests {
             assert!(msg.as_ref().is_empty());
         });
 
-        async_std::task::block_on(client);
+        let _ = tokio::runtime::Handle::current().block_on(client);
     }
 
     #[test]
@@ -553,12 +558,12 @@ mod tests {
         const PROTO_NAME: Cow<'static, str> = Cow::Borrowed("/test/proto/1");
         let (listener_addr_tx, listener_addr_rx) = oneshot::channel();
 
-        let client = async_std::task::spawn(async move {
+        let client = tokio::spawn(async move {
             let socket = TcpStream::connect(listener_addr_rx.await.unwrap())
                 .await
                 .unwrap();
             let outcome = upgrade::apply_outbound(
-                socket,
+                socket.compat(),
                 NotificationsOut::new(PROTO_NAME, &b"hello"[..], 1024 * 1024),
                 upgrade::Version::V1,
             )
@@ -570,17 +575,19 @@ mod tests {
             assert!(outcome.is_err());
         });
 
-        async_std::task::block_on(async move {
+        tokio::runtime::Handle::current().block_on(async move {
             let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
             listener_addr_tx
                 .send(listener.local_addr().unwrap())
                 .unwrap();
 
             let (socket, _) = listener.accept().await.unwrap();
-            let (initial_msg, substream) =
-                upgrade::apply_inbound(socket, NotificationsIn::new(PROTO_NAME, 1024 * 1024))
-                    .await
-                    .unwrap();
+            let (initial_msg, substream) = upgrade::apply_inbound(
+                socket.compat(),
+                NotificationsIn::new(PROTO_NAME, 1024 * 1024),
+            )
+            .await
+            .unwrap();
 
             assert_eq!(initial_msg, b"hello");
 
@@ -588,7 +595,7 @@ mod tests {
             drop(substream);
         });
 
-        async_std::task::block_on(client);
+        let _ = tokio::runtime::Handle::current().block_on(client);
     }
 
     #[test]
@@ -596,12 +603,12 @@ mod tests {
         const PROTO_NAME: Cow<'static, str> = Cow::Borrowed("/test/proto/1");
         let (listener_addr_tx, listener_addr_rx) = oneshot::channel();
 
-        let client = async_std::task::spawn(async move {
+        let client = tokio::spawn(async move {
             let socket = TcpStream::connect(listener_addr_rx.await.unwrap())
                 .await
                 .unwrap();
             let ret = upgrade::apply_outbound(
-                socket,
+                socket.compat(),
                 // We check that an initial message that is too large gets refused.
                 NotificationsOut::new(
                     PROTO_NAME,
@@ -614,19 +621,22 @@ mod tests {
             assert!(ret.is_err());
         });
 
-        async_std::task::block_on(async move {
+        tokio::runtime::Handle::current().block_on(async move {
             let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
             listener_addr_tx
                 .send(listener.local_addr().unwrap())
                 .unwrap();
 
             let (socket, _) = listener.accept().await.unwrap();
-            let ret =
-                upgrade::apply_inbound(socket, NotificationsIn::new(PROTO_NAME, 1024 * 1024)).await;
+            let ret = upgrade::apply_inbound(
+                socket.compat(),
+                NotificationsIn::new(PROTO_NAME, 1024 * 1024),
+            )
+            .await;
             assert!(ret.is_err());
         });
 
-        async_std::task::block_on(client);
+        let _ = tokio::runtime::Handle::current().block_on(client);
     }
 
     #[test]
@@ -634,12 +644,12 @@ mod tests {
         const PROTO_NAME: Cow<'static, str> = Cow::Borrowed("/test/proto/1");
         let (listener_addr_tx, listener_addr_rx) = oneshot::channel();
 
-        let client = async_std::task::spawn(async move {
+        let client = tokio::spawn(async move {
             let socket = TcpStream::connect(listener_addr_rx.await.unwrap())
                 .await
                 .unwrap();
             let ret = upgrade::apply_outbound(
-                socket,
+                socket.compat(),
                 NotificationsOut::new(PROTO_NAME, &b"initial message"[..], 1024 * 1024),
                 upgrade::Version::V1,
             )
@@ -647,17 +657,19 @@ mod tests {
             assert!(ret.is_err());
         });
 
-        async_std::task::block_on(async move {
+        tokio::runtime::Handle::current().block_on(async move {
             let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
             listener_addr_tx
                 .send(listener.local_addr().unwrap())
                 .unwrap();
 
             let (socket, _) = listener.accept().await.unwrap();
-            let (initial_message, mut substream) =
-                upgrade::apply_inbound(socket, NotificationsIn::new(PROTO_NAME, 1024 * 1024))
-                    .await
-                    .unwrap();
+            let (initial_message, mut substream) = upgrade::apply_inbound(
+                socket.compat(),
+                NotificationsIn::new(PROTO_NAME, 1024 * 1024),
+            )
+            .await
+            .unwrap();
             assert_eq!(initial_message, b"initial message");
 
             // We check that a handshake that is too large gets refused.
@@ -665,6 +677,6 @@ mod tests {
             let _ = substream.next().await;
         });
 
-        async_std::task::block_on(client);
+        let _ = tokio::runtime::Handle::current().block_on(client);
     }
 }

--- a/network-p2p/src/service.rs
+++ b/network-p2p/src/service.rs
@@ -51,7 +51,6 @@ use crate::{
 };
 use crate::{config, Multiaddr};
 use crate::{config::parse_str_addr, transport};
-use async_std::future;
 use futures::channel::oneshot::{Canceled, Receiver};
 use futures::{
     channel::{mpsc, oneshot},
@@ -77,6 +76,7 @@ use starcoin_metrics::{Histogram, HistogramVec};
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::time::Duration;
+use tokio::time as future;
 const REQUEST_RESPONSE_TIMEOUT_SECONDS: u64 = 60 * 5;
 
 /// A cloneable handle for reporting cost/benefits of peers.

--- a/network-p2p/src/service_test.rs
+++ b/network-p2p/src/service_test.rs
@@ -200,7 +200,7 @@ async fn lots_of_incoming_peers_works() {
             ..config::NetworkConfiguration::new_local()
         });
 
-        background_tasks_to_wait.push(async_std::task::spawn(async move {
+        background_tasks_to_wait.push(tokio::spawn(async move {
             // Create a dummy timer that will "never" fire, and that will be overwritten when we
             // actually need the timer. Using an Option would be technically cleaner, but it would
             // make the code below way more complicated.

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -20,7 +20,6 @@ lru = { workspace = true }
 parking_lot = { workspace = true }
 rand = { workspace = true }
 tempfile = { workspace = true }
-async-std = { workspace = true }
 async-trait = { workspace = true }
 derive_more = { workspace = true }
 serde = { features = ["derive"], workspace = true }

--- a/network/tests/network_service_test.rs
+++ b/network/tests/network_service_test.rs
@@ -188,7 +188,7 @@ async fn test_event_notify_receive_repeat_block() {
     assert_eq!(msg_send1.notification, msg_receive1.notification);
 
     //repeat message is filter, so expect timeout error.
-    let msg_receive2 = async_std::future::timeout(Duration::from_secs(2), receiver.next()).await;
+    let msg_receive2 = tokio::time::timeout(Duration::from_secs(2), receiver.next()).await;
     assert!(msg_receive2.is_err());
 }
 
@@ -235,7 +235,7 @@ async fn test_event_notify_receive_repeat_transaction() {
     );
 
     //msg3 is empty after filter, so expect timeout error.
-    let msg_receive3 = async_std::future::timeout(Duration::from_secs(1), receiver.next()).await;
+    let msg_receive3 = tokio::time::timeout(Duration::from_secs(1), receiver.next()).await;
     assert!(msg_receive3.is_err());
 }
 
@@ -277,10 +277,10 @@ async fn test_event_broadcast() {
     //repeat broadcast
     node2.service_ref.broadcast(notification.clone());
 
-    let msg_receive1 = async_std::future::timeout(Duration::from_secs(1), receiver1.next()).await;
+    let msg_receive1 = tokio::time::timeout(Duration::from_secs(1), receiver1.next()).await;
     assert!(msg_receive1.is_err());
 
-    let msg_receive3 = async_std::future::timeout(Duration::from_secs(1), receiver3.next()).await;
+    let msg_receive3 = tokio::time::timeout(Duration::from_secs(1), receiver3.next()).await;
     assert!(msg_receive3.is_err());
 
     print!("{:?}", node1.config.metrics.registry().unwrap().gather());

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -2,7 +2,6 @@
 actix = { workspace = true }
 actix-rt = { workspace = true }
 anyhow = { workspace = true }
-async-std = { workspace = true }
 async-trait = { workspace = true }
 backtrace = { workspace = true }
 chrono = { workspace = true }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -202,7 +202,7 @@ impl NodeHandle {
             let receiver = bus.oneshot::<NewHeadBlock>().await?;
             bus.broadcast(GenerateBlockEvent::new_break(true))?;
             let block = if let Ok(Ok(event)) =
-                async_std::future::timeout(Duration::from_secs(5), receiver).await
+                tokio::time::timeout(Duration::from_secs(5), receiver).await
             {
                 //wait for new block event to been processed.
                 Delay::new(Duration::from_millis(100)).await;

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -4,7 +4,6 @@
 use crate::genesis_parameter_resolve::RpcFutureBlockParameterResolver;
 use crate::node::NodeService;
 use anyhow::{bail, format_err, Result};
-use futures::executor::block_on;
 use futures_timer::Delay;
 use starcoin_chain_service::{ChainAsyncService, ChainReaderService};
 use starcoin_config::{BaseConfig, NodeConfig, StarcoinOpt};
@@ -134,7 +133,8 @@ impl NodeHandle {
     }
 
     pub fn bus(&self) -> Result<ServiceRef<BusService>> {
-        block_on(async { self.registry.service_ref::<BusService>().await })
+        self.runtime
+            .block_on(async { self.registry.service_ref::<BusService>().await })
     }
 
     pub fn network(&self) -> NetworkServiceRef {
@@ -144,30 +144,36 @@ impl NodeHandle {
     }
 
     pub fn sync_service(&self) -> Result<ServiceRef<SyncService>> {
-        block_on(async { self.registry.service_ref::<SyncService>().await })
+        self.runtime
+            .block_on(async { self.registry.service_ref::<SyncService>().await })
     }
 
     pub fn rpc_service(&self) -> Result<ServiceRef<RpcService>> {
-        block_on(async { self.registry.service_ref::<RpcService>().await })
+        self.runtime
+            .block_on(async { self.registry.service_ref::<RpcService>().await })
     }
 
     pub fn chain_service(&self) -> Result<ServiceRef<ChainReaderService>> {
-        block_on(async { self.registry.service_ref::<ChainReaderService>().await })
+        self.runtime
+            .block_on(async { self.registry.service_ref::<ChainReaderService>().await })
     }
 
     pub fn list_service(&self) -> Result<Vec<ServiceInfo>> {
         let node_addr = self.node_service();
-        block_on(async { node_addr.list_service().await })
+        self.runtime
+            .block_on(async { node_addr.list_service().await })
     }
 
     pub fn stop_service(&self, service_name: String) -> Result<()> {
         let node_addr = self.node_service();
-        block_on(async { node_addr.stop_service(service_name).await })
+        self.runtime
+            .block_on(async { node_addr.stop_service(service_name).await })
     }
 
     pub fn start_service(&self, service_name: String) -> Result<()> {
         let node_addr = self.node_service();
-        block_on(async { node_addr.start_service(service_name).await })
+        self.runtime
+            .block_on(async { node_addr.start_service(service_name).await })
     }
 
     pub fn txpool(&self) -> TxPoolService {
@@ -194,7 +200,7 @@ impl NodeHandle {
     /// Just for test
     pub fn generate_block(&self) -> Result<Block> {
         let registry = &self.registry;
-        block_on(async move {
+        self.runtime.block_on(async move {
             let bus = registry.service_ref::<BusService>().await?;
             let chain_service = registry.service_ref::<ChainReaderService>().await?;
             let head = chain_service.main_head_block().await?;

--- a/rpc/client/Cargo.toml
+++ b/rpc/client/Cargo.toml
@@ -2,7 +2,6 @@
 actix = { workspace = true }
 actix-rt = { workspace = true }
 anyhow = { workspace = true }
-async-std = { workspace = true }
 bcs-ext = { workspace = true }
 futures = { workspace = true }
 futures-timer = { workspace = true }

--- a/rpc/client/src/lib.rs
+++ b/rpc/client/src/lib.rs
@@ -210,7 +210,7 @@ impl RpcClient {
         let f = async move {
             let r = chain_watcher.send(WatchTxn { txn_hash }).await?;
             match timeout {
-                Some(t) => async_std::future::timeout(t, r).await??,
+                Some(t) => tokio::time::timeout(t, r).await??,
                 None => r.await?,
             }
         };

--- a/rpc/client/tests/client_server_test.rs
+++ b/rpc/client/tests/client_server_test.rs
@@ -105,7 +105,7 @@ fn test_client_reconnect_subscribe() -> Result<()> {
     let ws_client =
         RpcClient::connect_websocket(url.to_string().as_str()).expect("connect websocket fail.");
     let stream1 = ws_client.subscribe_new_mint_blocks()?;
-    let handle1 = async_std::task::spawn(async move {
+    let handle1 = tokio::spawn(async move {
         stream1
             .into_stream()
             .collect::<Vec<Result<MintBlockEvent>>>()
@@ -122,7 +122,7 @@ fn test_client_reconnect_subscribe() -> Result<()> {
     assert!(result.is_err());
 
     let stream2 = ws_client.subscribe_new_mint_blocks()?;
-    let handle2 = async_std::task::spawn(async move {
+    let handle2 = tokio::spawn(async move {
         stream2
             .into_stream()
             .collect::<Vec<Result<MintBlockEvent>>>()
@@ -133,8 +133,8 @@ fn test_client_reconnect_subscribe() -> Result<()> {
     std::thread::sleep(Duration::from_millis(300));
     let _e = node_handle.stop();
 
-    let events1 = futures::executor::block_on(handle1);
-    let events2 = futures::executor::block_on(handle2);
+    let events1 = futures::executor::block_on(handle1)?;
+    let events2 = futures::executor::block_on(handle2)?;
     assert_ne!(events1.len(), 0);
     assert_ne!(events2.len(), 0);
     Ok(())

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -1,6 +1,5 @@
 [dependencies]
 anyhow = { workspace = true }
-async-std = { workspace = true }
 async-trait = { workspace = true }
 bcs-ext = { workspace = true }
 forkable-jellyfish-merkle = { workspace = true }

--- a/sync/src/announcement/mod.rs
+++ b/sync/src/announcement/mod.rs
@@ -1,6 +1,5 @@
 use crate::verified_rpc_client::VerifiedRpcClient;
 use anyhow::Result;
-use async_std::sync::Arc;
 use network_api::messages::PeerAnnouncementMessage;
 use network_api::{PeerProvider, PeerSelector, PeerStrategy, ReputationChange};
 use starcoin_crypto::HashValue;
@@ -14,6 +13,7 @@ use starcoin_txpool_api::TxPoolSyncService;
 use starcoin_types::multi_transaction::MultiTransactionError;
 use starcoin_types::transaction::TransactionError;
 use starcoin_vm2_vm_types::transaction::TransactionError as TransactionError2;
+use std::sync::Arc;
 
 /// Service which handle Announcement message
 pub struct AnnouncementService {

--- a/sync/src/tasks/block_sync_task.rs
+++ b/sync/src/tasks/block_sync_task.rs
@@ -342,9 +342,7 @@ where
                         e,
                         block_info.block_id()
                     );
-                    async_std::task::block_on(async_std::task::sleep(Duration::from_millis(
-                        time_to_wait,
-                    )));
+                    std::thread::sleep(Duration::from_millis(time_to_wait));
                     time_to_wait = time_to_wait.saturating_mul(2);
                 }
             }
@@ -498,7 +496,7 @@ where
                 anyhow::Ok(ParallelSign::NeedMoreBlocks)
             }
         };
-        async_std::task::block_on(fut)
+        tokio::runtime::Handle::current().block_on(fut)
     }
 
     pub fn read_local_absent_block(

--- a/sync/src/tasks/mock.rs
+++ b/sync/src/tasks/mock.rs
@@ -6,7 +6,6 @@ use crate::tasks::{
     BlockConnectedEvent, BlockFetcher, BlockIdFetcher, BlockInfoFetcher, PeerOperator, SyncFetcher,
 };
 use anyhow::{format_err, Context, Ok, Result};
-use async_std::task::JoinHandle;
 use futures::channel::mpsc::UnboundedReceiver;
 use futures::future::BoxFuture;
 use futures::{FutureExt, StreamExt};
@@ -32,6 +31,7 @@ use starcoin_types::block::{Block, BlockIdAndNumber, BlockInfo, BlockNumber};
 use starcoin_types::startup_info::ChainInfo;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::task::JoinHandle;
 
 use super::BlockIdRangeFetcher;
 
@@ -396,7 +396,7 @@ impl SyncNodeMocker {
                 })
                 .await
         };
-        async_std::task::spawn(fut)
+        tokio::spawn(fut)
     }
 
     pub fn select_a_peer(&self) -> Result<PeerId> {

--- a/sync/src/tasks/test_tools.rs
+++ b/sync/src/tasks/test_tools.rs
@@ -82,7 +82,7 @@ impl SyncTestSystem {
             dag.clone(),
         )?;
 
-        let (registry_sender, registry_receiver) = async_std::channel::unbounded();
+        let (registry_sender, mut registry_receiver) = tokio::sync::mpsc::unbounded_channel();
 
         info!(
         "in test_sync_block_apply_failed_but_connect_success, start tokio runtime for main thread"
@@ -97,7 +97,7 @@ impl SyncTestSystem {
                     .build()
                     .expect("failed to create tokio runtime for main")
             });
-            async_std::task::block_on(async {
+            tokio::runtime::Handle::current().block_on(async {
                 let registry = RegistryService::launch();
 
                 registry.put_shared(config.clone()).await.unwrap();
@@ -119,7 +119,7 @@ impl SyncTestSystem {
                     .await
                     .unwrap();
 
-                registry_sender.send(registry).await.unwrap();
+                registry_sender.send(registry).unwrap();
             });
 
             system.run().unwrap();
@@ -178,7 +178,7 @@ pub async fn full_sync_new_node() -> Result<()> {
     )?;
     let join_handle = node2.process_block_connect_event(receiver_1).await;
     let branch = sync_task.await?;
-    let node2 = join_handle.await;
+    let node2 = join_handle.await?;
     let current_block_header = node2.chain().current_header();
     assert_eq!(branch.current_header().id(), target.target_id.id());
     assert_eq!(target.target_id.id(), current_block_header.id());
@@ -213,7 +213,7 @@ pub async fn full_sync_new_node() -> Result<()> {
     )?;
     let join_handle = node2.process_block_connect_event(receiver_1).await;
     let branch = sync_task.await?;
-    let node2 = join_handle.await;
+    let node2 = join_handle.await?;
     let current_block_header = node2.chain().current_header();
     assert_eq!(branch.current_header().id(), target.target_id.id());
     assert_eq!(target.target_id.id(), current_block_header.id());

--- a/sync/src/tasks/tests.rs
+++ b/sync/src/tasks/tests.rs
@@ -138,7 +138,7 @@ pub async fn test_full_sync_fork() -> Result<()> {
     )?;
     let join_handle = node2.process_block_connect_event(receiver).await;
     let branch = sync_task.await?;
-    let mut node2 = join_handle.await;
+    let mut node2 = join_handle.await?;
     let current_block_header = node2.chain().current_header();
     assert_eq!(branch.current_header().id(), target.target_id.id());
     assert_eq!(target.target_id.id(), current_block_header.id());
@@ -176,7 +176,7 @@ pub async fn test_full_sync_fork() -> Result<()> {
     )?;
     let join_handle = node2.process_block_connect_event(receiver).await;
     let branch = sync_task.await?;
-    let node2 = join_handle.await;
+    let node2 = join_handle.await?;
     let current_block_header = node2.chain().current_header();
     assert_eq!(branch.current_header().id(), target.target_id.id());
     assert_eq!(target.target_id.id(), current_block_header.id());
@@ -230,7 +230,7 @@ pub async fn test_full_sync_fork_from_genesis() -> Result<()> {
     )?;
     let join_handle = node2.process_block_connect_event(receiver).await;
     let branch = sync_task.await?;
-    let node2 = join_handle.await;
+    let node2 = join_handle.await?;
     let current_block_header = node2.chain().current_header();
     assert_eq!(branch.current_header().id(), target.target_id.id());
     assert_eq!(target.target_id.id(), current_block_header.id());
@@ -286,7 +286,7 @@ pub async fn test_full_sync_continue() -> Result<()> {
     )?;
     let join_handle = node2.process_block_connect_event(receiver).await;
     let branch = sync_task.await?;
-    let node2 = join_handle.await;
+    let node2 = join_handle.await?;
 
     // the dag in node 2 has two chains: one's current header is 7, the other's current header is 5.
     // As the dag ghost consent rule, the chain with 7 will be the main chain.
@@ -329,7 +329,7 @@ pub async fn test_full_sync_continue() -> Result<()> {
 
     let join_handle = node2.process_block_connect_event(receiver).await;
     let branch = sync_task.await?;
-    let node2 = join_handle.await;
+    let node2 = join_handle.await?;
     let current_block_header = node2.chain().current_header();
     assert_eq!(branch.current_header().id(), target.target_id.id());
     assert_eq!(target.target_id.id(), current_block_header.id());
@@ -393,7 +393,7 @@ pub async fn test_full_sync_cancel() -> Result<()> {
     assert!(sync_result.is_err());
     assert!(sync_result.err().unwrap().is_canceled());
 
-    let node2 = join_handle.await;
+    let node2 = join_handle.await?;
     let current_block_header = node2.chain().current_header();
     ensure!(
         target.target_id.id() != current_block_header.id(),
@@ -1051,7 +1051,7 @@ fn sync_block_in_async_connection(
         local_node.sync_dag_store.clone(),
         false,
     )?;
-    let branch = async_std::task::block_on(sync_task)?;
+    let branch = tokio::runtime::Handle::current().block_on(sync_task)?;
     assert_eq!(branch.current_header().number(), target.target_id.number());
     let target_dag_state = target_node.chain().get_dag_state()?;
     let local_dag_state = target_node.chain().get_dag_state()?;

--- a/sync/src/tasks/tests_dag.rs
+++ b/sync/src/tasks/tests_dag.rs
@@ -30,9 +30,8 @@ async fn sync_block_process(
         let local_net = local_node.chain_mocker.net();
         let (local_ancestor_sender, _local_ancestor_receiver) = unbounded();
 
-        let block_chain_service = async_std::task::block_on(
-            registry.service_ref::<BlockConnectorService<MockTxPoolService>>(),
-        )?;
+        let block_chain_service = tokio::runtime::Handle::current()
+            .block_on(registry.service_ref::<BlockConnectorService<MockTxPoolService>>())?;
 
         let storage2 = local_node.get_storage2();
         let (sync_task, _task_handle, task_event_counter) = full_sync_task(

--- a/sync/tests/full_sync_test.rs
+++ b/sync/tests/full_sync_test.rs
@@ -189,7 +189,7 @@ async fn check_synced(
             break;
         } else {
             debug!("waiting for sync, now sleep 60 second");
-            async_std::task::sleep(Duration::from_millis(500)).await;
+            tokio::time::sleep(Duration::from_millis(500)).await;
         }
     }
     Ok(true)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Refactor
  - Migrated asynchronous runtime usage to Tokio across services and utilities, unifying timeouts, sleeps, task spawning, and blocking behavior. Improves performance and runtime reliability without changing public APIs.

- Tests
  - Updated tests to run on Tokio with clearer error propagation and socket compatibility, improving determinism and failure visibility.

- Chores
  - Removed async-std from the dependency graph and added tokio-util where needed, reducing duplicate runtime dependencies and aligning with the Tokio ecosystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->