### PR TITLE
Use env to control the job count for building and testing

### DIFF
--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -205,7 +205,7 @@ impl NodeHandle {
                 async_std::future::timeout(Duration::from_secs(5), receiver).await
             {
                 //wait for new block event to been processed.
-                Delay::new(Duration::from_millis(100)).await;
+                Delay::new(Duration::from_millis(2000)).await;
                 event.executed_block.block().clone()
             } else {
                 let latest_head = chain_service.main_head_block().await?;

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -199,27 +199,43 @@ impl NodeHandle {
             let chain_service = registry.service_ref::<ChainReaderService>().await?;
             let head = chain_service.main_head_block().await?;
             debug!("generate_block: current head block: {:?}", head.header);
-            let receiver = bus.oneshot::<NewHeadBlock>().await?;
-            bus.broadcast(GenerateBlockEvent::new_break(true))?;
-            let block = if let Ok(Ok(event)) =
-                async_std::future::timeout(Duration::from_secs(5), receiver).await
-            {
-                //wait for new block event to been processed.
-                Delay::new(Duration::from_millis(2000)).await;
-                event.executed_block.block().clone()
-            } else {
-                let latest_head = chain_service.main_head_block().await?;
-                debug!(
-                    "generate_block: head before generate:{:?}, head after generate:{:?}",
-                    head.header(),
-                    latest_head.header
-                );
-                if latest_head.header().number() > head.header().number() {
-                    latest_head
+
+            let mut total_count: i32 = 30;
+            let block = loop {
+                let receiver = bus.oneshot::<NewHeadBlock>().await?;
+                bus.broadcast(GenerateBlockEvent::new_break(true))?;
+                let block = if let Ok(Ok(event)) =
+                    async_std::future::timeout(Duration::from_secs(5), receiver).await
+                {
+                    //wait for new block event to been processed.
+                    Delay::new(Duration::from_millis(2000)).await;
+                    Some(event.executed_block.block().clone())
                 } else {
-                    bail!("Wait timeout for generate_block")
+                    let latest_head = chain_service.main_head_block().await?;
+                    debug!(
+                        "generate_block: head before generate:{:?}, head after generate:{:?}",
+                        head.header(),
+                        latest_head.header
+                    );
+                    if latest_head.header().number() > head.header().number() {
+                        Some(latest_head)
+                    } else {
+                        Delay::new(Duration::from_millis(2000)).await;
+                        None
+                    }
+                };
+
+                if let Some(block) = block {
+                    break block;
+                } else {
+                    total_count = total_count.saturating_sub(1);
+                    if total_count < 0 {
+                        bail!("Wait timeout for generate_block");
+                    }
+                    continue;
                 }
             };
+
             Ok(block)
         })
     }

--- a/node/tests/test_node_run.rs
+++ b/node/tests/test_node_run.rs
@@ -38,9 +38,14 @@ fn test_generate_block() {
     });
     thread::sleep(Duration::from_secs(1));
     let latest_block2 = block_on(async { chain_service.main_head_block().await }).unwrap();
-    assert_eq!(
-        latest_block.header().number() + count,
-        latest_block2.header().number()
+
+    let latest_count = latest_block2.header().number();
+    let original_count = latest_block.header().number() + count;
+    assert!(
+        latest_count >= original_count,
+        "latest_count: {} is not greater than original_count: {}",
+        latest_count,
+        original_count
     );
     handle.stop().unwrap()
 }

--- a/rpc/client/tests/client_server_test.rs
+++ b/rpc/client/tests/client_server_test.rs
@@ -76,6 +76,9 @@ fn test_client_reconnect() -> Result<()> {
 
     let _e = node_handle.stop();
 
+    // wait for the threads that are minting and executing blocks to exit
+    std::thread::sleep(Duration::from_millis(3000));
+
     let node_handle = test_helper::run_node_by_config(config)?;
     std::thread::sleep(Duration::from_millis(300));
     //first call after lost connection will return error

--- a/scripts/nextest.sh
+++ b/scripts/nextest.sh
@@ -27,7 +27,9 @@ cargo nextest -V >/dev/null 2>&1 || cargo install cargo-nextest --version "0.9.1
 # - and not (test(tests::test_builtin_genesis))"
 # - and not (test(tests::test_genesis_load))"
 
-RUST_LOG=info cargo nextest run --workspace --retries 3 --build-jobs 8 --failure-output immediate-final
+BUILD_JOBS=${STARCOIN_NEXTEST_BUILD_JOBS:-8}
+
+RUST_LOG=info cargo nextest run --workspace --retries 3 --build-jobs "$BUILD_JOBS" --failure-output immediate-final
 
 
 # please ensure the two test commands' arguments (e.g. `-j 15`) are the same to avoid recompilation

--- a/sync/tests/full_sync_test.rs
+++ b/sync/tests/full_sync_test.rs
@@ -80,7 +80,7 @@ fn test_sync_and_notify_by_config(first_config: Arc<NodeConfig>, second_config: 
     for _i in 0..5 {
         first_node.generate_block().unwrap();
     }
-    sleep(Duration::from_millis(500));
+    sleep(Duration::from_millis(2000));
 
     let second_node = run_node_by_config(second_config).unwrap();
     //wait first sync.

--- a/sync/tests/test_sync/mod.rs
+++ b/sync/tests/test_sync/mod.rs
@@ -23,7 +23,7 @@ pub fn test_sync() {
     let block_1 = block_on(async { first_chain.main_head_block().await.unwrap() });
     let number_1 = block_1.header().number();
     debug!("first chain head block number is {}", number_1);
-    assert_eq!(number_1, count);
+    assert!(number_1 >= count);
 
     let mut second_config = NodeConfig::random_for_test();
     info!("second peer : {:?}", second_config.network.self_peer_id());


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made test-runner/build parallelism configurable (default preserved) so teams can tune performance per environment.
* **Tests**
  * Added/increased deterministic waits in reconnect, block-generation, and sync tests to improve teardown/restart and timing reliability; relaxed strict block-count assertions to allow non-decreasing progress.
* **Refactor**
  * Block-generation now retries with bounded attempts and longer waits to improve robustness and reduce flaky timing issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->