### PR TITLE
Misc fixes: network-p2p init and build workflow

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -41,8 +41,6 @@ jobs:
           args: --all
       - name: test
         run: ./scripts/nextest.sh
-#       - name: check changed files
-#         run: bash ./scripts/changed_files.sh
       - name: Doc Tests
         uses: actions-rs/cargo@v1
         with:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,7 @@ COPY --from=builder $RELEASE_PATH/starcoin \
      $RELEASE_PATH/starcoin_miner \
      $RELEASE_PATH/starcoin_txfactory \
      $RELEASE_PATH/starcoin_faucet \
-     $RELEASE_PATH/mpm \
+     $RELEASE_PATH/mpm2 \
      /starcoin/
      
 CMD ["/starcoin/starcoin"]

--- a/network-p2p/src/protocol.rs
+++ b/network-p2p/src/protocol.rs
@@ -501,13 +501,13 @@ impl<T: 'static + BusinessLayerHandle + Send> Protocol<T> {
         }
         out
     }
-    /// Notify the protocol that we have learned about the existence of nodes on the default set.
-    ///
-    /// Can be called multiple times with the same `PeerId`s.
-    pub fn add_default_set_discovered_nodes(&mut self, peer_ids: impl Iterator<Item = PeerId>) {
+
+    pub fn add_set_discovered_nodes(&mut self, peer_ids: impl Iterator<Item = PeerId>) {
         for peer_id in peer_ids {
-            self.peerset_handle
-                .add_to_peers_set(HARD_CORE_PROTOCOL_ID, peer_id);
+            for (set_id, _) in self.notif_protocols.iter().enumerate() {
+                self.peerset_handle
+                    .add_to_peers_set(SetId::from(set_id), peer_id);
+            }
         }
     }
 }

--- a/network-p2p/src/service.rs
+++ b/network-p2p/src/service.rs
@@ -1131,7 +1131,7 @@ impl<T: BusinessLayerHandle + Send> Future for NetworkWorker<T> {
                     this.network_service
                         .behaviour_mut()
                         .user_protocol_mut()
-                        .add_default_set_discovered_nodes(iter::once(peer_id));
+                        .add_set_discovered_nodes(iter::once(peer_id));
                 }
 
                 Poll::Ready(SwarmEvent::Behaviour(BehaviourOut::ReputationChanges {
@@ -1520,7 +1520,7 @@ impl<T: BusinessLayerHandle + Send> Future for NetworkWorker<T> {
                     this.network_service
                         .behaviour_mut()
                         .user_protocol_mut()
-                        .add_default_set_discovered_nodes(iter::once(peer_id));
+                        .add_set_discovered_nodes(iter::once(peer_id));
                 }
             };
         }

--- a/scripts/check_commit.sh
+++ b/scripts/check_commit.sh
@@ -19,7 +19,6 @@ cargo run -p starcoin-rpc-api -- -d ./rpc/api/generated_rpc_schema
 # generate rpc2 schema document
 cargo run -p starcoin-vm2-rpc-api -- -d ./vm2/rpc/api/generated_rpc_schema
 # test config file
-# TODO(BobOng) [migration]: block this check because the genesis has changed, unlock this part of the code after the code goes online
-# cargo test -p starcoin-config test_example_config_compact
+cargo test -p starcoin-config test_example_config_compact
 # check changed files
 "${STARCOIN_DIR}"/scripts/changed_files.sh

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -2,6 +2,13 @@
 # Copyright (c) The Diem Core Contributors
 # SPDX-License-Identifier: Apache-2.0
 # This script sets up the environment for the Diem build by installing necessary dependencies.
+
+# Skip on NixOS - all dependencies handled by nix-shell
+if [ -f /etc/nixos/configuration.nix ] || [ -n "$IN_NIX_SHELL" ]; then
+    echo "NixOS detected, skipping setup (dependencies provided by nix-shell)"
+    exit 0
+fi
+
 #
 # Usage ./dev_setup.sh <options>
 #   v - verbose, print all statements


### PR DESCRIPTION
## What
- Init peerset with notif_protocols in network-p2p
- Fix build workflow and Docker issues

## Why
- Fix network-p2p protocol initialization
- Clean up build scripts and fix Docker mpm binary name

## Impact
Minor fixes to improve build and network stability

## Test
CI will run on this PR

## Size
Small - 16 lines changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Improved peer discovery to register discovered peers across all notification channels, enhancing connectivity and message delivery.
- Chores
  - Docker image now packages the updated mpm2 binary for the final build.
  - Cleaned up the build-and-test workflow by removing obsolete commented steps.
  - Developer setup script skips dependency installation when running on NixOS / inside a nix-shell.
- Tests
  - Commit checks now run the starcoin-config test_example_config_compact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->