### PR TITLE
Fix prune handling and group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,16 @@ updates:
     time: "02:00"
     # Use UTC +08:00
     timezone: "Asia/Shanghai"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 3
+  groups:
+    rust-dependencies:
+      patterns:
+        - "*"
+      update-types:
+        - "minor"
+        - "patch"
+    rust-major-updates:
+      patterns:
+        - "*"
+      update-types:
+        - "major"

--- a/.github/workflows/benchmark_pr.yml
+++ b/.github/workflows/benchmark_pr.yml
@@ -1,4 +1,20 @@
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+      - 'LICENSE*'
+      - '.gitignore'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - '.github/dependabot.yml'
+      - '.github/CODEOWNERS'
+      - 'examples/**'
+      - 'vm2/move-examples/'
+      - 'scripts/**'
+      - 'kube/**'
+      - 'docker/**'
 
 name: benchmark pull requests
 jobs:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -2,8 +2,23 @@ name: Build and Test
 on:
   workflow_dispatch:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - dual-verse-dag
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+      - 'LICENSE*'
+      - '.gitignore'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - '.github/dependabot.yml'
+      - '.github/CODEOWNERS'
+      - 'examples/**'
+      - 'vm2/move-examples/'
+      - 'scripts/**'
+      - 'kube/**'
+      - 'docker/**'
 
 jobs:
   build-and-test:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11347,6 +11347,7 @@ dependencies = [
  "anyhow",
  "bcs-ext",
  "flate2",
+ "futures 0.3.31",
  "log 0.4.27",
  "once_cell",
  "proptest",

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -48,6 +48,7 @@ starcoin-types = { features = [
 ], workspace = true }
 stest = { workspace = true }
 test-helper = { workspace = true }
+futures = { workspace = true }
 starcoin-vm2-test-helper = { workspace = true }
 starcoin-vm2-state-api = { workspace = true }
 starcoin-vm2-crypto = { workspace = true }

--- a/chain/mock/src/mock_chain.rs
+++ b/chain/mock/src/mock_chain.rs
@@ -1,19 +1,20 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
+use anyhow::{format_err, Result};
 use starcoin_account_api::AccountInfo;
 use starcoin_chain::{BlockChain, ChainReader, ChainWriter};
 use starcoin_config::ChainNetwork;
 use starcoin_consensus::Consensus;
 use starcoin_crypto::HashValue;
-use starcoin_dag::blockdag::BlockDAG;
+use starcoin_dag::blockdag::{BlockDAG, MineNewDagBlockInfo};
 use starcoin_genesis::Genesis;
 use starcoin_logger::prelude::*;
+use starcoin_storage::storage::StorageInstance;
 use starcoin_storage::{Storage, Store};
 use starcoin_storage::{Storage2, Store2};
 use starcoin_types::block::{Block, BlockHeader, ExecutedBlock};
-use starcoin_types::multi_state::MultiState;
+use starcoin_types::blockhash::KType;
 use starcoin_types::startup_info::ChainInfo;
 use std::sync::Arc;
 
@@ -77,6 +78,30 @@ impl MockChain {
     }
 
     pub fn new_with_chain(net: ChainNetwork, chain: BlockChain) -> Result<Self> {
+        let miner = AccountInfo::random();
+        Ok(Self::new_inner(net, chain, miner))
+    }
+
+    pub fn new_with_genesis_for_test(
+        net: ChainNetwork,
+        genesis: Genesis,
+        k: KType,
+    ) -> Result<Self> {
+        let storage = Arc::new(Storage::new(StorageInstance::new_cache_instance())?);
+        let storage2 = Arc::new(Storage2(storage.clone()));
+        let dag = BlockDAG::create_for_testing_with_parameters(k)?;
+        let chain_info =
+            genesis.execute_genesis_block(&net, storage.clone(), storage2.clone(), dag.clone())?;
+
+        let chain = BlockChain::new(
+            net.time_service(),
+            chain_info.head().id(),
+            storage.clone(),
+            storage2,
+            None,
+            dag,
+        )?;
+
         let miner = AccountInfo::random();
         Ok(Self::new_inner(net, chain, miner))
     }
@@ -229,8 +254,9 @@ impl MockChain {
                 .get_storage()
                 .get_block_info(header.id())?
                 .unwrap();
-            // Create ExecutedBlock with MultiState
-            let executed_block = ExecutedBlock::new(block, block_info, MultiState::default());
+            // Get the actual MultiState from storage using the standard method
+            let multi_state = self.head.get_storage().get_vm_multi_state(header.id())?;
+            let executed_block = ExecutedBlock::new(block, block_info, multi_state);
             blocks.push(executed_block);
         }
         Ok(blocks)
@@ -255,14 +281,41 @@ impl MockChain {
         if self.head().current_header().id() != parent_header.id() {
             self.head = self.head.fork(parent_header.id())?;
         }
+
+        // TODO: API Design Issue - parent_header parameter is redundant after fork()
+        //
+        // The current API design has a fundamental issue:
+        // 1. We call fork(parent_header.id()) to switch to the historical view
+        // 2. After fork(), the chain head IS the parent we want to build on
+        // 3. Passing parent_header again to create_block_template is redundant
+        // 4. dual-verse-dag's strict validation exposes this redundancy
+        //
+        // Better API would be:
+        //   chain.fork(parent_id)?;
+        //   chain.create_block_template(author, txns, uncles, gas_limit, tips, pruning_point)?;
+        //   // parent_header derived automatically from current head after fork
+        //
+        // For now, we ensure consistency by using ghostdata.selected_parent
+        let tips_ghostdata = self.head.dag().ghost_dag_manager().ghostdag(&tips)?;
+        let consistent_parent_header = self
+            .head()
+            .get_storage()
+            .get_block_header_by_hash(tips_ghostdata.selected_parent)?
+            .ok_or_else(|| {
+                format_err!(
+                    "Cannot find block header by hash: {:?}",
+                    tips_ghostdata.selected_parent
+                )
+            })?;
+
         let (block_template, _) = self.head.create_block_template(
             *self.miner.address(),
-            Some(parent_header), // parent_header
-            Vec::new(),          // user_txns
-            None,                // uncles
-            None,                // block_gas_limit
-            Some(tips),          // tips
-            HashValue::zero(),   // pruning_point
+            Some(consistent_parent_header), // Use consistent parent from tips
+            Vec::new(),                     // user_txns
+            None,                           // uncles
+            None,                           // block_gas_limit
+            Some(tips),                     // tips
+            HashValue::zero(),              // pruning_point
         )?;
         let new_block = self
             .head
@@ -302,6 +355,100 @@ impl MockChain {
         assert_eq!(self.head.current_header().id(), new_header_id);
 
         Ok(())
+    }
+
+    pub fn produce_block_for_pruning(&mut self) -> Result<Block> {
+        let tips = self.head.get_dag_state()?.tips;
+        let ghostdata = self.head.dag().ghost_dag_manager().ghostdag(&tips)?;
+        let selected_header = self
+            .head()
+            .get_storage()
+            .get_block_header_by_hash(ghostdata.selected_parent)?
+            .ok_or_else(|| {
+                format_err!(
+                    "Cannot find block header by hash: {:?}",
+                    ghostdata.selected_parent
+                )
+            })?;
+
+        let previous_pruning = if selected_header.pruning_point() == HashValue::zero() {
+            self.head().get_storage().get_genesis()?.unwrap()
+        } else {
+            selected_header.pruning_point()
+        };
+
+        let MineNewDagBlockInfo {
+            selected_parents: pruned_tips,
+            ghostdata: pruned_ghostdata,
+            pruning_point,
+        } = self
+            .head
+            .dag()
+            .calc_mergeset_and_tips(previous_pruning, self.head().get_genesis_hash())?;
+
+        // Calculate the selected parent from pruned_tips to ensure consistency
+        let pruned_tips_ghostdata = self.head.dag().ghost_dag_manager().ghostdag(&pruned_tips)?;
+        let pruned_selected_parent_header = self
+            .head()
+            .get_storage()
+            .get_block_header_by_hash(pruned_tips_ghostdata.selected_parent)?
+            .ok_or_else(|| {
+                format_err!(
+                    "Cannot find selected parent header by hash: {:?}",
+                    pruned_tips_ghostdata.selected_parent
+                )
+            })?;
+
+        let (template, _) = self.head.create_block_template(
+            *self.miner.address(),
+            Some(pruned_selected_parent_header), // Use selected parent from pruned_tips for consistency
+            vec![],
+            Some(
+                pruned_ghostdata
+                    .mergeset_blues
+                    .get(1..)
+                    .unwrap_or(&[])
+                    .iter()
+                    .map(|block_id| {
+                        self.head()
+                            .get_storage()
+                            .get_block_header_by_hash(*block_id)?
+                            .ok_or_else(|| {
+                                format_err!("Block header not found for hash: {:?}", block_id)
+                            })
+                    })
+                    .collect::<Result<Vec<_>>>()?,
+            ), // Use uncles from pruned ghostdata
+            None,
+            Some(pruned_tips), // Use calculated tips to control parents
+            pruning_point,
+        )?;
+        self.head
+            .consensus()
+            .create_block(template, self.net.time_service().as_ref())
+    }
+
+    pub fn produce_block_by_params(
+        &mut self,
+        parent_header: BlockHeader,
+        tips: Vec<HashValue>,
+        pruning_point: HashValue,
+    ) -> Result<Block> {
+        let (block_template, _) = self.head.create_block_template(
+            *self.miner.address(),
+            Some(parent_header),
+            Vec::new(),
+            None,
+            None,
+            Some(tips),
+            pruning_point,
+        )?;
+
+        let new_block = self
+            .head
+            .consensus()
+            .create_block(block_template, self.net.time_service().as_ref())?;
+        Ok(new_block)
     }
 
     pub fn miner(&self) -> &AccountInfo {

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -1912,8 +1912,25 @@ impl BlockChain {
                 .find_selected_parent(state.tips.into_iter())?;
             self.fork(block_id)?
         } else {
-            // Handle pruning point change if needed
-            bail!("Pruning point change not yet fully implemented")
+            // Handle pruning point change: select best header from both states
+            let new_state = self.dag().get_dag_state(new_pruning_point)?;
+            let current_state = self.dag().get_dag_state(current_pruning_point)?;
+
+            let new_header = self
+                .dag()
+                .ghost_dag_manager()
+                .find_selected_parent(new_state.tips.into_iter())?;
+            let current_header = self
+                .dag()
+                .ghost_dag_manager()
+                .find_selected_parent(current_state.tips.into_iter())?;
+
+            let selected_header = self
+                .dag()
+                .ghost_dag_manager()
+                .find_selected_parent([new_header, current_header].into_iter())?;
+
+            self.fork(selected_header)?
         };
 
         Ok(chain)

--- a/chain/tests/test_prune.rs
+++ b/chain/tests/test_prune.rs
@@ -1,0 +1,141 @@
+use starcoin_chain::ChainReader;
+use starcoin_chain_mock::MockChain;
+use starcoin_config::ChainNetwork;
+use starcoin_logger::prelude::debug;
+use std::collections::HashSet;
+use test_helper::Genesis;
+
+#[stest::test]
+fn test_block_chain_prune() -> anyhow::Result<()> {
+    let net = ChainNetwork::new_test();
+    let genesis = Genesis::build(&net)?;
+    let mut mock_chain = MockChain::new_with_genesis_for_test(net, genesis, 3)?;
+    let genesis = mock_chain.head().status().head.clone();
+
+    // blue blocks
+    let block_blue_1 = mock_chain.produce_and_apply_by_tips(genesis.clone(), vec![genesis.id()])?;
+
+    let pruning_depth = 4;
+    let pruning_finality = 3;
+    futures::executor::block_on(mock_chain.head().dag().generate_pruning_point(
+        &block_blue_1,
+        pruning_depth,
+        pruning_finality,
+        genesis.id(),
+    ))?;
+
+    let block_blue_2 =
+        mock_chain.produce_and_apply_by_tips(block_blue_1.clone(), vec![block_blue_1.id()])?;
+    let block_blue_3 =
+        mock_chain.produce_and_apply_by_tips(block_blue_2.clone(), vec![block_blue_2.id()])?;
+    let block_blue_3_1 =
+        mock_chain.produce_and_apply_by_tips(block_blue_2.clone(), vec![block_blue_2.id()])?;
+    let block_blue_4 = mock_chain.produce_and_apply_by_tips(
+        block_blue_3.clone(),
+        vec![block_blue_3.id(), block_blue_3_1.id()],
+    )?;
+    let block_blue_5 =
+        mock_chain.produce_and_apply_by_tips(block_blue_4.clone(), vec![block_blue_4.id()])?;
+
+    // red blocks
+    let block_red_2 =
+        mock_chain.produce_and_apply_by_tips(block_blue_1.clone(), vec![block_blue_1.id()])?;
+    let block_red_2_1 =
+        mock_chain.produce_and_apply_by_tips(block_blue_1.clone(), vec![block_blue_1.id()])?;
+    let block_red_3 = mock_chain.produce_and_apply_by_tips(
+        block_red_2.clone(),
+        vec![block_red_2.id(), block_red_2_1.id()],
+    )?;
+
+    debug!(
+        "tips: {:?}, pruning point: {:?}",
+        mock_chain.head().get_dag_state()?,
+        mock_chain.head().status().head().pruning_point()
+    );
+    assert_eq!(
+        mock_chain
+            .head()
+            .get_dag_state()?
+            .tips
+            .into_iter()
+            .collect::<HashSet<_>>(),
+        HashSet::from_iter(vec![block_blue_5.id(), block_red_3.id()])
+    );
+
+    let block_blue_6 =
+        mock_chain.produce_and_apply_by_tips(block_blue_5.clone(), vec![block_blue_5.id()])?;
+    let block_blue_6_1 =
+        mock_chain.produce_and_apply_by_tips(block_blue_5.clone(), vec![block_blue_5.id()])?;
+    let block_red_4 =
+        mock_chain.produce_and_apply_by_tips(block_red_3.clone(), vec![block_red_3.id()])?;
+
+    debug!(
+        "tips: {:?}, pruning point: {:?}",
+        mock_chain.head().get_dag_state()?,
+        mock_chain.head().status().head().pruning_point()
+    );
+    assert_eq!(
+        mock_chain
+            .head()
+            .get_dag_state()?
+            .tips
+            .into_iter()
+            .collect::<HashSet<_>>(),
+        HashSet::from_iter(vec![
+            block_blue_6.id(),
+            block_blue_6_1.id(),
+            block_red_4.id()
+        ])
+    );
+
+    futures::executor::block_on(mock_chain.head().dag().generate_pruning_point(
+        &block_blue_6,
+        pruning_depth,
+        pruning_finality,
+        genesis.id(),
+    ))?;
+    futures::executor::block_on(mock_chain.head().dag().generate_pruning_point(
+        &block_blue_6_1,
+        pruning_depth,
+        pruning_finality,
+        genesis.id(),
+    ))?;
+
+    let block_blue_7 = mock_chain.produce_block_for_pruning()?;
+    mock_chain.apply(block_blue_7.clone())?;
+
+    assert_eq!(block_blue_7.header().pruning_point(), block_blue_2.id());
+    assert_eq!(
+        block_blue_7
+            .header()
+            .parents_hash()
+            .iter()
+            .collect::<HashSet<_>>(),
+        HashSet::from_iter(vec![&block_blue_6.id(), &block_blue_6_1.id()])
+    );
+
+    let tips = mock_chain.head().get_dag_state()?.tips;
+    assert_eq!(
+        tips.iter().cloned().collect::<HashSet<_>>(),
+        HashSet::from_iter(vec![block_blue_7.id()])
+    );
+
+    let failure_block = mock_chain.produce_block_by_params(
+        block_blue_7.header().clone(),
+        vec![block_red_4.id(), block_blue_7.id()],
+        block_blue_7.header().pruning_point(),
+    )?;
+    assert_eq!(
+        failure_block
+            .header()
+            .parents_hash()
+            .iter()
+            .collect::<HashSet<_>>(),
+        HashSet::from_iter(vec![&block_red_4.id(), &block_blue_7.id()])
+    );
+    let result = mock_chain.apply(failure_block);
+    debug!("apply failure block result: {:?}", result);
+    assert!(result.is_err());
+
+    Ok(())
+}

--- a/chain/tests/test_range_locate.rs
+++ b/chain/tests/test_range_locate.rs
@@ -1,0 +1,194 @@
+use anyhow::{bail, format_err};
+use starcoin_chain::ChainReader;
+use starcoin_chain_api::range_locate::{
+    find_common_header_in_range, get_range_in_location, FindCommonHeader, RangeInLocation,
+};
+use starcoin_chain_mock::MockChain;
+use starcoin_config::ChainNetwork;
+use test_helper::Genesis;
+
+#[stest::test(timeout = 480)]
+fn test_range_locate() -> anyhow::Result<()> {
+    let net = ChainNetwork::new_test();
+    let genesis = Genesis::build(&net)?;
+    let mut mock_chain_local =
+        MockChain::new_with_genesis_for_test(net.clone(), genesis.clone(), 3)?;
+    let mut mock_chain_remote = MockChain::new_with_genesis_for_test(net, genesis.clone(), 3)?;
+
+    let common_number = 37;
+    let blocks = mock_chain_local.produce_and_apply_with_tips_for_times(common_number)?;
+
+    assert_eq!(
+        common_number,
+        mock_chain_local.head().current_header().number()
+    );
+
+    blocks.into_iter().try_for_each(|block| {
+        mock_chain_remote.apply(block.block().clone())?;
+        mock_chain_remote.connect(block)?;
+        anyhow::Ok(())
+    })?;
+
+    assert_eq!(
+        common_number,
+        mock_chain_remote.head().current_header().number()
+    );
+
+    assert_eq!(
+        mock_chain_remote.head().current_header().id(),
+        mock_chain_local.head().current_header().id()
+    );
+
+    let common_block = mock_chain_local
+        .get_storage()
+        .get_block_by_hash(mock_chain_local.head().current_header().id())?
+        .unwrap();
+
+    // now fork
+    let _ = mock_chain_remote.produce_and_apply_with_tips_for_times(113)?;
+    let _ = mock_chain_local.produce_and_apply_with_tips_for_times(13)?;
+
+    let mut found_common_header = None;
+
+    let mut remote_start_id = genesis.block().id();
+    let mut remote_end_id = None;
+
+    loop {
+        println!(
+            "remote_start_id: {:?}, remote_end_id: {:?}",
+            remote_start_id, remote_end_id
+        );
+        let result = match get_range_in_location(
+            mock_chain_remote.head(),
+            mock_chain_remote.head().get_storage(),
+            remote_start_id,
+            remote_end_id,
+        )? {
+            RangeInLocation::NotInSelectedChain => bail!("all are no in selected chain!"),
+            RangeInLocation::InSelectedChain(_hash_value, hash_values) => hash_values,
+        };
+
+        result.iter().for_each(|block_id| {
+            let header = mock_chain_remote
+                .head()
+                .get_storage()
+                .get_block_header_by_hash(*block_id)
+                .unwrap()
+                .unwrap();
+            println!(
+                "result block id: {:?}, number: {:?}",
+                header.id(),
+                header.number()
+            );
+        });
+
+        if result.len() == 1 {
+            break;
+        }
+
+        let find_result = find_common_header_in_range(&mock_chain_local.head().dag(), &result)
+            .map_err(|err| {
+                format_err!("failed to find_common_header_in_range, error: {:?}", err)
+            })?;
+
+        println!("find common header: {:?}", find_result);
+
+        match find_result {
+            FindCommonHeader::AllInRange => {
+                found_common_header = Some(*result.last().unwrap());
+                remote_start_id = *result.last().unwrap();
+                remote_end_id = None;
+            }
+            FindCommonHeader::InRange(start_id, end_id) => {
+                found_common_header = Some(start_id);
+                remote_start_id = start_id;
+                remote_end_id = Some(end_id);
+            }
+            FindCommonHeader::Found(hash_value) => {
+                found_common_header = Some(hash_value);
+                break;
+            }
+            FindCommonHeader::NotInRange => break,
+        }
+    }
+
+    println!("found common header: {:?}", found_common_header);
+
+    assert_eq!(
+        common_block.id(),
+        found_common_header.expect("common header not found")
+    );
+
+    anyhow::Ok(())
+}
+
+#[stest::test]
+fn test_not_in_range_locate() -> anyhow::Result<()> {
+    let net = ChainNetwork::new_test();
+    let genesis = Genesis::build(&net)?;
+    let mut mock_chain_local =
+        MockChain::new_with_genesis_for_test(net.clone(), genesis.clone(), 3)?;
+    let mut mock_chain_remote = MockChain::new_with_genesis_for_test(net, genesis.clone(), 3)?;
+
+    let count = 37;
+    let _ = mock_chain_local.produce_and_apply_with_tips_for_times(count)?;
+    let _ = mock_chain_remote.produce_and_apply_with_tips_for_times(count)?;
+
+    let result = get_range_in_location(
+        mock_chain_remote.head(),
+        mock_chain_remote.head().get_storage(),
+        mock_chain_local.head().current_header().id(),
+        None,
+    )?;
+
+    assert_eq!(
+        result,
+        RangeInLocation::NotInSelectedChain,
+        "expect not in selected chain"
+    );
+
+    anyhow::Ok(())
+}
+
+#[stest::test]
+fn test_same_range_request() -> anyhow::Result<()> {
+    let net = ChainNetwork::new_test();
+    let genesis = Genesis::build(&net)?;
+    let mut mock_chain_remote = MockChain::new_with_genesis_for_test(net, genesis.clone(), 3)?;
+
+    let count = 8;
+    let _ = mock_chain_remote.produce_and_apply_with_tips_for_times(count)?;
+
+    match get_range_in_location(
+        mock_chain_remote.head(),
+        mock_chain_remote.head().get_storage(),
+        mock_chain_remote.head().current_header().id(),
+        Some(mock_chain_remote.head().current_header().id()),
+    )? {
+        RangeInLocation::NotInSelectedChain => bail!("expect in selected chain"),
+        RangeInLocation::InSelectedChain(hash_value, hash_values) => {
+            assert_eq!(hash_value, mock_chain_remote.head().current_header().id());
+            assert_eq!(hash_values.len(), 0);
+        }
+    }
+
+    let block_header = mock_chain_remote
+        .head()
+        .get_block_info_by_number(3)?
+        .ok_or_else(|| format_err!("block info not found"))?;
+
+    match get_range_in_location(
+        mock_chain_remote.head(),
+        mock_chain_remote.head().get_storage(),
+        *block_header.block_id(),
+        Some(*block_header.block_id()),
+    )? {
+        RangeInLocation::NotInSelectedChain => bail!("expect in selected chain"),
+        RangeInLocation::InSelectedChain(hash_value, hash_values) => {
+            assert_eq!(hash_value, block_header.block_id().clone());
+            assert_eq!(hash_values.len(), 0);
+        }
+    }
+
+    anyhow::Ok(())
+}

--- a/chain/tests/test_select_dag_state.rs
+++ b/chain/tests/test_select_dag_state.rs
@@ -1,0 +1,164 @@
+use anyhow::Result;
+use starcoin_chain::ChainReader;
+use starcoin_chain_mock::MockChain;
+use starcoin_config::ChainNetwork;
+use starcoin_crypto::HashValue;
+use test_helper::Genesis;
+
+/// Test basic case: same pruning point should not trigger complex logic
+#[stest::test]
+fn test_select_dag_state_same_pruning_point() -> Result<()> {
+    let net = ChainNetwork::new_test();
+    let genesis = Genesis::build(&net)?;
+    let mut mock_chain = MockChain::new_with_genesis_for_test(net, genesis, 3)?;
+    let genesis_header = mock_chain.head().status().head.clone();
+
+    // Create a simple chain: genesis -> block_1 -> block_2
+    let block_1 =
+        mock_chain.produce_and_apply_by_tips(genesis_header.clone(), vec![genesis_header.id()])?;
+    let block_2 = mock_chain.produce_and_apply_by_tips(block_1.clone(), vec![block_1.id()])?;
+
+    // Select DAG state with same pruning point (should use simple path)
+    let mut test_chain = mock_chain.fork_new_branch(Some(block_1.id()))?;
+    let new_chain = test_chain.select_dag_state(&block_2)?;
+
+    // Verify: selected chain should have block_2 as head (same pruning point, simple case)
+    assert_eq!(new_chain.status().head().id(), block_2.id());
+    assert_eq!(
+        new_chain.status().head().pruning_point(),
+        block_2.pruning_point()
+    );
+
+    Ok(())
+}
+
+/// Test complex case: different pruning points triggers comparison logic
+#[stest::test]
+fn test_select_dag_state_different_pruning_points() -> Result<()> {
+    let net = ChainNetwork::new_test();
+    let genesis = Genesis::build(&net)?;
+    let mut mock_chain = MockChain::new_with_genesis_for_test(net, genesis, 3)?;
+    let genesis_header = mock_chain.head().status().head.clone();
+
+    // Build a DAG with enough depth to trigger pruning
+    // Chain 1: genesis -> blue_1 -> blue_2 -> blue_3 -> blue_4 -> blue_5
+    let blue_1 =
+        mock_chain.produce_and_apply_by_tips(genesis_header.clone(), vec![genesis_header.id()])?;
+    let blue_2 = mock_chain.produce_and_apply_by_tips(blue_1.clone(), vec![blue_1.id()])?;
+    let blue_3 = mock_chain.produce_and_apply_by_tips(blue_2.clone(), vec![blue_2.id()])?;
+    let blue_4 = mock_chain.produce_and_apply_by_tips(blue_3.clone(), vec![blue_3.id()])?;
+    let blue_5 = mock_chain.produce_and_apply_by_tips(blue_4.clone(), vec![blue_4.id()])?;
+
+    // Generate pruning point for blue_5 (this should set pruning_point to blue_2)
+    futures::executor::block_on(mock_chain.head().dag().generate_pruning_point(
+        &blue_5,
+        4, // pruning_depth
+        3, // pruning_finality
+        genesis_header.id(),
+    ))?;
+
+    // Create a block with the new pruning point
+    let blue_6 = mock_chain.produce_block_for_pruning()?;
+    mock_chain.apply(blue_6.clone())?;
+
+    // Verify pruning was triggered (may or may not change from genesis depending on chain length)
+    // The key is that select_dag_state should handle any pruning point without failing
+
+    // Create a second chain branch for comparison
+    let mut fork_chain = mock_chain.fork(Some(blue_3.id()))?;
+    let red_4 = fork_chain.produce_and_apply_by_tips(blue_3.clone(), vec![blue_3.id()])?;
+    let _red_5 = fork_chain.produce_and_apply_by_tips(red_4.clone(), vec![red_4.id()])?;
+
+    // Now test select_dag_state with different pruning points
+    // This should trigger the complex comparison logic in lines 1915-1934
+    let mut test_chain = mock_chain.fork_new_branch(Some(blue_5.id()))?;
+    let selected_chain = test_chain.select_dag_state(blue_6.header())?;
+
+    // Verify: the selected chain should handle the pruning point change correctly
+    // The exact result depends on GHOSTDAG comparison, but it should not panic/fail
+    assert!(selected_chain.status().head().id() != HashValue::zero());
+
+    Ok(())
+}
+
+/// Test edge case: zero pruning point handling
+#[stest::test]
+fn test_select_dag_state_zero_pruning_point() -> Result<()> {
+    let net = ChainNetwork::new_test();
+    let genesis = Genesis::build(&net)?;
+    let mut mock_chain = MockChain::new_with_genesis_for_test(net, genesis, 3)?;
+    let genesis_header = mock_chain.head().status().head.clone();
+
+    // Create blocks without triggering pruning (short chain)
+    let block_1 =
+        mock_chain.produce_and_apply_by_tips(genesis_header.clone(), vec![genesis_header.id()])?;
+
+    // Both current and new blocks should have zero pruning point
+    assert_eq!(genesis_header.pruning_point(), HashValue::zero());
+    assert_eq!(block_1.pruning_point(), HashValue::zero());
+
+    // This should take the simple path (condition on line 1905-1907)
+    let mut test_chain = mock_chain.fork_new_branch(Some(genesis_header.id()))?;
+    let selected_chain = test_chain.select_dag_state(&block_1)?;
+
+    // Verify: should work without issues
+    assert_eq!(selected_chain.status().head().id(), block_1.id());
+
+    Ok(())
+}
+
+/// Test the specific fix: what used to fail with "not yet fully implemented"
+#[stest::test]
+fn test_select_dag_state_regression_pruning_change() -> Result<()> {
+    let net = ChainNetwork::new_test();
+    let genesis = Genesis::build(&net)?;
+    let mut mock_chain = MockChain::new_with_genesis_for_test(net, genesis, 3)?;
+    let genesis_header = mock_chain.head().status().head.clone();
+
+    // Build two separate chains with different pruning points
+    // Chain 1: Deep enough to get pruning_point = blue_2
+    let blue_1 =
+        mock_chain.produce_and_apply_by_tips(genesis_header.clone(), vec![genesis_header.id()])?;
+    let blue_2 = mock_chain.produce_and_apply_by_tips(blue_1.clone(), vec![blue_1.id()])?;
+    let blue_3 = mock_chain.produce_and_apply_by_tips(blue_2.clone(), vec![blue_2.id()])?;
+    let blue_4 = mock_chain.produce_and_apply_by_tips(blue_3.clone(), vec![blue_3.id()])?;
+    let blue_5 = mock_chain.produce_and_apply_by_tips(blue_4.clone(), vec![blue_4.id()])?;
+    let blue_6 = mock_chain.produce_and_apply_by_tips(blue_5.clone(), vec![blue_5.id()])?;
+
+    // Generate pruning point
+    futures::executor::block_on(mock_chain.head().dag().generate_pruning_point(
+        &blue_6,
+        4, // pruning_depth
+        3, // pruning_finality
+        genesis_header.id(),
+    ))?;
+
+    let pruned_block = mock_chain.produce_block_for_pruning()?;
+    mock_chain.apply(pruned_block.clone())?;
+
+    // This block should have a non-zero pruning point
+    let new_pruning_point = pruned_block.header().pruning_point();
+    assert_ne!(new_pruning_point, HashValue::zero());
+
+    // Fork to a different chain with zero pruning point
+    let mut other_chain = mock_chain.fork(Some(genesis_header.id()))?;
+    let _other_block =
+        other_chain.produce_and_apply_by_tips(genesis_header.clone(), vec![genesis_header.id()])?;
+
+    // This is the scenario that used to fail with "Pruning point change not yet fully implemented"
+    // Current chain has zero pruning point, new block has non-zero pruning point
+    let mut test_chain = other_chain.fork_new_branch(Some(genesis_header.id()))?;
+    let result = test_chain.select_dag_state(pruned_block.header());
+
+    // The key test: this should NOT fail anymore
+    assert!(
+        result.is_ok(),
+        "select_dag_state should handle pruning point changes"
+    );
+
+    let selected_chain = result?;
+    // Should successfully create a chain, exact head depends on GHOSTDAG logic
+    assert!(selected_chain.status().head().id() != HashValue::zero());
+
+    Ok(())
+}

--- a/config/src/genesis_config/vm2.rs
+++ b/config/src/genesis_config/vm2.rs
@@ -286,8 +286,8 @@ pub static G_TEST_CONFIG: Lazy<GenesisConfig> = Lazy::new(|| {
             base_block_gas_limit: G_BASE_BLOCK_GAS_LIMIT * 10,
             strategy: 0, //ConsensusStrategy::Dummy.value(),
             max_transaction_per_block: G_MAX_TRANSACTION_PER_BLOCK,
-            pruning_depth: G_PRUNING_DEPTH,
-            pruning_finality: G_PRUNING_FINALITY,
+            pruning_depth: 4,
+            pruning_finality: 3,
         },
         association_key_pair: (
             Some(Arc::new(association_private_key)),


### PR DESCRIPTION
Fix prune handling and group dependabot updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - More block-production options for pruning scenarios and explicit parent/tip selection.
  - Easier test-chain setup via a dedicated test constructor.

- Bug Fixes
  - Handles pruning-point changes by reconciling states instead of failing; more consistent parent selection.

- Tests
  - Added comprehensive tests for pruning, DAG selection, and range-locate behaviors.

- Chores
  - Tuned dependency-update automation (fewer open PRs, grouped updates).
  - Added a development-only async dependency.
  - Updated CI workflows: removed one pipeline, added reusable/core and comment-triggered run, refined PR triggers and path-ignore rules.
- Other
  - Test genesis pruning parameters set to explicit values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->