### PR TITLE
ci: require PR label "ci-runner:" to trigger builds

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,46 +1,74 @@
 name: Build and Test
+
 on:
   workflow_dispatch:
+    inputs:
+      runner_label:
+        description: "self-hosted runner unique label (e.g. nixos-amd or k8s)"
+        required: true
+        type: string
+
   pull_request:
-    types: [ opened, synchronize, reopened, ready_for_review ]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
     branches:
       - dual-verse-dag
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
-      - 'LICENSE*'
-      - '.gitignore'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/PULL_REQUEST_TEMPLATE.md'
-      - '.github/dependabot.yml'
-      - '.github/CODEOWNERS'
-      - 'examples/**'
-      - 'vm2/move-examples/'
-      - 'scripts/**'
-      - 'kube/**'
-      - 'docker/**'
 
 jobs:
+  choose-runner:
+    if: ${{ (github.event_name == 'pull_request' && contains(join(github.event.pull_request.labels.*.name, ','), 'ci-runner:')) || (github.event_name == 'workflow_dispatch' && inputs.runner_label != '') }}
+    runs-on: ubuntu-latest
+    outputs:
+      runs_on_json: ${{ steps.pick.outputs.runs_on_json }}
+    steps:
+      - name: Pick runner from PR label.
+        id: pick
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          LABELS_JSON: ${{ toJson(github.event.pull_request.labels) }}
+          INPUT_LABEL: ${{ inputs.runner_label }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            target=$(printf '%s' "$LABELS_JSON" \
+              | jq -r '.[]?.name
+                        | select(startswith("ci-runner:"))
+                        | sub("^ci-runner:\\s*"; "")' \
+              | head -n1)
+            if [ -z "${target:-}" ] || [ "$target" = "null" ]; then
+              echo "No ci-runner label found" >&2
+              exit 1
+            fi
+            printf 'runs_on_json=%s\n' "$(jq -cn --arg t "$target" '["self-hosted", $t]')" >> "$GITHUB_OUTPUT"
+          else
+            printf 'runs_on_json=%s\n' "$(jq -cn --arg t "$INPUT_LABEL" '["self-hosted", $t]')" >> "$GITHUB_OUTPUT"
+          fi
+
   build-and-test:
     name: build and test
-    runs-on: self-hosted
+    needs: choose-runner
+    if: ${{ (github.event_name == 'pull_request' && contains(join(github.event.pull_request.labels.*.name, ','), 'ci-runner:')) || (github.event_name == 'workflow_dispatch' && inputs.runner_label != '') }}
+    runs-on: ${{ fromJSON(needs.choose-runner.outputs.runs_on_json) }}
     timeout-minutes: 120
     steps:
       - name: checkout
         uses: actions/checkout@v1
         with:
           submodules: recursive
+
       - name: run fmt check
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: -- --check
+
       - name: setup environment
-        run: bash ./scripts/dev_setup.sh  -b -t -m
+        run: bash ./scripts/dev_setup.sh -b -t -m
+
       - name: run cargo clean
         uses: actions-rs/cargo@v1
         with:
           command: clean
+
       - name: run cargo check
         uses: actions-rs/cargo@v1
         env:
@@ -54,13 +82,16 @@ jobs:
         with:
           command: build
           args: --all
+
       - name: test
         run: ./scripts/nextest.sh
+
       - name: Doc Tests
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --doc
+
       - name: integration test dev environment
         env:
           RUST_LOG: info


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Improved CI with dynamic runner selection for labeled PRs and manual triggers, gating runs to valid runner inputs.
  - Expanded workflow triggers to include labeled PR events and manual dispatch for greater flexibility and faster feedback.
  - Refined build-and-test orchestration and steps for more reliable execution.

- Tests
  - Expanded pipeline to run style/lint checks, builds for all targets, doc tests, unit tests, and integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->