### PR TITLE
Add rpc batch interface for pushing the transaction into the vm2 transaction pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
  "pin-project-lite 0.2.16",
  "smallvec 1.10.0",
  "tokio",
- "tokio-util 0.7.7",
+ "tokio-util 0.7.16",
 ]
 
 [[package]]
@@ -291,7 +291,7 @@ dependencies = [
  "serde 1.0.205",
  "serde_json",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-rpc-api",
  "starcoin-vm1-types",
  "starcoin-vm1-vm-types",
@@ -806,27 +806,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e22d1f4b888c298a027c99dc9048015fac177587de20fc30232a057dfbe24a21"
 
 [[package]]
-name = "async-attributes"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
-dependencies = [
- "quote 1.0.36",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "async-channel"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
-dependencies = [
- "concurrent-queue",
- "event-listener",
- "futures-core",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,36 +815,6 @@ dependencies = [
  "futures-core",
  "memchr",
  "pin-project-lite 0.2.16",
- "tokio",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17adb73da160dfb475c183343c8cccd80721ea5a605d3eb57125f0a7b7a92d0b"
-dependencies = [
- "async-lock",
- "async-task",
- "concurrent-queue",
- "fastrand 1.9.0",
- "futures-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
-dependencies = [
- "async-channel",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
  "tokio",
 ]
 
@@ -898,39 +847,6 @@ dependencies = [
  "event-listener",
  "futures-lite",
 ]
-
-[[package]]
-name = "async-std"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
-dependencies = [
- "async-attributes",
- "async-channel",
- "async-global-executor",
- "async-io",
- "async-lock",
- "crossbeam-utils 0.8.21",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log 0.4.27",
- "memchr",
- "once_cell",
- "pin-project-lite 0.2.16",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
-name = "async-task"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
@@ -1368,20 +1284,6 @@ name = "block-padding"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
-
-[[package]]
-name = "blocking"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c67b173a56acffd6d2326fb7ab938ba0b00a71480e14902b2591c87bc5741e8"
-dependencies = [
- "async-channel",
- "async-lock",
- "async-task",
- "atomic-waker",
- "fastrand 1.9.0",
- "futures-lite",
-]
 
 [[package]]
 name = "blst"
@@ -3658,7 +3560,7 @@ dependencies = [
  "serde 1.0.205",
  "serde_bytes",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "thiserror",
 ]
 
@@ -4071,18 +3973,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gloo-timers"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "goldenfile"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4148,7 +4038,7 @@ dependencies = [
  "indexmap 2.7.1",
  "slab",
  "tokio",
- "tokio-util 0.7.7",
+ "tokio-util 0.7.16",
  "tracing",
 ]
 
@@ -5113,15 +5003,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log 0.4.27",
-]
-
-[[package]]
 name = "language-tags"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5532,7 +5413,7 @@ dependencies = [
  "thiserror",
  "tinytemplate",
  "tokio",
- "tokio-util 0.7.7",
+ "tokio-util 0.7.16",
  "webrtc",
 ]
 
@@ -5736,7 +5617,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 dependencies = [
  "serde 1.0.205",
- "value-bag",
 ]
 
 [[package]]
@@ -7745,9 +7625,9 @@ dependencies = [
  "schemars",
  "serde 1.0.205",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger 2.1.1",
- "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
- "starcoin-service-registry 1.13.19",
+ "starcoin-logger",
+ "starcoin-metrics",
+ "starcoin-service-registry",
  "starcoin-vm1-types",
 ]
 
@@ -7756,7 +7636,6 @@ name = "network-p2p"
 version = "2.1.1"
 dependencies = [
  "anyhow",
- "async-std",
  "async-trait",
  "asynchronous-codec 0.5.0",
  "bcs-ext",
@@ -7787,12 +7666,13 @@ dependencies = [
  "smallvec 1.10.0",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
+ "starcoin-metrics",
  "starcoin-vm1-types",
  "stest",
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-util 0.7.16",
  "unsigned-varint 0.6.0",
  "void",
  "wasm-timer",
@@ -9911,7 +9791,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.7.7",
+ "tokio-util 0.7.16",
  "tower-service",
  "url 2.3.1",
  "wasm-bindgen",
@@ -9943,7 +9823,7 @@ dependencies = [
  "starcoin-consensus",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-genesis",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-state-tree",
  "starcoin-statedb",
  "starcoin-storage",
@@ -11243,7 +11123,7 @@ dependencies = [
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-decrypt",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-storage",
  "starcoin-vm1-types",
  "tempfile",
@@ -11265,7 +11145,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-service-registry 1.13.19",
+ "starcoin-service-registry",
  "starcoin-vm1-types",
  "thiserror",
 ]
@@ -11299,8 +11179,8 @@ dependencies = [
  "starcoin-chain-notify",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger 2.1.1",
- "starcoin-service-registry 1.13.19",
+ "starcoin-logger",
+ "starcoin-service-registry",
  "starcoin-vm1-types",
  "stest",
  "tempfile",
@@ -11326,7 +11206,7 @@ dependencies = [
  "schemars",
  "serde 1.0.205",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
 ]
 
 [[package]]
@@ -11340,7 +11220,7 @@ dependencies = [
  "move-core-types 0.0.4 (git+https://github.com/starcoinorg/move?rev=7c0ec30b6dd783cc0377b5b2c85650130028d3b5)",
  "move-vm-types 0.1.0 (git+https://github.com/starcoinorg/move?rev=7c0ec30b6dd783cc0377b5b2c85650130028d3b5)",
  "once_cell",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-types",
  "starcoin-vm-types",
  "test-case",
@@ -11360,11 +11240,11 @@ dependencies = [
  "starcoin-chain-api",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger 2.1.1",
- "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
+ "starcoin-logger",
+ "starcoin-metrics",
  "starcoin-network",
  "starcoin-network-rpc-api",
- "starcoin-service-registry 1.13.19",
+ "starcoin-service-registry",
  "starcoin-sync",
  "starcoin-sync-api",
  "starcoin-time-service",
@@ -11418,9 +11298,9 @@ dependencies = [
  "starcoin-data-migration",
  "starcoin-executor",
  "starcoin-genesis",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-open-block",
- "starcoin-service-registry 1.13.19",
+ "starcoin-service-registry",
  "starcoin-state-api",
  "starcoin-statedb",
  "starcoin-storage",
@@ -11458,7 +11338,7 @@ dependencies = [
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-dag",
  "starcoin-network-rpc-api",
- "starcoin-service-registry 1.13.19",
+ "starcoin-service-registry",
  "starcoin-state-api",
  "starcoin-statedb",
  "starcoin-storage",
@@ -11493,7 +11373,7 @@ dependencies = [
  "starcoin-dag",
  "starcoin-executor",
  "starcoin-genesis",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-open-block",
  "starcoin-state-api",
  "starcoin-statedb",
@@ -11509,8 +11389,8 @@ version = "2.1.1"
 dependencies = [
  "anyhow",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger 2.1.1",
- "starcoin-service-registry 1.13.19",
+ "starcoin-logger",
+ "starcoin-service-registry",
  "starcoin-storage",
  "starcoin-vm-types",
  "starcoin-vm1-types",
@@ -11531,9 +11411,9 @@ dependencies = [
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-dag",
- "starcoin-logger 2.1.1",
- "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
- "starcoin-service-registry 1.13.19",
+ "starcoin-logger",
+ "starcoin-metrics",
+ "starcoin-service-registry",
  "starcoin-state-api",
  "starcoin-storage",
  "starcoin-types",
@@ -11586,7 +11466,7 @@ dependencies = [
  "starcoin-executor",
  "starcoin-framework 0.1.0",
  "starcoin-genesis",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-move-compiler",
  "starcoin-move-explain",
  "starcoin-network-rpc-api",
@@ -11595,7 +11475,7 @@ dependencies = [
  "starcoin-resource-viewer",
  "starcoin-rpc-api",
  "starcoin-rpc-client",
- "starcoin-service-registry 1.13.19",
+ "starcoin-service-registry",
  "starcoin-state-api",
  "starcoin-status-translator",
  "starcoin-storage",
@@ -11655,8 +11535,8 @@ dependencies = [
  "starcoin-gas-algebra-ext",
  "starcoin-gas-meter",
  "starcoin-gas-schedule",
- "starcoin-logger 2.1.1",
- "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
+ "starcoin-logger",
+ "starcoin-metrics",
  "starcoin-system",
  "starcoin-time-service",
  "starcoin-uint",
@@ -11690,7 +11570,7 @@ dependencies = [
  "starcoin-chain-api",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-dag",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-state-api",
  "starcoin-time-service",
  "starcoin-vm-types",
@@ -11786,8 +11666,8 @@ dependencies = [
  "starcoin-accumulator",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger 2.1.1",
- "starcoin-service-registry 1.13.19",
+ "starcoin-logger",
+ "starcoin-service-registry",
  "starcoin-state-api",
  "starcoin-statedb",
  "starcoin-storage",
@@ -11813,7 +11693,7 @@ dependencies = [
  "log 0.4.27",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-state-api",
  "starcoin-statedb",
  "starcoin-vm1-types",
@@ -11860,8 +11740,8 @@ dependencies = [
  "starcoin-abi-resolver",
  "starcoin-abi-types",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger 2.1.1",
- "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
+ "starcoin-logger",
+ "starcoin-metrics",
  "starcoin-resource-viewer",
  "starcoin-rpc-api",
  "starcoin-state-api",
@@ -11891,8 +11771,8 @@ dependencies = [
  "starcoin-consensus",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-dev",
- "starcoin-logger 2.1.1",
- "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
+ "starcoin-logger",
+ "starcoin-metrics",
  "starcoin-resource-viewer",
  "starcoin-state-api",
  "starcoin-state-tree",
@@ -11926,7 +11806,7 @@ dependencies = [
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-executor",
  "starcoin-genesis",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-state-api",
  "starcoin-statedb",
  "starcoin-storage",
@@ -11953,7 +11833,7 @@ dependencies = [
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-executor",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-rpc-client",
  "starcoin-state-api",
  "starcoin-transaction-builder",
@@ -12057,7 +11937,7 @@ dependencies = [
  "move-table-extension 0.1.0 (git+https://github.com/starcoinorg/move?rev=babf994a38cda17b84186c7992f92fb3554347f0)",
  "move-vm-types 0.1.0 (git+https://github.com/starcoinorg/move?rev=babf994a38cda17b84186c7992f92fb3554347f0)",
  "starcoin-gas-algebra-ext",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-natives",
 ]
 
@@ -12102,7 +11982,7 @@ dependencies = [
  "move-vm-types 0.1.0 (git+https://github.com/starcoinorg/move?rev=7c0ec30b6dd783cc0377b5b2c85650130028d3b5)",
  "starcoin-gas-algebra",
  "starcoin-gas-schedule",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
 ]
 
 [[package]]
@@ -12141,7 +12021,7 @@ dependencies = [
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-dag",
  "starcoin-genesis",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-storage",
  "starcoin-vm1-types",
 ]
@@ -12164,7 +12044,7 @@ dependencies = [
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-dag",
  "starcoin-executor",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-state-api",
  "starcoin-statedb",
  "starcoin-storage",
@@ -12225,26 +12105,6 @@ dependencies = [
 
 [[package]]
 name = "starcoin-logger"
-version = "1.13.19"
-source = "git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79#401ce6289a78b9f44e62e2b9f907030ad26d8d79"
-dependencies = [
- "anyhow",
- "arc-swap",
- "chrono",
- "lazy_static 1.4.0",
- "log 0.4.27",
- "log4rs",
- "once_cell",
- "parking_lot 0.12.1",
- "schemars",
- "serde 1.0.205",
- "slog",
- "slog-async",
- "slog-term",
-]
-
-[[package]]
-name = "starcoin-logger"
 version = "2.1.1"
 dependencies = [
  "anyhow",
@@ -12272,23 +12132,8 @@ dependencies = [
  "prometheus",
  "psutil",
  "serde_json",
- "starcoin-logger 2.1.1",
- "timeout-join-handler 2.0.1",
-]
-
-[[package]]
-name = "starcoin-metrics"
-version = "2.0.1"
-source = "git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79#401ce6289a78b9f44e62e2b9f907030ad26d8d79"
-dependencies = [
- "anyhow",
- "futures 0.3.31",
- "hyper 0.14.24",
- "prometheus",
- "psutil",
- "serde_json",
- "starcoin-logger 1.13.19",
- "timeout-join-handler 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
+ "starcoin-logger",
+ "timeout-join-handler",
 ]
 
 [[package]]
@@ -12318,13 +12163,13 @@ dependencies = [
  "starcoin-dag",
  "starcoin-executor",
  "starcoin-genesis",
- "starcoin-logger 2.1.1",
- "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
+ "starcoin-logger",
+ "starcoin-metrics",
  "starcoin-network-rpc",
  "starcoin-network-rpc-api",
  "starcoin-node",
  "starcoin-open-block",
- "starcoin-service-registry 1.13.19",
+ "starcoin-service-registry",
  "starcoin-state-api",
  "starcoin-state-service",
  "starcoin-statedb",
@@ -12353,7 +12198,6 @@ dependencies = [
  "actix",
  "actix-rt",
  "anyhow",
- "async-std",
  "async-trait",
  "byteorder",
  "clap 4.5.47",
@@ -12375,12 +12219,12 @@ dependencies = [
  "starcoin-config",
  "starcoin-consensus",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-miner",
  "starcoin-miner-client-api",
  "starcoin-rpc-api",
  "starcoin-rpc-client",
- "starcoin-service-registry 1.13.19",
+ "starcoin-service-registry",
  "starcoin-stratum",
  "starcoin-time-service",
  "starcoin-vm-types",
@@ -12413,7 +12257,7 @@ dependencies = [
  "petgraph 0.5.1",
  "regex",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-vm1-vm-types",
  "stest",
  "tempfile",
@@ -12474,7 +12318,7 @@ dependencies = [
  "sha3",
  "smallvec 1.10.0",
  "starcoin-gas-schedule",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-native-interface",
  "tempfile",
 ]
@@ -12541,7 +12385,6 @@ name = "starcoin-network"
 version = "2.1.1"
 dependencies = [
  "anyhow",
- "async-std",
  "async-trait",
  "bcs-ext",
  "bitflags 1.3.2",
@@ -12565,11 +12408,11 @@ dependencies = [
  "serde_json",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger 2.1.1",
- "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
+ "starcoin-logger",
+ "starcoin-metrics",
  "starcoin-network-rpc",
  "starcoin-network-rpc-api",
- "starcoin-service-registry 1.13.19",
+ "starcoin-service-registry",
  "starcoin-storage",
  "starcoin-txpool-api",
  "starcoin-vm1-types",
@@ -12595,10 +12438,10 @@ dependencies = [
  "starcoin-chain-service",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-network-rpc-api",
  "starcoin-node",
- "starcoin-service-registry 1.13.19",
+ "starcoin-service-registry",
  "starcoin-storage",
  "starcoin-txpool",
  "starcoin-txpool-api",
@@ -12606,6 +12449,7 @@ dependencies = [
  "starcoin-vm1-vm-types",
  "stest",
  "test-helper",
+ "tokio",
 ]
 
 [[package]]
@@ -12623,7 +12467,7 @@ dependencies = [
  "serde 1.0.205",
  "starcoin-accumulator",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-state-api",
  "starcoin-state-tree",
  "starcoin-vm1-types",
@@ -12637,7 +12481,6 @@ dependencies = [
  "actix",
  "actix-rt",
  "anyhow",
- "async-std",
  "async-trait",
  "backtrace",
  "chrono",
@@ -12659,8 +12502,8 @@ dependencies = [
  "starcoin-dev",
  "starcoin-executor",
  "starcoin-genesis",
- "starcoin-logger 2.1.1",
- "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
+ "starcoin-logger",
+ "starcoin-metrics",
  "starcoin-miner",
  "starcoin-miner-client",
  "starcoin-network",
@@ -12669,7 +12512,7 @@ dependencies = [
  "starcoin-node-api",
  "starcoin-rpc-client",
  "starcoin-rpc-server",
- "starcoin-service-registry 1.13.19",
+ "starcoin-service-registry",
  "starcoin-state-api",
  "starcoin-state-service",
  "starcoin-statedb",
@@ -12687,7 +12530,7 @@ dependencies = [
  "starcoin-vm2-state-service",
  "stest",
  "thiserror",
- "timeout-join-handler 2.0.1",
+ "timeout-join-handler",
  "tokio",
 ]
 
@@ -12704,8 +12547,8 @@ dependencies = [
  "starcoin-consensus",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-genesis",
- "starcoin-logger 2.1.1",
- "starcoin-service-registry 1.13.19",
+ "starcoin-logger",
+ "starcoin-service-registry",
  "starcoin-storage",
  "starcoin-vm1-types",
  "stest",
@@ -12728,7 +12571,7 @@ dependencies = [
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-executor",
  "starcoin-genesis",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-state-api",
  "starcoin-statedb",
  "starcoin-storage",
@@ -12771,7 +12614,7 @@ dependencies = [
  "proptest-derive 0.6.0",
  "rayon",
  "starcoin-infallible",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-mvhashmap",
 ]
 
@@ -12830,9 +12673,9 @@ dependencies = [
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-dag",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-resource-viewer",
- "starcoin-service-registry 1.13.19",
+ "starcoin-service-registry",
  "starcoin-state-api",
  "starcoin-sync-api",
  "starcoin-txpool-api",
@@ -12853,7 +12696,6 @@ dependencies = [
  "actix",
  "actix-rt",
  "anyhow",
- "async-std",
  "bcs-ext",
  "futures 0.3.31",
  "futures-timer",
@@ -12878,10 +12720,10 @@ dependencies = [
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=5417dce574142c3da24adf987194a6931869f588)",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-dag",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-rpc-api",
  "starcoin-rpc-server",
- "starcoin-service-registry 1.13.19",
+ "starcoin-service-registry",
  "starcoin-state-api",
  "starcoin-state-tree",
  "starcoin-sync-api",
@@ -12911,8 +12753,8 @@ dependencies = [
  "rand 0.8.5",
  "serde_json",
  "starcoin-config",
- "starcoin-logger 2.1.1",
- "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
+ "starcoin-logger",
+ "starcoin-metrics",
  "starcoin-rpc-api",
  "stest",
  "thiserror",
@@ -12966,8 +12808,8 @@ dependencies = [
  "starcoin-dev",
  "starcoin-executor",
  "starcoin-genesis",
- "starcoin-logger 2.1.1",
- "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
+ "starcoin-logger",
+ "starcoin-metrics",
  "starcoin-miner",
  "starcoin-network",
  "starcoin-node-api",
@@ -12975,7 +12817,7 @@ dependencies = [
  "starcoin-rpc-api",
  "starcoin-rpc-client",
  "starcoin-rpc-middleware",
- "starcoin-service-registry 1.13.19",
+ "starcoin-service-registry",
  "starcoin-state-api",
  "starcoin-state-service",
  "starcoin-state-tree",
@@ -13026,31 +12868,11 @@ dependencies = [
 
 [[package]]
 name = "starcoin-service-registry"
-version = "1.13.19"
-source = "git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79#401ce6289a78b9f44e62e2b9f907030ad26d8d79"
-dependencies = [
- "actix",
- "actix-rt",
- "anyhow",
- "async-trait",
- "futures 0.3.31",
- "futures-timer",
- "log 0.4.27",
- "once_cell",
- "schemars",
- "serde 1.0.205",
- "thiserror",
- "tokio",
-]
-
-[[package]]
-name = "starcoin-service-registry"
 version = "2.1.1"
 dependencies = [
  "actix",
  "actix-rt",
  "anyhow",
- "async-std",
  "async-trait",
  "futures 0.3.31",
  "futures-timer",
@@ -13074,7 +12896,7 @@ dependencies = [
  "once_cell",
  "serde 1.0.205",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-service-registry 1.13.19",
+ "starcoin-service-registry",
  "starcoin-state-store-api",
  "starcoin-state-tree",
  "starcoin-vm1-types",
@@ -13090,8 +12912,8 @@ dependencies = [
  "futures 0.3.31",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger 2.1.1",
- "starcoin-service-registry 1.13.19",
+ "starcoin-logger",
+ "starcoin-service-registry",
  "starcoin-state-api",
  "starcoin-state-tree",
  "starcoin-statedb",
@@ -13124,7 +12946,7 @@ dependencies = [
  "serde 1.0.205",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-state-store-api",
  "starcoin-storage",
  "starcoin-vm1-types",
@@ -13143,7 +12965,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "serde 1.0.205",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-state-api",
  "starcoin-state-tree",
  "starcoin-vm1-types",
@@ -13186,8 +13008,8 @@ dependencies = [
  "starcoin-accumulator",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger 2.1.1",
- "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
+ "starcoin-logger",
+ "starcoin-metrics",
  "starcoin-state-store-api",
  "starcoin-uint",
  "starcoin-vm1-types",
@@ -13213,9 +13035,9 @@ dependencies = [
  "serde_json",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-miner",
- "starcoin-service-registry 1.13.19",
+ "starcoin-service-registry",
  "starcoin-vm1-types",
  "stest",
 ]
@@ -13225,7 +13047,6 @@ name = "starcoin-sync"
 version = "2.1.1"
 dependencies = [
  "anyhow",
- "async-std",
  "async-trait",
  "bcs-ext",
  "byteorder",
@@ -13259,14 +13080,14 @@ dependencies = [
  "starcoin-dag",
  "starcoin-executor",
  "starcoin-genesis",
- "starcoin-logger 2.1.1",
- "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
+ "starcoin-logger",
+ "starcoin-metrics",
  "starcoin-miner",
  "starcoin-network",
  "starcoin-network-rpc",
  "starcoin-network-rpc-api",
  "starcoin-node",
- "starcoin-service-registry 1.13.19",
+ "starcoin-service-registry",
  "starcoin-state-api",
  "starcoin-state-service",
  "starcoin-state-tree",
@@ -13288,7 +13109,7 @@ dependencies = [
  "sysinfo",
  "test-helper",
  "thiserror",
- "timeout-join-handler 2.0.1",
+ "timeout-join-handler",
  "tokio",
 ]
 
@@ -13303,8 +13124,8 @@ dependencies = [
  "serde 1.0.205",
  "starcoin-accumulator",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger 2.1.1",
- "starcoin-service-registry 1.13.19",
+ "starcoin-logger",
+ "starcoin-service-registry",
  "starcoin-vm1-types",
  "stream-task",
 ]
@@ -13345,7 +13166,7 @@ dependencies = [
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-framework 0.1.0",
  "starcoin-genesis",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-transaction-builder",
  "starcoin-types",
  "starcoin-vm-types",
@@ -13416,7 +13237,7 @@ dependencies = [
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=5417dce574142c3da24adf987194a6931869f588)",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-executor",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-rpc-api",
  "starcoin-rpc-client",
  "starcoin-state-api",
@@ -13455,10 +13276,10 @@ dependencies = [
  "starcoin-dag",
  "starcoin-executor",
  "starcoin-genesis",
- "starcoin-logger 2.1.1",
- "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
+ "starcoin-logger",
+ "starcoin-metrics",
  "starcoin-open-block",
- "starcoin-service-registry 1.13.19",
+ "starcoin-service-registry",
  "starcoin-state-api",
  "starcoin-state-tree",
  "starcoin-statedb",
@@ -13591,8 +13412,8 @@ dependencies = [
  "starcoin-gas-algebra",
  "starcoin-gas-meter",
  "starcoin-gas-schedule",
- "starcoin-logger 2.1.1",
- "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
+ "starcoin-logger",
+ "starcoin-metrics",
  "starcoin-move-stdlib",
  "starcoin-native-interface",
  "starcoin-parallel-executor",
@@ -13723,8 +13544,8 @@ dependencies = [
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-gas",
  "starcoin-gas-algebra-ext",
- "starcoin-logger 2.1.1",
- "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
+ "starcoin-logger",
+ "starcoin-metrics",
  "starcoin-natives",
  "starcoin-parallel-executor",
  "starcoin-vm-types",
@@ -13833,7 +13654,7 @@ dependencies = [
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=5417dce574142c3da24adf987194a6931869f588)",
  "starcoin-decrypt",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-storage",
  "starcoin-types",
  "starcoin-vm2-account-api",
@@ -13856,7 +13677,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=5417dce574142c3da24adf987194a6931869f588)",
- "starcoin-service-registry 1.13.19",
+ "starcoin-service-registry",
  "starcoin-types",
  "thiserror",
 ]
@@ -13881,8 +13702,8 @@ dependencies = [
  "starcoin-chain-notify",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=5417dce574142c3da24adf987194a6931869f588)",
- "starcoin-logger 2.1.1",
- "starcoin-service-registry 1.13.19",
+ "starcoin-logger",
+ "starcoin-service-registry",
  "starcoin-storage",
  "starcoin-types",
  "starcoin-vm-types",
@@ -13910,7 +13731,7 @@ version = "2.0.1"
 dependencies = [
  "anyhow",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=5417dce574142c3da24adf987194a6931869f588)",
- "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
+ "starcoin-metrics",
  "starcoin-state-api",
  "starcoin-status-translator",
  "starcoin-types",
@@ -13934,7 +13755,7 @@ dependencies = [
  "serde 1.0.205",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=5417dce574142c3da24adf987194a6931869f588)",
- "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
+ "starcoin-metrics",
  "starcoin-test-helper",
  "starcoin-transaction-builder",
  "starcoin-types",
@@ -13958,7 +13779,7 @@ dependencies = [
  "regex",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=5417dce574142c3da24adf987194a6931869f588)",
  "starcoin-framework 0.1.0",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-vm-types",
  "tempfile",
  "walkdir",
@@ -14022,7 +13843,7 @@ dependencies = [
  "serde_json",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=5417dce574142c3da24adf987194a6931869f588)",
- "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
+ "starcoin-metrics",
  "starcoin-status-translator",
  "starcoin-storage",
  "starcoin-txpool-api",
@@ -14051,7 +13872,7 @@ dependencies = [
  "once_cell",
  "serde 1.0.205",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-service-registry 1.13.19",
+ "starcoin-service-registry",
  "starcoin-state-tree",
  "starcoin-types",
  "starcoin-vm-types",
@@ -14066,8 +13887,8 @@ dependencies = [
  "futures 0.3.31",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=5417dce574142c3da24adf987194a6931869f588)",
- "starcoin-logger 2.1.1",
- "starcoin-service-registry 1.13.19",
+ "starcoin-logger",
+ "starcoin-service-registry",
  "starcoin-storage",
  "starcoin-types",
  "starcoin-vm-types",
@@ -14090,7 +13911,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "serde 1.0.205",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=5417dce574142c3da24adf987194a6931869f588)",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-state-tree",
  "starcoin-types",
  "starcoin-vm-types",
@@ -14205,9 +14026,9 @@ dependencies = [
  "anyhow",
  "futures 0.3.31",
  "log 0.4.27",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "stest-macro",
- "timeout-join-handler 2.0.1",
+ "timeout-join-handler",
  "tokio",
 ]
 
@@ -14240,7 +14061,6 @@ name = "stream-task"
 version = "2.1.1"
 dependencies = [
  "anyhow",
- "async-std",
  "futures 0.3.31",
  "futures-retry",
  "futures-timer",
@@ -14250,7 +14070,7 @@ dependencies = [
  "pin-utils",
  "schemars",
  "serde 1.0.205",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "stest",
  "thiserror",
  "tokio",
@@ -14712,8 +14532,8 @@ dependencies = [
  "starcoin-dev",
  "starcoin-executor",
  "starcoin-genesis",
- "starcoin-logger 2.1.1",
- "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
+ "starcoin-logger",
+ "starcoin-metrics",
  "starcoin-miner",
  "starcoin-move-compiler",
  "starcoin-network",
@@ -14722,7 +14542,7 @@ dependencies = [
  "starcoin-node",
  "starcoin-node-api",
  "starcoin-rpc-server",
- "starcoin-service-registry 1.13.19",
+ "starcoin-service-registry",
  "starcoin-state-api",
  "starcoin-state-service",
  "starcoin-statedb",
@@ -14763,7 +14583,7 @@ dependencies = [
  "starcoin-consensus",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-executor",
- "starcoin-logger 2.1.1",
+ "starcoin-logger",
  "starcoin-miner",
  "starcoin-network",
  "starcoin-node",
@@ -14914,14 +14734,6 @@ name = "timeout-join-handler"
 version = "2.0.1"
 dependencies = [
  "anyhow",
- "thiserror",
-]
-
-[[package]]
-name = "timeout-join-handler"
-version = "2.0.1"
-source = "git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79#401ce6289a78b9f44e62e2b9f907030ad26d8d79"
-dependencies = [
  "thiserror",
 ]
 
@@ -15155,9 +14967,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.7"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes 1.6.1",
  "futures-core",
@@ -15165,7 +14977,6 @@ dependencies = [
  "futures-sink",
  "pin-project-lite 0.2.16",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -15742,12 +15553,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "value-bag"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
 
 [[package]]
 name = "variant_count"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
  "pin-project-lite 0.2.16",
  "smallvec 1.10.0",
  "tokio",
- "tokio-util 0.7.16",
+ "tokio-util 0.7.7",
 ]
 
 [[package]]
@@ -291,7 +291,7 @@ dependencies = [
  "serde 1.0.205",
  "serde_json",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-rpc-api",
  "starcoin-vm1-types",
  "starcoin-vm1-vm-types",
@@ -806,6 +806,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e22d1f4b888c298a027c99dc9048015fac177587de20fc30232a057dfbe24a21"
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote 1.0.36",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -815,6 +836,36 @@ dependencies = [
  "futures-core",
  "memchr",
  "pin-project-lite 0.2.16",
+ "tokio",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17adb73da160dfb475c183343c8cccd80721ea5a605d3eb57125f0a7b7a92d0b"
+dependencies = [
+ "async-lock",
+ "async-task",
+ "concurrent-queue",
+ "fastrand 1.9.0",
+ "futures-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
  "tokio",
 ]
 
@@ -847,6 +898,39 @@ dependencies = [
  "event-listener",
  "futures-lite",
 ]
+
+[[package]]
+name = "async-std"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+dependencies = [
+ "async-attributes",
+ "async-channel",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils 0.8.21",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log 0.4.27",
+ "memchr",
+ "once_cell",
+ "pin-project-lite 0.2.16",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
@@ -1284,6 +1368,20 @@ name = "block-padding"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
+
+[[package]]
+name = "blocking"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c67b173a56acffd6d2326fb7ab938ba0b00a71480e14902b2591c87bc5741e8"
+dependencies = [
+ "async-channel",
+ "async-lock",
+ "async-task",
+ "atomic-waker",
+ "fastrand 1.9.0",
+ "futures-lite",
+]
 
 [[package]]
 name = "blst"
@@ -3560,7 +3658,7 @@ dependencies = [
  "serde 1.0.205",
  "serde_bytes",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "thiserror",
 ]
 
@@ -3973,6 +4071,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "goldenfile"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4038,7 +4148,7 @@ dependencies = [
  "indexmap 2.7.1",
  "slab",
  "tokio",
- "tokio-util 0.7.16",
+ "tokio-util 0.7.7",
  "tracing",
 ]
 
@@ -5003,6 +5113,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log 0.4.27",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5413,7 +5532,7 @@ dependencies = [
  "thiserror",
  "tinytemplate",
  "tokio",
- "tokio-util 0.7.16",
+ "tokio-util 0.7.7",
  "webrtc",
 ]
 
@@ -5617,6 +5736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 dependencies = [
  "serde 1.0.205",
+ "value-bag",
 ]
 
 [[package]]
@@ -7625,9 +7745,9 @@ dependencies = [
  "schemars",
  "serde 1.0.205",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger",
- "starcoin-metrics",
- "starcoin-service-registry",
+ "starcoin-logger 2.1.1",
+ "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
+ "starcoin-service-registry 1.13.19",
  "starcoin-vm1-types",
 ]
 
@@ -7636,6 +7756,7 @@ name = "network-p2p"
 version = "2.1.1"
 dependencies = [
  "anyhow",
+ "async-std",
  "async-trait",
  "asynchronous-codec 0.5.0",
  "bcs-ext",
@@ -7666,13 +7787,12 @@ dependencies = [
  "smallvec 1.10.0",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-metrics",
+ "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
  "starcoin-vm1-types",
  "stest",
  "tempfile",
  "thiserror",
  "tokio",
- "tokio-util 0.7.16",
  "unsigned-varint 0.6.0",
  "void",
  "wasm-timer",
@@ -9791,7 +9911,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.7.16",
+ "tokio-util 0.7.7",
  "tower-service",
  "url 2.3.1",
  "wasm-bindgen",
@@ -9823,7 +9943,7 @@ dependencies = [
  "starcoin-consensus",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-genesis",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-state-tree",
  "starcoin-statedb",
  "starcoin-storage",
@@ -11123,7 +11243,7 @@ dependencies = [
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-decrypt",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-storage",
  "starcoin-vm1-types",
  "tempfile",
@@ -11145,7 +11265,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-service-registry",
+ "starcoin-service-registry 1.13.19",
  "starcoin-vm1-types",
  "thiserror",
 ]
@@ -11179,8 +11299,8 @@ dependencies = [
  "starcoin-chain-notify",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger",
- "starcoin-service-registry",
+ "starcoin-logger 2.1.1",
+ "starcoin-service-registry 1.13.19",
  "starcoin-vm1-types",
  "stest",
  "tempfile",
@@ -11206,7 +11326,7 @@ dependencies = [
  "schemars",
  "serde 1.0.205",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
 ]
 
 [[package]]
@@ -11220,7 +11340,7 @@ dependencies = [
  "move-core-types 0.0.4 (git+https://github.com/starcoinorg/move?rev=7c0ec30b6dd783cc0377b5b2c85650130028d3b5)",
  "move-vm-types 0.1.0 (git+https://github.com/starcoinorg/move?rev=7c0ec30b6dd783cc0377b5b2c85650130028d3b5)",
  "once_cell",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-types",
  "starcoin-vm-types",
  "test-case",
@@ -11240,11 +11360,11 @@ dependencies = [
  "starcoin-chain-api",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger",
- "starcoin-metrics",
+ "starcoin-logger 2.1.1",
+ "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
  "starcoin-network",
  "starcoin-network-rpc-api",
- "starcoin-service-registry",
+ "starcoin-service-registry 1.13.19",
  "starcoin-sync",
  "starcoin-sync-api",
  "starcoin-time-service",
@@ -11298,9 +11418,9 @@ dependencies = [
  "starcoin-data-migration",
  "starcoin-executor",
  "starcoin-genesis",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-open-block",
- "starcoin-service-registry",
+ "starcoin-service-registry 1.13.19",
  "starcoin-state-api",
  "starcoin-statedb",
  "starcoin-storage",
@@ -11338,7 +11458,7 @@ dependencies = [
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-dag",
  "starcoin-network-rpc-api",
- "starcoin-service-registry",
+ "starcoin-service-registry 1.13.19",
  "starcoin-state-api",
  "starcoin-statedb",
  "starcoin-storage",
@@ -11373,7 +11493,7 @@ dependencies = [
  "starcoin-dag",
  "starcoin-executor",
  "starcoin-genesis",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-open-block",
  "starcoin-state-api",
  "starcoin-statedb",
@@ -11389,8 +11509,8 @@ version = "2.1.1"
 dependencies = [
  "anyhow",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger",
- "starcoin-service-registry",
+ "starcoin-logger 2.1.1",
+ "starcoin-service-registry 1.13.19",
  "starcoin-storage",
  "starcoin-vm-types",
  "starcoin-vm1-types",
@@ -11411,9 +11531,9 @@ dependencies = [
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-dag",
- "starcoin-logger",
- "starcoin-metrics",
- "starcoin-service-registry",
+ "starcoin-logger 2.1.1",
+ "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
+ "starcoin-service-registry 1.13.19",
  "starcoin-state-api",
  "starcoin-storage",
  "starcoin-types",
@@ -11466,7 +11586,7 @@ dependencies = [
  "starcoin-executor",
  "starcoin-framework 0.1.0",
  "starcoin-genesis",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-move-compiler",
  "starcoin-move-explain",
  "starcoin-network-rpc-api",
@@ -11475,7 +11595,7 @@ dependencies = [
  "starcoin-resource-viewer",
  "starcoin-rpc-api",
  "starcoin-rpc-client",
- "starcoin-service-registry",
+ "starcoin-service-registry 1.13.19",
  "starcoin-state-api",
  "starcoin-status-translator",
  "starcoin-storage",
@@ -11535,8 +11655,8 @@ dependencies = [
  "starcoin-gas-algebra-ext",
  "starcoin-gas-meter",
  "starcoin-gas-schedule",
- "starcoin-logger",
- "starcoin-metrics",
+ "starcoin-logger 2.1.1",
+ "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
  "starcoin-system",
  "starcoin-time-service",
  "starcoin-uint",
@@ -11570,7 +11690,7 @@ dependencies = [
  "starcoin-chain-api",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-dag",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-state-api",
  "starcoin-time-service",
  "starcoin-vm-types",
@@ -11666,8 +11786,8 @@ dependencies = [
  "starcoin-accumulator",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger",
- "starcoin-service-registry",
+ "starcoin-logger 2.1.1",
+ "starcoin-service-registry 1.13.19",
  "starcoin-state-api",
  "starcoin-statedb",
  "starcoin-storage",
@@ -11693,7 +11813,7 @@ dependencies = [
  "log 0.4.27",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-state-api",
  "starcoin-statedb",
  "starcoin-vm1-types",
@@ -11740,8 +11860,8 @@ dependencies = [
  "starcoin-abi-resolver",
  "starcoin-abi-types",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger",
- "starcoin-metrics",
+ "starcoin-logger 2.1.1",
+ "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
  "starcoin-resource-viewer",
  "starcoin-rpc-api",
  "starcoin-state-api",
@@ -11771,8 +11891,8 @@ dependencies = [
  "starcoin-consensus",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-dev",
- "starcoin-logger",
- "starcoin-metrics",
+ "starcoin-logger 2.1.1",
+ "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
  "starcoin-resource-viewer",
  "starcoin-state-api",
  "starcoin-state-tree",
@@ -11806,7 +11926,7 @@ dependencies = [
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-executor",
  "starcoin-genesis",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-state-api",
  "starcoin-statedb",
  "starcoin-storage",
@@ -11833,7 +11953,7 @@ dependencies = [
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-executor",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-rpc-client",
  "starcoin-state-api",
  "starcoin-transaction-builder",
@@ -11937,7 +12057,7 @@ dependencies = [
  "move-table-extension 0.1.0 (git+https://github.com/starcoinorg/move?rev=babf994a38cda17b84186c7992f92fb3554347f0)",
  "move-vm-types 0.1.0 (git+https://github.com/starcoinorg/move?rev=babf994a38cda17b84186c7992f92fb3554347f0)",
  "starcoin-gas-algebra-ext",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-natives",
 ]
 
@@ -11982,7 +12102,7 @@ dependencies = [
  "move-vm-types 0.1.0 (git+https://github.com/starcoinorg/move?rev=7c0ec30b6dd783cc0377b5b2c85650130028d3b5)",
  "starcoin-gas-algebra",
  "starcoin-gas-schedule",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
 ]
 
 [[package]]
@@ -12021,7 +12141,7 @@ dependencies = [
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-dag",
  "starcoin-genesis",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-storage",
  "starcoin-vm1-types",
 ]
@@ -12044,7 +12164,7 @@ dependencies = [
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-dag",
  "starcoin-executor",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-state-api",
  "starcoin-statedb",
  "starcoin-storage",
@@ -12105,6 +12225,26 @@ dependencies = [
 
 [[package]]
 name = "starcoin-logger"
+version = "1.13.19"
+source = "git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79#401ce6289a78b9f44e62e2b9f907030ad26d8d79"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "chrono",
+ "lazy_static 1.4.0",
+ "log 0.4.27",
+ "log4rs",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "schemars",
+ "serde 1.0.205",
+ "slog",
+ "slog-async",
+ "slog-term",
+]
+
+[[package]]
+name = "starcoin-logger"
 version = "2.1.1"
 dependencies = [
  "anyhow",
@@ -12132,8 +12272,23 @@ dependencies = [
  "prometheus",
  "psutil",
  "serde_json",
- "starcoin-logger",
- "timeout-join-handler",
+ "starcoin-logger 2.1.1",
+ "timeout-join-handler 2.0.1",
+]
+
+[[package]]
+name = "starcoin-metrics"
+version = "2.0.1"
+source = "git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79#401ce6289a78b9f44e62e2b9f907030ad26d8d79"
+dependencies = [
+ "anyhow",
+ "futures 0.3.31",
+ "hyper 0.14.24",
+ "prometheus",
+ "psutil",
+ "serde_json",
+ "starcoin-logger 1.13.19",
+ "timeout-join-handler 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
 ]
 
 [[package]]
@@ -12163,13 +12318,13 @@ dependencies = [
  "starcoin-dag",
  "starcoin-executor",
  "starcoin-genesis",
- "starcoin-logger",
- "starcoin-metrics",
+ "starcoin-logger 2.1.1",
+ "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
  "starcoin-network-rpc",
  "starcoin-network-rpc-api",
  "starcoin-node",
  "starcoin-open-block",
- "starcoin-service-registry",
+ "starcoin-service-registry 1.13.19",
  "starcoin-state-api",
  "starcoin-state-service",
  "starcoin-statedb",
@@ -12198,6 +12353,7 @@ dependencies = [
  "actix",
  "actix-rt",
  "anyhow",
+ "async-std",
  "async-trait",
  "byteorder",
  "clap 4.5.47",
@@ -12219,12 +12375,12 @@ dependencies = [
  "starcoin-config",
  "starcoin-consensus",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-miner",
  "starcoin-miner-client-api",
  "starcoin-rpc-api",
  "starcoin-rpc-client",
- "starcoin-service-registry",
+ "starcoin-service-registry 1.13.19",
  "starcoin-stratum",
  "starcoin-time-service",
  "starcoin-vm-types",
@@ -12257,7 +12413,7 @@ dependencies = [
  "petgraph 0.5.1",
  "regex",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-vm1-vm-types",
  "stest",
  "tempfile",
@@ -12318,7 +12474,7 @@ dependencies = [
  "sha3",
  "smallvec 1.10.0",
  "starcoin-gas-schedule",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-native-interface",
  "tempfile",
 ]
@@ -12385,6 +12541,7 @@ name = "starcoin-network"
 version = "2.1.1"
 dependencies = [
  "anyhow",
+ "async-std",
  "async-trait",
  "bcs-ext",
  "bitflags 1.3.2",
@@ -12408,11 +12565,11 @@ dependencies = [
  "serde_json",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger",
- "starcoin-metrics",
+ "starcoin-logger 2.1.1",
+ "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
  "starcoin-network-rpc",
  "starcoin-network-rpc-api",
- "starcoin-service-registry",
+ "starcoin-service-registry 1.13.19",
  "starcoin-storage",
  "starcoin-txpool-api",
  "starcoin-vm1-types",
@@ -12438,10 +12595,10 @@ dependencies = [
  "starcoin-chain-service",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-network-rpc-api",
  "starcoin-node",
- "starcoin-service-registry",
+ "starcoin-service-registry 1.13.19",
  "starcoin-storage",
  "starcoin-txpool",
  "starcoin-txpool-api",
@@ -12449,7 +12606,6 @@ dependencies = [
  "starcoin-vm1-vm-types",
  "stest",
  "test-helper",
- "tokio",
 ]
 
 [[package]]
@@ -12467,7 +12623,7 @@ dependencies = [
  "serde 1.0.205",
  "starcoin-accumulator",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-state-api",
  "starcoin-state-tree",
  "starcoin-vm1-types",
@@ -12481,6 +12637,7 @@ dependencies = [
  "actix",
  "actix-rt",
  "anyhow",
+ "async-std",
  "async-trait",
  "backtrace",
  "chrono",
@@ -12502,8 +12659,8 @@ dependencies = [
  "starcoin-dev",
  "starcoin-executor",
  "starcoin-genesis",
- "starcoin-logger",
- "starcoin-metrics",
+ "starcoin-logger 2.1.1",
+ "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
  "starcoin-miner",
  "starcoin-miner-client",
  "starcoin-network",
@@ -12512,7 +12669,7 @@ dependencies = [
  "starcoin-node-api",
  "starcoin-rpc-client",
  "starcoin-rpc-server",
- "starcoin-service-registry",
+ "starcoin-service-registry 1.13.19",
  "starcoin-state-api",
  "starcoin-state-service",
  "starcoin-statedb",
@@ -12530,7 +12687,7 @@ dependencies = [
  "starcoin-vm2-state-service",
  "stest",
  "thiserror",
- "timeout-join-handler",
+ "timeout-join-handler 2.0.1",
  "tokio",
 ]
 
@@ -12547,8 +12704,8 @@ dependencies = [
  "starcoin-consensus",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-genesis",
- "starcoin-logger",
- "starcoin-service-registry",
+ "starcoin-logger 2.1.1",
+ "starcoin-service-registry 1.13.19",
  "starcoin-storage",
  "starcoin-vm1-types",
  "stest",
@@ -12571,7 +12728,7 @@ dependencies = [
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-executor",
  "starcoin-genesis",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-state-api",
  "starcoin-statedb",
  "starcoin-storage",
@@ -12614,7 +12771,7 @@ dependencies = [
  "proptest-derive 0.6.0",
  "rayon",
  "starcoin-infallible",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-mvhashmap",
 ]
 
@@ -12672,9 +12829,10 @@ dependencies = [
  "starcoin-chain-api",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger",
+ "starcoin-dag",
+ "starcoin-logger 2.1.1",
  "starcoin-resource-viewer",
- "starcoin-service-registry",
+ "starcoin-service-registry 1.13.19",
  "starcoin-state-api",
  "starcoin-sync-api",
  "starcoin-txpool-api",
@@ -12695,6 +12853,7 @@ dependencies = [
  "actix",
  "actix-rt",
  "anyhow",
+ "async-std",
  "bcs-ext",
  "futures 0.3.31",
  "futures-timer",
@@ -12718,10 +12877,11 @@ dependencies = [
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=5417dce574142c3da24adf987194a6931869f588)",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger",
+ "starcoin-dag",
+ "starcoin-logger 2.1.1",
  "starcoin-rpc-api",
  "starcoin-rpc-server",
- "starcoin-service-registry",
+ "starcoin-service-registry 1.13.19",
  "starcoin-state-api",
  "starcoin-state-tree",
  "starcoin-sync-api",
@@ -12751,8 +12911,8 @@ dependencies = [
  "rand 0.8.5",
  "serde_json",
  "starcoin-config",
- "starcoin-logger",
- "starcoin-metrics",
+ "starcoin-logger 2.1.1",
+ "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
  "starcoin-rpc-api",
  "stest",
  "thiserror",
@@ -12806,8 +12966,8 @@ dependencies = [
  "starcoin-dev",
  "starcoin-executor",
  "starcoin-genesis",
- "starcoin-logger",
- "starcoin-metrics",
+ "starcoin-logger 2.1.1",
+ "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
  "starcoin-miner",
  "starcoin-network",
  "starcoin-node-api",
@@ -12815,7 +12975,7 @@ dependencies = [
  "starcoin-rpc-api",
  "starcoin-rpc-client",
  "starcoin-rpc-middleware",
- "starcoin-service-registry",
+ "starcoin-service-registry 1.13.19",
  "starcoin-state-api",
  "starcoin-state-service",
  "starcoin-state-tree",
@@ -12866,11 +13026,31 @@ dependencies = [
 
 [[package]]
 name = "starcoin-service-registry"
+version = "1.13.19"
+source = "git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79#401ce6289a78b9f44e62e2b9f907030ad26d8d79"
+dependencies = [
+ "actix",
+ "actix-rt",
+ "anyhow",
+ "async-trait",
+ "futures 0.3.31",
+ "futures-timer",
+ "log 0.4.27",
+ "once_cell",
+ "schemars",
+ "serde 1.0.205",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "starcoin-service-registry"
 version = "2.1.1"
 dependencies = [
  "actix",
  "actix-rt",
  "anyhow",
+ "async-std",
  "async-trait",
  "futures 0.3.31",
  "futures-timer",
@@ -12894,7 +13074,7 @@ dependencies = [
  "once_cell",
  "serde 1.0.205",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-service-registry",
+ "starcoin-service-registry 1.13.19",
  "starcoin-state-store-api",
  "starcoin-state-tree",
  "starcoin-vm1-types",
@@ -12910,8 +13090,8 @@ dependencies = [
  "futures 0.3.31",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger",
- "starcoin-service-registry",
+ "starcoin-logger 2.1.1",
+ "starcoin-service-registry 1.13.19",
  "starcoin-state-api",
  "starcoin-state-tree",
  "starcoin-statedb",
@@ -12944,7 +13124,7 @@ dependencies = [
  "serde 1.0.205",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-state-store-api",
  "starcoin-storage",
  "starcoin-vm1-types",
@@ -12963,7 +13143,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "serde 1.0.205",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-state-api",
  "starcoin-state-tree",
  "starcoin-vm1-types",
@@ -13006,8 +13186,8 @@ dependencies = [
  "starcoin-accumulator",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger",
- "starcoin-metrics",
+ "starcoin-logger 2.1.1",
+ "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
  "starcoin-state-store-api",
  "starcoin-uint",
  "starcoin-vm1-types",
@@ -13033,9 +13213,9 @@ dependencies = [
  "serde_json",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-miner",
- "starcoin-service-registry",
+ "starcoin-service-registry 1.13.19",
  "starcoin-vm1-types",
  "stest",
 ]
@@ -13045,6 +13225,7 @@ name = "starcoin-sync"
 version = "2.1.1"
 dependencies = [
  "anyhow",
+ "async-std",
  "async-trait",
  "bcs-ext",
  "byteorder",
@@ -13078,14 +13259,14 @@ dependencies = [
  "starcoin-dag",
  "starcoin-executor",
  "starcoin-genesis",
- "starcoin-logger",
- "starcoin-metrics",
+ "starcoin-logger 2.1.1",
+ "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
  "starcoin-miner",
  "starcoin-network",
  "starcoin-network-rpc",
  "starcoin-network-rpc-api",
  "starcoin-node",
- "starcoin-service-registry",
+ "starcoin-service-registry 1.13.19",
  "starcoin-state-api",
  "starcoin-state-service",
  "starcoin-state-tree",
@@ -13107,7 +13288,7 @@ dependencies = [
  "sysinfo",
  "test-helper",
  "thiserror",
- "timeout-join-handler",
+ "timeout-join-handler 2.0.1",
  "tokio",
 ]
 
@@ -13122,8 +13303,8 @@ dependencies = [
  "serde 1.0.205",
  "starcoin-accumulator",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-logger",
- "starcoin-service-registry",
+ "starcoin-logger 2.1.1",
+ "starcoin-service-registry 1.13.19",
  "starcoin-vm1-types",
  "stream-task",
 ]
@@ -13164,7 +13345,7 @@ dependencies = [
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-framework 0.1.0",
  "starcoin-genesis",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-transaction-builder",
  "starcoin-types",
  "starcoin-vm-types",
@@ -13235,7 +13416,7 @@ dependencies = [
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=5417dce574142c3da24adf987194a6931869f588)",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-executor",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-rpc-api",
  "starcoin-rpc-client",
  "starcoin-state-api",
@@ -13274,10 +13455,10 @@ dependencies = [
  "starcoin-dag",
  "starcoin-executor",
  "starcoin-genesis",
- "starcoin-logger",
- "starcoin-metrics",
+ "starcoin-logger 2.1.1",
+ "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
  "starcoin-open-block",
- "starcoin-service-registry",
+ "starcoin-service-registry 1.13.19",
  "starcoin-state-api",
  "starcoin-state-tree",
  "starcoin-statedb",
@@ -13410,8 +13591,8 @@ dependencies = [
  "starcoin-gas-algebra",
  "starcoin-gas-meter",
  "starcoin-gas-schedule",
- "starcoin-logger",
- "starcoin-metrics",
+ "starcoin-logger 2.1.1",
+ "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
  "starcoin-move-stdlib",
  "starcoin-native-interface",
  "starcoin-parallel-executor",
@@ -13542,8 +13723,8 @@ dependencies = [
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-gas",
  "starcoin-gas-algebra-ext",
- "starcoin-logger",
- "starcoin-metrics",
+ "starcoin-logger 2.1.1",
+ "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
  "starcoin-natives",
  "starcoin-parallel-executor",
  "starcoin-vm-types",
@@ -13652,7 +13833,7 @@ dependencies = [
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=5417dce574142c3da24adf987194a6931869f588)",
  "starcoin-decrypt",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-storage",
  "starcoin-types",
  "starcoin-vm2-account-api",
@@ -13675,7 +13856,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=5417dce574142c3da24adf987194a6931869f588)",
- "starcoin-service-registry",
+ "starcoin-service-registry 1.13.19",
  "starcoin-types",
  "thiserror",
 ]
@@ -13700,8 +13881,8 @@ dependencies = [
  "starcoin-chain-notify",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=5417dce574142c3da24adf987194a6931869f588)",
- "starcoin-logger",
- "starcoin-service-registry",
+ "starcoin-logger 2.1.1",
+ "starcoin-service-registry 1.13.19",
  "starcoin-storage",
  "starcoin-types",
  "starcoin-vm-types",
@@ -13729,7 +13910,7 @@ version = "2.0.1"
 dependencies = [
  "anyhow",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=5417dce574142c3da24adf987194a6931869f588)",
- "starcoin-metrics",
+ "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
  "starcoin-state-api",
  "starcoin-status-translator",
  "starcoin-types",
@@ -13753,7 +13934,7 @@ dependencies = [
  "serde 1.0.205",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=5417dce574142c3da24adf987194a6931869f588)",
- "starcoin-metrics",
+ "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
  "starcoin-test-helper",
  "starcoin-transaction-builder",
  "starcoin-types",
@@ -13777,7 +13958,7 @@ dependencies = [
  "regex",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=5417dce574142c3da24adf987194a6931869f588)",
  "starcoin-framework 0.1.0",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-vm-types",
  "tempfile",
  "walkdir",
@@ -13841,7 +14022,7 @@ dependencies = [
  "serde_json",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=5417dce574142c3da24adf987194a6931869f588)",
- "starcoin-metrics",
+ "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
  "starcoin-status-translator",
  "starcoin-storage",
  "starcoin-txpool-api",
@@ -13870,7 +14051,7 @@ dependencies = [
  "once_cell",
  "serde 1.0.205",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
- "starcoin-service-registry",
+ "starcoin-service-registry 1.13.19",
  "starcoin-state-tree",
  "starcoin-types",
  "starcoin-vm-types",
@@ -13885,8 +14066,8 @@ dependencies = [
  "futures 0.3.31",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=5417dce574142c3da24adf987194a6931869f588)",
- "starcoin-logger",
- "starcoin-service-registry",
+ "starcoin-logger 2.1.1",
+ "starcoin-service-registry 1.13.19",
  "starcoin-storage",
  "starcoin-types",
  "starcoin-vm-types",
@@ -13909,7 +14090,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "serde 1.0.205",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=5417dce574142c3da24adf987194a6931869f588)",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-state-tree",
  "starcoin-types",
  "starcoin-vm-types",
@@ -14024,9 +14205,9 @@ dependencies = [
  "anyhow",
  "futures 0.3.31",
  "log 0.4.27",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "stest-macro",
- "timeout-join-handler",
+ "timeout-join-handler 2.0.1",
  "tokio",
 ]
 
@@ -14059,6 +14240,7 @@ name = "stream-task"
 version = "2.1.1"
 dependencies = [
  "anyhow",
+ "async-std",
  "futures 0.3.31",
  "futures-retry",
  "futures-timer",
@@ -14068,7 +14250,7 @@ dependencies = [
  "pin-utils",
  "schemars",
  "serde 1.0.205",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "stest",
  "thiserror",
  "tokio",
@@ -14530,8 +14712,8 @@ dependencies = [
  "starcoin-dev",
  "starcoin-executor",
  "starcoin-genesis",
- "starcoin-logger",
- "starcoin-metrics",
+ "starcoin-logger 2.1.1",
+ "starcoin-metrics 2.0.1 (git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79)",
  "starcoin-miner",
  "starcoin-move-compiler",
  "starcoin-network",
@@ -14540,7 +14722,7 @@ dependencies = [
  "starcoin-node",
  "starcoin-node-api",
  "starcoin-rpc-server",
- "starcoin-service-registry",
+ "starcoin-service-registry 1.13.19",
  "starcoin-state-api",
  "starcoin-state-service",
  "starcoin-statedb",
@@ -14581,7 +14763,7 @@ dependencies = [
  "starcoin-consensus",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
  "starcoin-executor",
- "starcoin-logger",
+ "starcoin-logger 2.1.1",
  "starcoin-miner",
  "starcoin-network",
  "starcoin-node",
@@ -14732,6 +14914,14 @@ name = "timeout-join-handler"
 version = "2.0.1"
 dependencies = [
  "anyhow",
+ "thiserror",
+]
+
+[[package]]
+name = "timeout-join-handler"
+version = "2.0.1"
+source = "git+https://github.com/starcoinorg/starcoin?rev=401ce6289a78b9f44e62e2b9f907030ad26d8d79#401ce6289a78b9f44e62e2b9f907030ad26d8d79"
+dependencies = [
  "thiserror",
 ]
 
@@ -14965,9 +15155,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.16"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
  "bytes 1.6.1",
  "futures-core",
@@ -14975,6 +15165,7 @@ dependencies = [
  "futures-sink",
  "pin-project-lite 0.2.16",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -15551,6 +15742,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "value-bag"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
 
 [[package]]
 name = "variant_count"

--- a/account/api/src/message.rs
+++ b/account/api/src/message.rs
@@ -22,6 +22,9 @@ pub enum AccountRequest {
         txn: Box<RawUserTransaction>,
         signer: AccountAddress,
     },
+    SignTxnInBatch {
+        txns: Vec<RawUserTransaction>,
+    },
     SignMessage {
         signer: AccountAddress,
         message: SigningMessage,
@@ -30,6 +33,7 @@ pub enum AccountRequest {
         address: AccountAddress,
     },
     UnlockAccount(AccountAddress, String, Duration),
+    UnlockAccountInBatch(Vec<(AccountAddress, String)>, Duration),
     LockAccount(AccountAddress),
     ImportAccount {
         address: AccountAddress,
@@ -60,6 +64,7 @@ pub enum AccountResponse {
     AccountInfoOption(Box<Option<AccountInfo>>),
     AccountList(Vec<AccountInfo>),
     SignedTxn(Box<SignedUserTransaction>),
+    SignedTxnList(Vec<SignedUserTransaction>),
     UnlockAccountResponse,
     ExportAccountResponse(Vec<u8>),
     AcceptedTokens(Vec<TokenCode>),

--- a/account/api/src/provider.rs
+++ b/account/api/src/provider.rs
@@ -5,7 +5,7 @@ use starcoin_types::account_config::token_code::TokenCode;
 use starcoin_types::sign_message::{SignedMessage, SigningMessage};
 use starcoin_types::transaction::{RawUserTransaction, SignedUserTransaction};
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum AccountProviderStrategy {
     #[default]
     RPC,

--- a/account/api/src/rich_wallet.rs
+++ b/account/api/src/rich_wallet.rs
@@ -59,7 +59,7 @@ pub struct Setting {
 
 impl Setting {
     pub fn readonly() -> Self {
-        Setting {
+        Self {
             default_expiration_timeout: 3600,
             default_gas_price: 1,
             default_gas_token: G_STC_TOKEN_CODE.clone(),
@@ -71,7 +71,7 @@ impl Setting {
 
 impl std::default::Default for Setting {
     fn default() -> Self {
-        Setting {
+        Self {
             default_expiration_timeout: 3600,
             default_gas_price: 1,
             default_gas_token: G_STC_TOKEN_CODE.clone(),

--- a/account/api/src/types.rs
+++ b/account/api/src/types.rs
@@ -55,7 +55,7 @@ impl AccountInfo {
         let (_private_key, public_key) = key_gen.generate_keypair();
         let address = account_address::from_public_key(&public_key);
         let account_public_key = AccountPublicKey::Single(public_key);
-        AccountInfo {
+        Self {
             address,
             is_default: false,
             is_readonly: false,
@@ -68,7 +68,7 @@ impl AccountInfo {
 
 impl From<&Account> for AccountInfo {
     fn from(account: &Account) -> Self {
-        AccountInfo::new(account.addr, account.public_key(), false, false, false)
+        Self::new(account.addr, account.public_key(), false, false, false)
     }
 }
 

--- a/account/service/src/account_events.rs
+++ b/account/service/src/account_events.rs
@@ -25,8 +25,8 @@ impl ActorService for AccountEventService {
     }
 }
 
-impl ServiceFactory<AccountEventService> for AccountEventService {
-    fn create(ctx: &mut ServiceContext<AccountEventService>) -> Result<AccountEventService> {
+impl ServiceFactory<Self> for AccountEventService {
+    fn create(ctx: &mut ServiceContext<Self>) -> Result<Self> {
         Ok(Self {
             storage: ctx.get_shared::<AccountStorage>()?,
         })
@@ -34,11 +34,7 @@ impl ServiceFactory<AccountEventService> for AccountEventService {
 }
 
 impl EventHandler<Self, ContractEventNotification> for AccountEventService {
-    fn handle_event(
-        &mut self,
-        item: ContractEventNotification,
-        _ctx: &mut ServiceContext<AccountEventService>,
-    ) {
+    fn handle_event(&mut self, item: ContractEventNotification, _ctx: &mut ServiceContext<Self>) {
         let addrs = match self.storage.list_addresses() {
             Ok(addresses) => addresses,
             Err(e) => {

--- a/account/service/src/service.rs
+++ b/account/service/src/service.rs
@@ -30,16 +30,12 @@ impl AccountService {
     }
 }
 
-impl MockHandler<AccountService> for AccountService {
-    fn handle(
-        &mut self,
-        r: Box<dyn Any>,
-        ctx: &mut ServiceContext<AccountService>,
-    ) -> Box<dyn Any> {
+impl MockHandler<Self> for AccountService {
+    fn handle(&mut self, r: Box<dyn Any>, ctx: &mut ServiceContext<Self>) -> Box<dyn Any> {
         let request = r
             .downcast::<AccountRequest>()
             .expect("Downcast to AccountRequest fail.");
-        let result = ServiceHandler::<AccountService, AccountRequest>::handle(self, *request, ctx);
+        let result = ServiceHandler::<Self, AccountRequest>::handle(self, *request, ctx);
         Box::new(result)
     }
 }
@@ -89,8 +85,8 @@ impl ActorService for AccountService {
     }
 }
 
-impl ServiceFactory<AccountService> for AccountService {
-    fn create(ctx: &mut ServiceContext<AccountService>) -> Result<AccountService> {
+impl ServiceFactory<Self> for AccountService {
+    fn create(ctx: &mut ServiceContext<Self>) -> Result<Self> {
         let account_storage = ctx.get_shared::<AccountStorage>()?;
         let config = ctx.get_shared::<Arc<NodeConfig>>()?;
         let manager = AccountManager::new(account_storage, config.net().chain_id())?;
@@ -98,7 +94,7 @@ impl ServiceFactory<AccountService> for AccountService {
     }
 }
 
-impl ServiceHandler<AccountService, AccountRequest> for AccountService {
+impl ServiceHandler<Self, AccountRequest> for AccountService {
     fn handle(
         &mut self,
         msg: AccountRequest,
@@ -141,6 +137,9 @@ impl ServiceHandler<AccountService, AccountRequest> for AccountService {
                 txn: raw_txn,
                 signer,
             } => AccountResponse::SignedTxn(Box::new(self.manager.sign_txn(signer, *raw_txn)?)),
+            AccountRequest::SignTxnInBatch { txns } => {
+                AccountResponse::SignedTxnList(self.manager.sign_txn_in_batch(txns)?)
+            }
             AccountRequest::SignMessage { message, signer } => AccountResponse::SignedMessage(
                 Box::new(self.manager.sign_message(signer, message)?),
             ),
@@ -149,6 +148,10 @@ impl ServiceHandler<AccountService, AccountRequest> for AccountService {
                     self.manager
                         .unlock_account(address, password.as_str(), duration)?;
                 AccountResponse::AccountInfo(Box::new(account_info))
+            }
+            AccountRequest::UnlockAccountInBatch(batch, duration) => {
+                let account_infos = self.manager.unlock_account_in_batch(batch, duration)?;
+                AccountResponse::AccountList(account_infos)
             }
             AccountRequest::LockAccount(address) => {
                 AccountResponse::AccountInfo(Box::new(self.manager.lock_account(address)?))

--- a/account/src/account_storage.rs
+++ b/account/src/account_storage.rs
@@ -92,7 +92,7 @@ impl KeyCodec for GlobalSettingKey {
     }
 
     fn decode_key(data: &[u8]) -> Result<Self, Error> {
-        GlobalSettingKey::decode(data)
+        Self::decode(data)
     }
 }
 
@@ -102,7 +102,7 @@ impl ValueCodec for GlobalValue {
     }
 
     fn decode_value(data: &[u8]) -> Result<Self, Error> {
-        <Vec<AccountAddress>>::decode(data).map(|addresses| GlobalValue { addresses })
+        <Vec<AccountAddress>>::decode(data).map(|addresses| Self { addresses })
     }
 }
 
@@ -139,7 +139,7 @@ impl ValueCodec for SettingWrapper {
     }
 
     fn decode_value(data: &[u8]) -> Result<Self, Error> {
-        Ok(SettingWrapper(serde_json::from_slice(data)?))
+        Ok(Self(serde_json::from_slice(data)?))
     }
 }
 
@@ -157,7 +157,7 @@ impl ValueCodec for EncryptedPrivateKey {
     }
 
     fn decode_value(data: &[u8]) -> Result<Self, Error> {
-        Ok(EncryptedPrivateKey(data.to_vec()))
+        Ok(Self(data.to_vec()))
     }
 }
 

--- a/cmd/starcoin/src/account/sign_multisig_txn_cmd.rs
+++ b/cmd/starcoin/src/account/sign_multisig_txn_cmd.rs
@@ -205,6 +205,9 @@ impl CommandAction for GenerateMultisigTxnCommand {
         }
 
         let mut output_dir = opt.output_dir.clone().unwrap_or(current_dir()?);
+        if !output_dir.exists() {
+            std::fs::create_dir_all(output_dir.as_path())?;
+        }
         let _ = ctx.state().vm2()?.sign_multisig_txn_to_file_or_submit(
             raw_txn.sender(),
             account_public_key,

--- a/cmd/starcoin/src/node/sync/status_cmd.rs
+++ b/cmd/starcoin/src/node/sync/status_cmd.rs
@@ -6,6 +6,7 @@ use crate::StarcoinOpt;
 use anyhow::Result;
 use clap::Parser;
 use scmd::{CommandAction, ExecContext};
+use starcoin_rpc_api::types::SyncStatusView;
 use starcoin_types::sync_status::SyncStatus;
 
 #[derive(Debug, Parser, Default)]
@@ -18,7 +19,7 @@ impl CommandAction for StatusCommand {
     type State = CliState;
     type GlobalOpt = StarcoinOpt;
     type Opt = StatusOpt;
-    type ReturnItem = SyncStatus;
+    type ReturnItem = SyncStatusView;
 
     fn run(
         &self,

--- a/cmd/starcoin/src/node/sync/status_cmd.rs
+++ b/cmd/starcoin/src/node/sync/status_cmd.rs
@@ -7,7 +7,6 @@ use anyhow::Result;
 use clap::Parser;
 use scmd::{CommandAction, ExecContext};
 use starcoin_rpc_api::types::SyncStatusView;
-use starcoin_types::sync_status::SyncStatus;
 
 #[derive(Debug, Parser, Default)]
 #[clap(name = "status")]

--- a/cmd/tx-factory/src/main.rs
+++ b/cmd/tx-factory/src/main.rs
@@ -570,7 +570,7 @@ impl TxnMocker {
 
         if !addr_vec.is_empty() {
             self.recheck_sequence_number()?;
-            self.unlock_account_association_account()?;
+            self.unlock_account()?;
             let txn = self.generator.generate_account_txn(
                 self.next_sequence_number,
                 self.account_address,
@@ -619,7 +619,7 @@ impl TxnMocker {
             .collect())
     }
 
-    fn sequence_number<R>(&self, state_reader: &R, address: AccountAddress) -> Result<Option<u64>>
+    fn sequence_number<R>(&self, _state_reader: &R, address: AccountAddress) -> Result<Option<u64>>
     where
         R: ChainStateReader,
     {

--- a/cmd/tx-factory/src/main.rs
+++ b/cmd/tx-factory/src/main.rs
@@ -1,7 +1,8 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{bail, Result};
+use anyhow::bail;
+use anyhow::{format_err, Result};
 use clap::Parser;
 use starcoin_account_api::AccountInfo;
 use starcoin_crypto::HashValue;
@@ -11,13 +12,15 @@ use starcoin_rpc_client::RpcClient;
 use starcoin_rpc_client::StateRootOption;
 use starcoin_state_api::{ChainStateReader, StateReaderExt};
 use starcoin_tx_factory::txn_generator::MockTxnGenerator;
-use starcoin_types::account::DEFAULT_EXPIRATION_TIME;
 use starcoin_types::account_address::AccountAddress;
 use starcoin_types::account_config::association_address;
+use starcoin_types::sync_status::SyncStatus;
 use starcoin_types::transaction::RawUserTransaction;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 use std::time::{Duration, Instant};
 
 #[derive(Debug, Clone, Parser, Default)]
@@ -32,6 +35,13 @@ pub struct TxFactoryOpt {
         help = "interval(in ms) of txn gen"
     )]
     pub interval: u64,
+    #[clap(
+        long,
+        short = 'f',
+        default_value = "800",
+        help = "The number of accounts participating in each round of transactions: the first half are sender accounts, and the second half are receiver accounts, with a default total of 800."
+    )]
+    pub transfer_account_size: usize,
     #[clap(
         long,
         short = 'a',
@@ -120,6 +130,7 @@ fn main() {
 
     let account_address = opts.account_address;
     let interval = Duration::from_millis(opts.interval);
+    let transfer_account_size = opts.transfer_account_size;
     let account_password = opts.account_password.clone();
 
     let is_stress = opts.stress;
@@ -151,7 +162,7 @@ fn main() {
         txn_generator,
         account.address,
         account_password,
-        Duration::from_secs(60 * 10),
+        Duration::from_secs(60 * 1000),
         watch_timeout,
     );
 
@@ -176,7 +187,12 @@ fn main() {
             if tx_mocker.get_factory_status() {
                 if is_stress {
                     info!("stress account: {}", accounts.len());
-                    let success = tx_mocker.stress_test(accounts.clone(), round_num);
+                    let success = tx_mocker.stress_test(
+                        accounts.clone(),
+                        round_num,
+                        interval,
+                        transfer_account_size,
+                    );
                     if let Err(e) = success {
                         error!("fail to run stress test, err: {:?}", &e);
                         // if txn is rejected, recheck sequence number, and start over
@@ -256,11 +272,16 @@ impl TxnMocker {
 
 impl TxnMocker {
     fn fetch_expiration_time(&self) -> u64 {
-        let node_info = self
-            .client
-            .node_info()
-            .expect("node_info() should not failed");
-        node_info.now_seconds + DEFAULT_EXPIRATION_TIME
+        let now = SystemTime::now();
+        now.duration_since(UNIX_EPOCH)
+            .expect("time error")
+            .as_secs()
+            + 180 // 3 minutes
+                  // let node_info = self
+                  //     .client
+                  //     .node_info()
+                  //     .expect("node_info() should not failed");
+                  // node_info.now_seconds + DEFAULT_EXPIRATION_TIME
     }
     fn get_factory_status(&self) -> bool {
         self.client
@@ -308,9 +329,10 @@ impl TxnMocker {
             Ok(txn) => txn,
         };
         info!(
-            "prepare to submit txn, sender:{},seq:{}",
+            "prepare to submit txn, sender:{},seq:{},id:{}",
             user_txn.sender(),
             user_txn.sequence_number(),
+            user_txn.id(),
         );
         let txn_hash = user_txn.id();
         let result = self.client.submit_transaction(user_txn);
@@ -350,6 +372,37 @@ impl TxnMocker {
         Ok(())
     }
 
+    fn submit_transaction_in_batch(
+        &self,
+        txns: Vec<(AccountAddress, Vec<RawUserTransaction>)>,
+        blocking: bool,
+    ) -> Result<()> {
+        info!("going to unlock accounts");
+        self.client.account_unlock_in_batch(
+            txns.iter()
+                .map(|(sender, _)| (*sender, self.account_password.clone()))
+                .collect(),
+            self.unlock_duration,
+        )?;
+
+        let signed_transactions = self.client.account_sign_txn_in_batch(
+            txns.iter()
+                .flat_map(|(_, raw_txns)| raw_txns.clone())
+                .collect(),
+        )?;
+
+        let hashes = self.client.submit_transactions(signed_transactions)?;
+        info!("submitted {} txns", hashes.len());
+
+        if blocking {
+            for hash in hashes {
+                self.client
+                    .watch_txn(hash, Some(Duration::from_secs(self.watch_timeout as u64)))?;
+            }
+        }
+        Ok(())
+    }
+
     fn submit_txn(
         &self,
         raw_txn: RawUserTransaction,
@@ -367,9 +420,10 @@ impl TxnMocker {
             Ok(txn) => txn,
         };
         info!(
-            "prepare to submit txn, sender:{},seq:{}",
+            "prepare to submit txn, sender:{},seq:{},id:{}",
             user_txn.sender(),
             user_txn.sequence_number(),
+            user_txn.id(),
         );
         let txn_hash = user_txn.id();
         let result = self.client.submit_transaction(user_txn);
@@ -383,6 +437,7 @@ impl TxnMocker {
         result
     }
 
+    #[allow(dead_code)]
     fn gen_and_submit_transfer_txn(
         &self,
         sender: AccountAddress,
@@ -481,7 +536,13 @@ impl TxnMocker {
         let mut sub_account_list = vec![];
         while i < account_num {
             self.recheck_sequence_number()?;
-            let account = self.client.account_create(self.account_password.clone())?;
+            let account = match self.client.account_create(self.account_password.clone()) {
+                Ok(account) => account,
+                Err(e) => {
+                    error!("create account error: {}", e);
+                    continue;
+                }
+            };
             addr_vec.push(account.address);
             sub_account_list.push(account);
             if addr_vec.len() >= batch_size as usize {
@@ -506,8 +567,56 @@ impl TxnMocker {
             }
             i += 1;
         }
+
+        if !addr_vec.is_empty() {
+            self.recheck_sequence_number()?;
+            self.unlock_account_association_account()?;
+            let txn = self.generator.generate_account_txn(
+                self.next_sequence_number,
+                self.account_address,
+                addr_vec.clone(),
+                10000,
+                1,
+                expiration_timestamp,
+            )?;
+            let result = self.submit_txn(txn, self.account_address, true);
+            if result.is_ok() {
+                info!("account transfer submit ok.");
+            } else {
+                info!("error: {:?}", result);
+            }
+            account_list.extend_from_slice(sub_account_list.as_slice());
+        }
+
         info!("{:?} accounts are created.", Vec::len(&account_list));
         Ok(account_list)
+    }
+
+    fn next_sequence_number_in_batch(
+        &self,
+        addresses: Vec<AccountAddress>,
+    ) -> Result<Vec<(AccountAddress, Option<u64>)>> {
+        let seq_numbers = self
+            .client
+            .next_sequence_number_in_batch(addresses)?
+            .ok_or_else(|| format_err!("next_sequence_number_in_batch error"))?;
+        Ok(seq_numbers
+            .into_iter()
+            .map(|(address, seq_number)| match seq_number {
+                Some(seq_number) => (address, Some(seq_number)),
+                None => {
+                    let state_reader = self
+                        .client
+                        .state_reader(StateRootOption::Latest)
+                        .expect("state_reader error");
+                    let account_resource = state_reader
+                        .get_account_resource(address)
+                        .expect("get_account_resource error");
+                    let seq = account_resource.map(|resource| resource.sequence_number());
+                    (address, seq)
+                }
+            })
+            .collect())
     }
 
     fn sequence_number<R>(&self, state_reader: &R, address: AccountAddress) -> Result<Option<u64>>
@@ -522,71 +631,106 @@ impl TxnMocker {
         let result = match seq_number_in_pool {
             Some(n) => Some(n),
             None => {
+                let state_reader = self.client.state_reader(StateRootOption::Latest)?;
                 let account_resource = state_reader.get_account_resource(address)?;
-                match account_resource {
-                    None => None,
-                    Some(resource) => {
-                        info!("read from state {:?}", resource.sequence_number());
-                        Some(resource.sequence_number())
-                    }
-                }
+                account_resource.map(|resource| resource.sequence_number())
             }
         };
         Ok(result)
     }
 
-    fn stress_test(&self, accounts: Vec<AccountInfo>, round_num: u32) -> Result<()> {
+    fn send_and_receive(
+        &self,
+        senders: Vec<(AccountAddress, Option<u64>)>,
+        receivers: Vec<AccountAddress>,
+        amount: u128,
+        round_num: u64,
+    ) -> Result<()> {
+        if receivers.len() < senders.len() {
+            bail!("receivers len {} is less than senders len {}, the account number should be better even", receivers.len(), senders.len());
+        }
+        let mut transactions = Vec::new();
+        let mut sender_transactions = Vec::new();
+        for (index, (sender_address, sequence_op)) in senders.iter().enumerate() {
+            let seq = match sequence_op {
+                Some(seq) => seq,
+                None => {
+                    error!("address {:?} seq is none", sender_address);
+                    continue;
+                }
+            };
+
+            for i in 0..round_num {
+                let txn = self.generator.generate_transfer_txn(
+                    *seq + i,
+                    *sender_address,
+                    receivers[index],
+                    amount,
+                    1,
+                    self.fetch_expiration_time(),
+                )?;
+                transactions.push(txn);
+            }
+            sender_transactions.push((*sender_address, transactions.clone()));
+            transactions.clear();
+        }
+
+        self.submit_transaction_in_batch(sender_transactions, false)
+    }
+
+    fn stress_test(
+        &self,
+        accounts: Vec<AccountInfo>,
+        round_num: u32,
+        interval: Duration,
+        transfer_account_size: usize,
+    ) -> Result<()> {
         //check node status
-        let sync_status = self.client.sync_status()?;
+        let sync_status: SyncStatus = self.client.sync_status()?.into();
         if sync_status.is_syncing() {
             info!("node syncing, pause stress");
             return Ok(());
         }
-        let state_reader = self.client.state_reader(StateRootOption::Latest)?;
 
         //unlock all account and get sequence
-        let mut sequences = vec![];
-        for account in &accounts {
-            sequences.push(
-                self.sequence_number(&state_reader, account.address)
-                    .unwrap()
-                    .unwrap(),
-            );
+        let sequences =
+            self.next_sequence_number_in_batch(accounts.iter().map(|a| a.address).collect())?;
+
+        for addresses in sequences.chunks(transfer_account_size) {
+            let mid = addresses.len() / 2;
+            let senders = &addresses[..mid];
+            let receivers = &addresses[mid..];
+            self.send_and_receive(
+                senders.to_vec(),
+                receivers
+                    .iter()
+                    .copied()
+                    .map(|(address, _)| address)
+                    .collect(),
+                1,
+                round_num as u64,
+            )?;
+
+            std::thread::sleep(interval);
         }
-        //get  of all account
-        let expiration_timestamp = self.fetch_expiration_time();
-        let count = accounts.len();
-        (0..round_num).for_each(|_| {
-            (0..count).for_each(|index| {
-                let mut j = index + 1;
-                if j >= count {
-                    j = 0;
-                }
-                let result = self.gen_and_submit_transfer_txn(
-                    accounts[index].address,
-                    accounts[j].address,
-                    1,
-                    1,
-                    sequences[index],
-                    false,
-                    expiration_timestamp,
-                );
-                //handle result
-                match result {
-                    Ok(_) => {
-                        // sequence add
-                        sequences[index] += 1;
-                    }
-                    Err(err) => {
-                        info!(
-                            "Submit txn failed with error: {:?}. Try again after 500ms.",
-                            err
-                        );
-                        std::thread::sleep(Duration::from_millis(500));
-                    }
-                }
-            });
-        });
+
+        for addresses in sequences.rchunks(transfer_account_size) {
+            let mid = addresses.len() / 2;
+            let senders = &addresses[..mid];
+            let receivers = &addresses[mid..];
+            self.send_and_receive(
+                senders.to_vec(),
+                receivers
+                    .iter()
+                    .copied()
+                    .map(|(address, _)| address)
+                    .collect(),
+                1,
+                round_num as u64,
+            )?;
+
+            std::thread::sleep(interval);
+        }
         Ok(())
     }
 }

--- a/cmd/tx-factory/src/main.rs
+++ b/cmd/tx-factory/src/main.rs
@@ -162,7 +162,7 @@ fn main() {
         txn_generator,
         account.address,
         account_password,
-        Duration::from_secs(60 * 1000),
+        Duration::from_secs(86400), // 24 hours
         watch_timeout,
     );
 
@@ -575,7 +575,7 @@ impl TxnMocker {
                 self.next_sequence_number,
                 self.account_address,
                 addr_vec.clone(),
-                10000,
+                1,
                 1,
                 expiration_timestamp,
             )?;

--- a/cmd/tx-factory/src/main.rs
+++ b/cmd/tx-factory/src/main.rs
@@ -619,6 +619,7 @@ impl TxnMocker {
             .collect())
     }
 
+    #[allow(dead_code)]
     fn sequence_number<R>(&self, _state_reader: &R, address: AccountAddress) -> Result<Option<u64>>
     where
         R: ChainStateReader,

--- a/cmd/tx-factory/src/txn_generator.rs
+++ b/cmd/tx-factory/src/txn_generator.rs
@@ -16,7 +16,7 @@ pub struct MockTxnGenerator {
 
 impl MockTxnGenerator {
     pub fn new(chain_id: ChainId, account: AccountInfo, receiver_address: AccountAddress) -> Self {
-        MockTxnGenerator {
+        Self {
             chain_id,
             receiver_address,
             account,
@@ -58,7 +58,7 @@ impl MockTxnGenerator {
             sequence_number,
             amount,
             gas_price,
-            40000000,
+            4000000,
             expiration_timestamp,
             self.chain_id,
         );

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,7 @@ COPY --from=builder $RELEASE_PATH/starcoin \
      $RELEASE_PATH/starcoin_miner \
      $RELEASE_PATH/starcoin_txfactory \
      $RELEASE_PATH/starcoin_faucet \
-     $RELEASE_PATH/mpm2 \
+     $RELEASE_PATH/mpm \
      /starcoin/
      
 CMD ["/starcoin/starcoin"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,6 @@ COPY --from=builder $RELEASE_PATH/starcoin \
      $RELEASE_PATH/starcoin_miner \
      $RELEASE_PATH/starcoin_txfactory \
      $RELEASE_PATH/starcoin_faucet \
-     $RELEASE_PATH/mpm \
      /starcoin/
      
 CMD ["/starcoin/starcoin"]

--- a/miner/src/create_block_template/block_builder_service.rs
+++ b/miner/src/create_block_template/block_builder_service.rs
@@ -246,7 +246,23 @@ impl TemplateTxProvider for TxPoolService {
         max: u64,
         header: &BlockHeader,
     ) -> Vec<MultiSignedUserTransaction> {
-        self.get_pending_with_header(max, None, header)
+        let (state_root1, state_root2) = match self.get_store().get_vm_multi_state(header.id()) {
+            Ok(state) => (state.state_root1(), state.state_root2()),
+            Err(e) => {
+                error!(
+                    "Failed to get vm_multi_state when creating block template: {}",
+                    e
+                );   
+                return vec![];
+            }
+        };
+        self.get_pending_with_state(max, None, state_root1, state_root2).unwrap_or_else(|e| {
+            error!(
+                "Failed to get pending txns when creating block template: {}",
+                e
+            );
+            vec![]
+        })
     }
 
     fn remove_invalid_txn(&self, txn_hash: HashValue) {

--- a/miner/src/create_block_template/block_builder_service.rs
+++ b/miner/src/create_block_template/block_builder_service.rs
@@ -252,17 +252,18 @@ impl TemplateTxProvider for TxPoolService {
                 error!(
                     "Failed to get vm_multi_state when creating block template: {}",
                     e
-                );   
+                );
                 return vec![];
             }
         };
-        self.get_pending_with_state(max, None, state_root1, state_root2).unwrap_or_else(|e| {
-            error!(
-                "Failed to get pending txns when creating block template: {}",
-                e
-            );
-            vec![]
-        })
+        self.get_pending_with_state(max, None, state_root1, state_root2)
+            .unwrap_or_else(|e| {
+                error!(
+                    "Failed to get pending txns when creating block template: {}",
+                    e
+                );
+                vec![]
+            })
     }
 
     fn remove_invalid_txn(&self, txn_hash: HashValue) {

--- a/network-rpc/src/rpc.rs
+++ b/network-rpc/src/rpc.rs
@@ -61,10 +61,17 @@ impl gen_server::NetworkRpc for NetworkRpcImpl {
         } else {
             MAX_TXN_REQUEST_SIZE
         };
-        let fut = async move { Ok(txpool.get_pending_txns(Some(max_size), None).unwrap_or_else(|e| {
-            error!("get_txns_from_pool error in get_txns_from_pool in gen_server: {}", e);
-            vec![]
-        }))};
+        let fut = async move {
+            Ok(txpool
+                .get_pending_txns(Some(max_size), None)
+                .unwrap_or_else(|e| {
+                    error!(
+                        "get_txns_from_pool error in get_txns_from_pool in gen_server: {}",
+                        e
+                    );
+                    vec![]
+                }))
+        };
         Box::pin(fut)
     }
 

--- a/network-rpc/src/rpc.rs
+++ b/network-rpc/src/rpc.rs
@@ -62,15 +62,14 @@ impl gen_server::NetworkRpc for NetworkRpcImpl {
             MAX_TXN_REQUEST_SIZE
         };
         let fut = async move {
-            Ok(txpool
-                .get_pending_txns(Some(max_size), None)
-                .unwrap_or_else(|e| {
-                    error!(
-                        "get_txns_from_pool error in get_txns_from_pool in gen_server: {}",
-                        e
-                    );
-                    vec![]
-                }))
+            let txns = txpool.get_pending_txns(Some(max_size), None).map_err(|e| {
+                error!(
+                    "get_txns_from_pool error in get_txns_from_pool in gen_server: {}",
+                    e
+                );
+                e
+            })?;
+            Ok(txns)
         };
         Box::pin(fut)
     }

--- a/network-rpc/src/rpc.rs
+++ b/network-rpc/src/rpc.rs
@@ -9,6 +9,7 @@ use network_p2p_core::NetRpcError;
 use starcoin_accumulator::AccumulatorNode;
 use starcoin_chain_service::{ChainAsyncService, ChainReaderService};
 use starcoin_crypto::HashValue;
+use starcoin_logger::prelude::error;
 use starcoin_network_rpc_api::{
     gen_server, BlockBody, GetAbsentBlockRequest, GetAbsentBlockResponse,
     GetAccumulatorNodeByNodeHash, GetBlockHeadersByNumber, GetBlockIds, GetRangeInLocationRequest,
@@ -60,7 +61,10 @@ impl gen_server::NetworkRpc for NetworkRpcImpl {
         } else {
             MAX_TXN_REQUEST_SIZE
         };
-        let fut = async move { Ok(txpool.get_pending_txns(Some(max_size), None)) };
+        let fut = async move { Ok(txpool.get_pending_txns(Some(max_size), None).unwrap_or_else(|e| {
+            error!("get_txns_from_pool error in get_txns_from_pool in gen_server: {}", e);
+            vec![]
+        }))};
         Box::pin(fut)
     }
 

--- a/rpc/api/Cargo.toml
+++ b/rpc/api/Cargo.toml
@@ -47,6 +47,7 @@ starcoin-vm-types = { workspace = true }
 thiserror = { workspace = true }
 vm-status-translator = { workspace = true }
 move-core-types = { workspace = true }
+starcoin-dag = { workspace = true }
 starcoin-vm2-vm-types = { workspace = true }
 starcoin-vm2-types = { workspace = true }
 starcoin-vm2-rpc-api = { workspace = true}

--- a/rpc/api/generated_rpc_schema/account.json
+++ b/rpc/api/generated_rpc_schema/account.json
@@ -1053,6 +1053,504 @@
       }
     },
     {
+      "name": "account.sign_txn_in_batch",
+      "params": [
+        {
+          "name": "raw_txn",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "Array_of_RawUserTransaction",
+            "type": "array",
+            "items": {
+              "description": "RawUserTransaction is the portion of a transaction that a client signs",
+              "type": "object",
+              "required": [
+                "chain_id",
+                "expiration_timestamp_secs",
+                "gas_token_code",
+                "gas_unit_price",
+                "max_gas_amount",
+                "payload",
+                "sender",
+                "sequence_number"
+              ],
+              "properties": {
+                "chain_id": {
+                  "type": "object",
+                  "required": [
+                    "id"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": "integer",
+                      "format": "uint8",
+                      "minimum": 0.0
+                    }
+                  }
+                },
+                "expiration_timestamp_secs": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                },
+                "gas_token_code": {
+                  "type": "string"
+                },
+                "gas_unit_price": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                },
+                "max_gas_amount": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                },
+                "payload": {
+                  "oneOf": [
+                    {
+                      "description": "A transaction that executes code.",
+                      "type": "object",
+                      "required": [
+                        "Script"
+                      ],
+                      "properties": {
+                        "Script": {
+                          "description": "Call a Move script.",
+                          "type": "object",
+                          "required": [
+                            "args",
+                            "code",
+                            "ty_args"
+                          ],
+                          "properties": {
+                            "args": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "code": {
+                              "type": "string"
+                            },
+                            "ty_args": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    {
+                      "description": "A transaction that publish or update module code by a package.",
+                      "type": "object",
+                      "required": [
+                        "Package"
+                      ],
+                      "properties": {
+                        "Package": {
+                          "type": "object",
+                          "required": [
+                            "modules",
+                            "package_address"
+                          ],
+                          "properties": {
+                            "init_script": {
+                              "description": "Call a Move script function.",
+                              "type": [
+                                "object",
+                                "null"
+                              ],
+                              "required": [
+                                "args",
+                                "function",
+                                "module",
+                                "ty_args"
+                              ],
+                              "properties": {
+                                "args": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "function": {
+                                  "type": "string"
+                                },
+                                "module": {
+                                  "type": "string"
+                                },
+                                "ty_args": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "modules": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "code"
+                                ],
+                                "properties": {
+                                  "code": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "package_address": {
+                              "description": "Package's all Module must at same address.",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    {
+                      "description": "A transaction that executes an existing script function published on-chain.",
+                      "type": "object",
+                      "required": [
+                        "ScriptFunction"
+                      ],
+                      "properties": {
+                        "ScriptFunction": {
+                          "description": "Call a Move script function.",
+                          "type": "object",
+                          "required": [
+                            "args",
+                            "function",
+                            "module",
+                            "ty_args"
+                          ],
+                          "properties": {
+                            "args": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "function": {
+                              "type": "string"
+                            },
+                            "module": {
+                              "type": "string"
+                            },
+                            "ty_args": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
+                },
+                "sender": {
+                  "description": "Sender's address.",
+                  "type": "string"
+                },
+                "sequence_number": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                }
+              }
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "Vec < SignedUserTransaction >",
+        "schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "title": "Array_of_SignedUserTransaction",
+          "type": "array",
+          "items": {
+            "description": "A transaction that has been signed.\n\nA `SignedUserTransaction` is a single transaction that can be atomically executed. Clients submit these to validator nodes, and the validator and executor submits these to the VM.\n\n**IMPORTANT:** The signature of a `SignedUserTransaction` is not guaranteed to be verified. For a transaction whose signature is statically guaranteed to be verified, see [`SignatureCheckedTransaction`].",
+            "type": "object",
+            "required": [
+              "authenticator",
+              "raw_txn"
+            ],
+            "properties": {
+              "authenticator": {
+                "description": "Public key and signature to authenticate",
+                "oneOf": [
+                  {
+                    "description": "Single signature",
+                    "type": "object",
+                    "required": [
+                      "Ed25519"
+                    ],
+                    "properties": {
+                      "Ed25519": {
+                        "type": "object",
+                        "required": [
+                          "public_key",
+                          "signature"
+                        ],
+                        "properties": {
+                          "public_key": {
+                            "type": "string"
+                          },
+                          "signature": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  {
+                    "description": "K-of-N multisignature",
+                    "type": "object",
+                    "required": [
+                      "MultiEd25519"
+                    ],
+                    "properties": {
+                      "MultiEd25519": {
+                        "type": "object",
+                        "required": [
+                          "public_key",
+                          "signature"
+                        ],
+                        "properties": {
+                          "public_key": {
+                            "type": "string"
+                          },
+                          "signature": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                ]
+              },
+              "raw_txn": {
+                "description": "The raw transaction",
+                "type": "object",
+                "required": [
+                  "chain_id",
+                  "expiration_timestamp_secs",
+                  "gas_token_code",
+                  "gas_unit_price",
+                  "max_gas_amount",
+                  "payload",
+                  "sender",
+                  "sequence_number"
+                ],
+                "properties": {
+                  "chain_id": {
+                    "type": "object",
+                    "required": [
+                      "id"
+                    ],
+                    "properties": {
+                      "id": {
+                        "type": "integer",
+                        "format": "uint8",
+                        "minimum": 0.0
+                      }
+                    }
+                  },
+                  "expiration_timestamp_secs": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  },
+                  "gas_token_code": {
+                    "type": "string"
+                  },
+                  "gas_unit_price": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  },
+                  "max_gas_amount": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  },
+                  "payload": {
+                    "oneOf": [
+                      {
+                        "description": "A transaction that executes code.",
+                        "type": "object",
+                        "required": [
+                          "Script"
+                        ],
+                        "properties": {
+                          "Script": {
+                            "description": "Call a Move script.",
+                            "type": "object",
+                            "required": [
+                              "args",
+                              "code",
+                              "ty_args"
+                            ],
+                            "properties": {
+                              "args": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "code": {
+                                "type": "string"
+                              },
+                              "ty_args": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      {
+                        "description": "A transaction that publish or update module code by a package.",
+                        "type": "object",
+                        "required": [
+                          "Package"
+                        ],
+                        "properties": {
+                          "Package": {
+                            "type": "object",
+                            "required": [
+                              "modules",
+                              "package_address"
+                            ],
+                            "properties": {
+                              "init_script": {
+                                "description": "Call a Move script function.",
+                                "type": [
+                                  "object",
+                                  "null"
+                                ],
+                                "required": [
+                                  "args",
+                                  "function",
+                                  "module",
+                                  "ty_args"
+                                ],
+                                "properties": {
+                                  "args": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "function": {
+                                    "type": "string"
+                                  },
+                                  "module": {
+                                    "type": "string"
+                                  },
+                                  "ty_args": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "modules": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": [
+                                    "code"
+                                  ],
+                                  "properties": {
+                                    "code": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "package_address": {
+                                "description": "Package's all Module must at same address.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      {
+                        "description": "A transaction that executes an existing script function published on-chain.",
+                        "type": "object",
+                        "required": [
+                          "ScriptFunction"
+                        ],
+                        "properties": {
+                          "ScriptFunction": {
+                            "description": "Call a Move script function.",
+                            "type": "object",
+                            "required": [
+                              "args",
+                              "function",
+                              "module",
+                              "ty_args"
+                            ],
+                            "properties": {
+                              "args": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "function": {
+                                "type": "string"
+                              },
+                              "module": {
+                                "type": "string"
+                              },
+                              "ty_args": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    ]
+                  },
+                  "sender": {
+                    "description": "Sender's address.",
+                    "type": "string"
+                  },
+                  "sequence_number": {
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
       "name": "account.unlock",
       "params": [
         {
@@ -1145,6 +1643,112 @@
             },
             "receipt_identifier": {
               "type": "string"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "account.unlock_in_batch",
+      "params": [
+        {
+          "name": "batch",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "Array_of_Tuple_of_AccountAddress_and_String",
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "string",
+                  "format": "AccountAddress"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          }
+        },
+        {
+          "name": "duration",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "Nullable_uint32",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "Vec < AccountInfo >",
+        "schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "title": "Array_of_AccountInfo",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "address",
+              "is_default",
+              "is_locked",
+              "is_readonly",
+              "public_key",
+              "receipt_identifier"
+            ],
+            "properties": {
+              "address": {
+                "type": "string",
+                "format": "AccountAddress"
+              },
+              "is_default": {
+                "description": "This account is default at current wallet. Every wallet must has one default account.",
+                "type": "boolean"
+              },
+              "is_locked": {
+                "type": "boolean"
+              },
+              "is_readonly": {
+                "type": "boolean"
+              },
+              "public_key": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "required": [
+                      "Single"
+                    ],
+                    "properties": {
+                      "Single": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "required": [
+                      "Multi"
+                    ],
+                    "properties": {
+                      "Multi": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                ]
+              },
+              "receipt_identifier": {
+                "type": "string"
+              }
             }
           }
         }

--- a/rpc/api/generated_rpc_schema/chain.json
+++ b/rpc/api/generated_rpc_schema/chain.json
@@ -2990,6 +2990,114 @@
       }
     },
     {
+      "name": "chain.get_block_info_by_hash",
+      "params": [
+        {
+          "name": "id",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "HashValue",
+            "type": "string",
+            "format": "HashValue"
+          }
+        }
+      ],
+      "result": {
+        "name": "Option < BlockInfoView >",
+        "schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "title": "Nullable_BlockInfoView",
+          "type": [
+            "object",
+            "null"
+          ],
+          "required": [
+            "block_accumulator_info",
+            "block_hash",
+            "total_difficulty",
+            "txn_accumulator_info"
+          ],
+          "properties": {
+            "block_accumulator_info": {
+              "description": "The block accumulator info.",
+              "type": "object",
+              "required": [
+                "accumulator_root",
+                "frozen_subtree_roots",
+                "num_leaves",
+                "num_nodes"
+              ],
+              "properties": {
+                "accumulator_root": {
+                  "description": "Accumulator root hash",
+                  "type": "string",
+                  "format": "HashValue"
+                },
+                "frozen_subtree_roots": {
+                  "description": "Frozen subtree roots of this accumulator.",
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "HashValue"
+                  }
+                },
+                "num_leaves": {
+                  "description": "The total number of leaves in this accumulator.",
+                  "type": "string"
+                },
+                "num_nodes": {
+                  "description": "The total number of nodes in this accumulator.",
+                  "type": "string"
+                }
+              }
+            },
+            "block_hash": {
+              "description": "Block hash",
+              "type": "string",
+              "format": "HashValue"
+            },
+            "total_difficulty": {
+              "description": "The total difficulty.",
+              "type": "string"
+            },
+            "txn_accumulator_info": {
+              "description": "The transaction accumulator info",
+              "type": "object",
+              "required": [
+                "accumulator_root",
+                "frozen_subtree_roots",
+                "num_leaves",
+                "num_nodes"
+              ],
+              "properties": {
+                "accumulator_root": {
+                  "description": "Accumulator root hash",
+                  "type": "string",
+                  "format": "HashValue"
+                },
+                "frozen_subtree_roots": {
+                  "description": "Frozen subtree roots of this accumulator.",
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "HashValue"
+                  }
+                },
+                "num_leaves": {
+                  "description": "The total number of leaves in this accumulator.",
+                  "type": "string"
+                },
+                "num_nodes": {
+                  "description": "The total number of nodes in this accumulator.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
       "name": "chain.get_block_info_by_number2",
       "params": [
         {

--- a/rpc/api/generated_rpc_schema/sync_manager.json
+++ b/rpc/api/generated_rpc_schema/sync_manager.json
@@ -9,10 +9,10 @@
       "name": "sync.status",
       "params": [],
       "result": {
-        "name": "SyncStatus",
+        "name": "SyncStatusView",
         "schema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "title": "SyncStatus",
+          "title": "SyncStatusView",
           "type": "object",
           "required": [
             "chain_status",
@@ -20,7 +20,6 @@
           ],
           "properties": {
             "chain_status": {
-              "description": "The latest status of a chain.",
               "type": "object",
               "required": [
                 "head",
@@ -33,6 +32,7 @@
                   "required": [
                     "author",
                     "block_accumulator_root",
+                    "block_hash",
                     "body_hash",
                     "chain_id",
                     "difficulty",
@@ -55,14 +55,18 @@
                       "format": "AccountAddress"
                     },
                     "author_auth_key": {
-                      "description": "Block author auth key. this field is deprecated",
+                      "description": "Block author auth key.",
                       "type": [
                         "string",
                         "null"
                       ]
                     },
                     "block_accumulator_root": {
-                      "description": "The parent block info's block accumulator root hash.",
+                      "description": "The block accumulator root hash.",
+                      "type": "string",
+                      "format": "HashValue"
+                    },
+                    "block_hash": {
                       "type": "string",
                       "format": "HashValue"
                     },
@@ -73,17 +77,9 @@
                     },
                     "chain_id": {
                       "description": "The chain id",
-                      "type": "object",
-                      "required": [
-                        "id"
-                      ],
-                      "properties": {
-                        "id": {
-                          "type": "integer",
-                          "format": "uint8",
-                          "minimum": 0.0
-                        }
-                      }
+                      "type": "integer",
+                      "format": "uint8",
+                      "minimum": 0.0
                     },
                     "difficulty": {
                       "description": "Block difficulty",
@@ -95,9 +91,7 @@
                     },
                     "gas_used": {
                       "description": "Gas used for contracts execution.",
-                      "type": "integer",
-                      "format": "uint64",
-                      "minimum": 0.0
+                      "type": "string"
                     },
                     "nonce": {
                       "description": "Consensus nonce field.",
@@ -107,9 +101,7 @@
                     },
                     "number": {
                       "description": "Block number.",
-                      "type": "integer",
-                      "format": "uint64",
-                      "minimum": 0.0
+                      "type": "string"
                     },
                     "parent_hash": {
                       "description": "Parent hash.",
@@ -117,7 +109,7 @@
                       "format": "HashValue"
                     },
                     "parents_hash": {
-                      "description": "Parents hash.",
+                      "description": "DAG parents hash",
                       "type": "array",
                       "items": {
                         "type": "string",
@@ -125,7 +117,7 @@
                       }
                     },
                     "pruning_point": {
-                      "description": "pruning point",
+                      "description": "DAG pruning point",
                       "type": "string",
                       "format": "HashValue"
                     },
@@ -136,9 +128,7 @@
                     },
                     "timestamp": {
                       "description": "Block timestamp.",
-                      "type": "integer",
-                      "format": "uint64",
-                      "minimum": 0.0
+                      "type": "string"
                     },
                     "txn_accumulator_root": {
                       "description": "The transaction accumulator root hash after executing this block.",
@@ -146,7 +136,7 @@
                       "format": "HashValue"
                     },
                     "version": {
-                      "description": "Header version",
+                      "description": "DAG block version",
                       "type": "integer",
                       "format": "uint8",
                       "minimum": 0.0

--- a/rpc/api/generated_rpc_schema/txpool.json
+++ b/rpc/api/generated_rpc_schema/txpool.json
@@ -296,6 +296,302 @@
       }
     },
     {
+      "name": "txpool.submit_transactions",
+      "params": [
+        {
+          "name": "txs",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "Array_of_SignedUserTransaction",
+            "type": "array",
+            "items": {
+              "description": "A transaction that has been signed.\n\nA `SignedUserTransaction` is a single transaction that can be atomically executed. Clients submit these to validator nodes, and the validator and executor submits these to the VM.\n\n**IMPORTANT:** The signature of a `SignedUserTransaction` is not guaranteed to be verified. For a transaction whose signature is statically guaranteed to be verified, see [`SignatureCheckedTransaction`].",
+              "type": "object",
+              "required": [
+                "authenticator",
+                "raw_txn"
+              ],
+              "properties": {
+                "authenticator": {
+                  "description": "Public key and signature to authenticate",
+                  "oneOf": [
+                    {
+                      "description": "Single signature",
+                      "type": "object",
+                      "required": [
+                        "Ed25519"
+                      ],
+                      "properties": {
+                        "Ed25519": {
+                          "type": "object",
+                          "required": [
+                            "public_key",
+                            "signature"
+                          ],
+                          "properties": {
+                            "public_key": {
+                              "type": "string"
+                            },
+                            "signature": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    {
+                      "description": "K-of-N multisignature",
+                      "type": "object",
+                      "required": [
+                        "MultiEd25519"
+                      ],
+                      "properties": {
+                        "MultiEd25519": {
+                          "type": "object",
+                          "required": [
+                            "public_key",
+                            "signature"
+                          ],
+                          "properties": {
+                            "public_key": {
+                              "type": "string"
+                            },
+                            "signature": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
+                },
+                "raw_txn": {
+                  "description": "The raw transaction",
+                  "type": "object",
+                  "required": [
+                    "chain_id",
+                    "expiration_timestamp_secs",
+                    "gas_token_code",
+                    "gas_unit_price",
+                    "max_gas_amount",
+                    "payload",
+                    "sender",
+                    "sequence_number"
+                  ],
+                  "properties": {
+                    "chain_id": {
+                      "type": "object",
+                      "required": [
+                        "id"
+                      ],
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "format": "uint8",
+                          "minimum": 0.0
+                        }
+                      }
+                    },
+                    "expiration_timestamp_secs": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    },
+                    "gas_token_code": {
+                      "type": "string"
+                    },
+                    "gas_unit_price": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    },
+                    "max_gas_amount": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    },
+                    "payload": {
+                      "oneOf": [
+                        {
+                          "description": "A transaction that executes code.",
+                          "type": "object",
+                          "required": [
+                            "Script"
+                          ],
+                          "properties": {
+                            "Script": {
+                              "description": "Call a Move script.",
+                              "type": "object",
+                              "required": [
+                                "args",
+                                "code",
+                                "ty_args"
+                              ],
+                              "properties": {
+                                "args": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "code": {
+                                  "type": "string"
+                                },
+                                "ty_args": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        {
+                          "description": "A transaction that publish or update module code by a package.",
+                          "type": "object",
+                          "required": [
+                            "Package"
+                          ],
+                          "properties": {
+                            "Package": {
+                              "type": "object",
+                              "required": [
+                                "modules",
+                                "package_address"
+                              ],
+                              "properties": {
+                                "init_script": {
+                                  "description": "Call a Move script function.",
+                                  "type": [
+                                    "object",
+                                    "null"
+                                  ],
+                                  "required": [
+                                    "args",
+                                    "function",
+                                    "module",
+                                    "ty_args"
+                                  ],
+                                  "properties": {
+                                    "args": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "function": {
+                                      "type": "string"
+                                    },
+                                    "module": {
+                                      "type": "string"
+                                    },
+                                    "ty_args": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "modules": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "required": [
+                                      "code"
+                                    ],
+                                    "properties": {
+                                      "code": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "package_address": {
+                                  "description": "Package's all Module must at same address.",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        {
+                          "description": "A transaction that executes an existing script function published on-chain.",
+                          "type": "object",
+                          "required": [
+                            "ScriptFunction"
+                          ],
+                          "properties": {
+                            "ScriptFunction": {
+                              "description": "Call a Move script function.",
+                              "type": "object",
+                              "required": [
+                                "args",
+                                "function",
+                                "module",
+                                "ty_args"
+                              ],
+                              "properties": {
+                                "args": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "function": {
+                                  "type": "string"
+                                },
+                                "module": {
+                                  "type": "string"
+                                },
+                                "ty_args": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      ]
+                    },
+                    "sender": {
+                      "description": "Sender's address.",
+                      "type": "string"
+                    },
+                    "sequence_number": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "Vec < HashValue >",
+        "schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "title": "Array_of_HashValue",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "HashValue"
+          }
+        }
+      }
+    },
+    {
       "name": "txpool.submit_transaction2",
       "params": [
         {
@@ -2345,6 +2641,53 @@
           ],
           "format": "uint64",
           "minimum": 0.0
+        }
+      }
+    },
+    {
+      "name": "txpool.next_sequence_number_in_batch",
+      "params": [
+        {
+          "name": "addresses",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "Array_of_AccountAddress",
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "AccountAddress"
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "Option < Vec < (AccountAddress, Option < u64 >) > >",
+        "schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "title": "Nullable_Array_of_Tuple_of_AccountAddress_and_Nullable_uint64",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "array",
+            "items": [
+              {
+                "type": "string",
+                "format": "AccountAddress"
+              },
+              {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            ],
+            "maxItems": 2,
+            "minItems": 2
+          }
         }
       }
     },

--- a/rpc/api/src/account/mod.rs
+++ b/rpc/api/src/account/mod.rs
@@ -42,6 +42,12 @@ pub trait AccountApi {
         signer: AccountAddress,
     ) -> FutureResult<SignedUserTransaction>;
 
+    #[rpc(name = "account.sign_txn_in_batch")]
+    fn sign_txn_in_batch(
+        &self,
+        raw_txn: Vec<RawUserTransaction>,
+    ) -> FutureResult<Vec<SignedUserTransaction>>;
+
     /// unlock account for duration in seconds, default to u32::max.
     #[rpc(name = "account.unlock")]
     fn unlock(
@@ -50,6 +56,14 @@ pub trait AccountApi {
         password: String,
         duration: Option<u32>,
     ) -> FutureResult<AccountInfo>;
+
+    /// unlock accounts for duration in seconds, default to u32::max.
+    #[rpc(name = "account.unlock_in_batch")]
+    fn unlock_in_batch(
+        &self,
+        batch: Vec<(AccountAddress, String)>,
+        duration: Option<u32>,
+    ) -> FutureResult<Vec<AccountInfo>>;
 
     #[rpc(name = "account.lock")]
     fn lock(&self, address: AccountAddress) -> FutureResult<AccountInfo>;

--- a/rpc/api/src/chain/mod.rs
+++ b/rpc/api/src/chain/mod.rs
@@ -56,7 +56,7 @@ pub trait ChainApi {
     ) -> FutureResult<Vec<BlockView>>;
     #[rpc(name = "chain.get_block_info_by_number")]
     fn get_block_info_by_number(&self, number: BlockNumber) -> FutureResult<Option<BlockInfoView>>;
-    
+
     #[rpc(name = "chain.get_block_info_by_hash")]
     fn get_block_info_by_hash(&self, id: HashValue) -> FutureResult<Option<BlockInfoView>>;
 
@@ -184,7 +184,7 @@ pub trait ChainApi {
         event_index: Option<u64>,
         access_path: Option<StrView<AccessPath>>,
     ) -> FutureResult<Option<StrView<Vec<u8>>>>;
-    
+
     /// Get TransactionInfoWithProof2, if the block with `block_hash` or transaction with `transaction_global_index` do not exists, return None.
     /// if `event_index` is some, also return the EventWithProof in current transaction event_root
     /// if `access_path` is some, also return the StateWithProof in current transaction state_root

--- a/rpc/api/src/chain/mod.rs
+++ b/rpc/api/src/chain/mod.rs
@@ -56,6 +56,9 @@ pub trait ChainApi {
     ) -> FutureResult<Vec<BlockView>>;
     #[rpc(name = "chain.get_block_info_by_number")]
     fn get_block_info_by_number(&self, number: BlockNumber) -> FutureResult<Option<BlockInfoView>>;
+    
+    #[rpc(name = "chain.get_block_info_by_hash")]
+    fn get_block_info_by_hash(&self, id: HashValue) -> FutureResult<Option<BlockInfoView>>;
 
     #[rpc(name = "chain.get_block_info_by_number2")]
     fn get_block_info_by_number2(
@@ -181,7 +184,7 @@ pub trait ChainApi {
         event_index: Option<u64>,
         access_path: Option<StrView<AccessPath>>,
     ) -> FutureResult<Option<StrView<Vec<u8>>>>;
-
+    
     /// Get TransactionInfoWithProof2, if the block with `block_hash` or transaction with `transaction_global_index` do not exists, return None.
     /// if `event_index` is some, also return the EventWithProof in current transaction event_root
     /// if `access_path` is some, also return the StateWithProof in current transaction state_root

--- a/rpc/api/src/state/mod.rs
+++ b/rpc/api/src/state/mod.rs
@@ -141,7 +141,7 @@ pub struct ListResourceOption {
 
 impl Default for ListResourceOption {
     fn default() -> Self {
-        ListResourceOption {
+        Self {
             decode: false,
             state_root: None,
             start_index: 0,

--- a/rpc/api/src/sync_manager.rs
+++ b/rpc/api/src/sync_manager.rs
@@ -2,17 +2,16 @@
 // SPDX-License-Identifier: Apache-2
 
 pub use self::gen_client::Client as SyncManagerClient;
-use crate::FutureResult;
+use crate::{types::SyncStatusView, FutureResult};
 use network_api::PeerStrategy;
 use network_p2p_types::peer_id::PeerId;
 use openrpc_derive::openrpc;
 use starcoin_sync_api::{PeerScoreResponse, SyncProgressReport};
-use starcoin_types::sync_status::SyncStatus;
 
 #[openrpc]
 pub trait SyncManagerApi {
     #[rpc(name = "sync.status")]
-    fn status(&self) -> FutureResult<SyncStatus>;
+    fn status(&self) -> FutureResult<SyncStatusView>;
 
     #[rpc(name = "sync.cancel")]
     fn cancel(&self) -> FutureResult<()>;

--- a/rpc/api/src/txpool/mod.rs
+++ b/rpc/api/src/txpool/mod.rs
@@ -1,11 +1,11 @@
 // Copyright (c) The Starcoin Core Contributors
 // SPDX-License-Identifier: Apache-2
 
-use crate::FutureResult;
-use openrpc_derive::openrpc;
 pub use self::gen_client::Client as TxPoolClient;
 use crate::multi_types::MultiSignedUserTransactionView;
 use crate::types::{SignedUserTransactionView, StrView};
+use crate::FutureResult;
+use openrpc_derive::openrpc;
 use starcoin_crypto::HashValue;
 use starcoin_txpool_api::TxPoolStatus;
 use starcoin_types::{account_address::AccountAddress, transaction::SignedUserTransaction};
@@ -18,7 +18,7 @@ use starcoin_vm2_types::{
 pub trait TxPoolApi {
     #[rpc(name = "txpool.submit_transaction")]
     fn submit_transaction(&self, tx: SignedUserTransaction) -> FutureResult<HashValue>;
-    
+
     #[rpc(name = "txpool.submit_transactions")]
     fn submit_transactions(&self, txs: Vec<SignedUserTransaction>) -> FutureResult<Vec<HashValue>>;
 

--- a/rpc/api/src/txpool/mod.rs
+++ b/rpc/api/src/txpool/mod.rs
@@ -3,7 +3,6 @@
 
 use crate::FutureResult;
 use openrpc_derive::openrpc;
-
 pub use self::gen_client::Client as TxPoolClient;
 use crate::multi_types::MultiSignedUserTransactionView;
 use crate::types::{SignedUserTransactionView, StrView};
@@ -19,6 +18,9 @@ use starcoin_vm2_types::{
 pub trait TxPoolApi {
     #[rpc(name = "txpool.submit_transaction")]
     fn submit_transaction(&self, tx: SignedUserTransaction) -> FutureResult<HashValue>;
+    
+    #[rpc(name = "txpool.submit_transactions")]
+    fn submit_transactions(&self, txs: Vec<SignedUserTransaction>) -> FutureResult<Vec<HashValue>>;
 
     #[rpc(name = "txpool.submit_transaction2")]
     fn submit_transaction2(&self, tx: SignedUserTransaction2) -> FutureResult<HashValue>;
@@ -63,6 +65,14 @@ pub trait TxPoolApi {
     /// or `None` if there are no pending transactions from that sender in txpool.
     #[rpc(name = "txpool.next_sequence_number")]
     fn next_sequence_number(&self, address: AccountAddress) -> FutureResult<Option<u64>>;
+
+    /// Returns next valid sequence number for given sender
+    /// or `None` if there are no pending transactions from that sender in txpool.
+    #[rpc(name = "txpool.next_sequence_number_in_batch")]
+    fn next_sequence_number_in_batch(
+        &self,
+        addresses: Vec<AccountAddress>,
+    ) -> FutureResult<Option<Vec<(AccountAddress, Option<u64>)>>>;
 
     /// or `None` if there are no pending transactions from that sender in txpool.
     #[rpc(name = "txpool.state")]

--- a/rpc/api/src/types.rs
+++ b/rpc/api/src/types.rs
@@ -33,7 +33,6 @@ use starcoin_crypto::{CryptoMaterialError, HashValue, ValidCryptoMaterialStringE
 use starcoin_resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue};
 use starcoin_service_registry::ServiceRequest;
 use starcoin_state_api::{StateProof, StateWithProof, StateWithTableItemProof};
-use starcoin_types::{language_storage::StcTypeTag, startup_info::ChainStatus, sync_status::{SyncState, SyncStatus}};
 use starcoin_types::{
     account_address::AccountAddress,
     block::{Block, BlockBody, BlockHeader, BlockHeaderExtra, BlockInfo, BlockNumber},
@@ -52,6 +51,11 @@ use starcoin_types::{
     },
     vm_error::AbortLocation,
     U256,
+};
+use starcoin_types::{
+    language_storage::StcTypeTag,
+    startup_info::ChainStatus,
+    sync_status::{SyncState, SyncStatus},
 };
 use starcoin_vm_types::event::EventKey;
 use starcoin_vm_types::{

--- a/rpc/api/src/types.rs
+++ b/rpc/api/src/types.rs
@@ -33,7 +33,7 @@ use starcoin_crypto::{CryptoMaterialError, HashValue, ValidCryptoMaterialStringE
 use starcoin_resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue};
 use starcoin_service_registry::ServiceRequest;
 use starcoin_state_api::{StateProof, StateWithProof, StateWithTableItemProof};
-use starcoin_types::language_storage::StcTypeTag;
+use starcoin_types::{language_storage::StcTypeTag, startup_info::ChainStatus, sync_status::{SyncState, SyncStatus}};
 use starcoin_types::{
     account_address::AccountAddress,
     block::{Block, BlockBody, BlockHeader, BlockHeaderExtra, BlockInfo, BlockNumber},
@@ -229,7 +229,7 @@ pub struct TransactionRequest {
 
 impl From<RawUserTransaction> for TransactionRequest {
     fn from(raw: RawUserTransaction) -> Self {
-        let mut request = TransactionRequest {
+        let mut request = Self {
             sender: Some(raw.sender()),
             sequence_number: Some(raw.sequence_number()),
             script: None,
@@ -292,7 +292,7 @@ impl<'de> Deserialize<'de> for ArgumentsView {
         D: Deserializer<'de>,
     {
         let args = <Vec<TransactionArgumentView>>::deserialize(deserializer)?;
-        Ok(ArgumentsView::HumanReadable(args))
+        Ok(Self::HumanReadable(args))
     }
 }
 
@@ -364,7 +364,7 @@ impl Into<TransactionPayload> for ScriptData {
 impl From<Script> for ScriptData {
     fn from(s: Script) -> Self {
         let (code, ty_args, args) = s.into_inner();
-        ScriptData {
+        Self {
             code: StrView(ByteCodeOrScriptFunction::ByteCode(code)),
             type_args: ty_args.into_iter().map(TypeTagView::from).collect(),
             args: ArgumentsView::BCS(args.into_iter().map(StrView).collect()),
@@ -375,7 +375,7 @@ impl From<Script> for ScriptData {
 impl From<ScriptFunction> for ScriptData {
     fn from(s: ScriptFunction) -> Self {
         let (module, function, ty_args, args) = s.into_inner();
-        ScriptData {
+        Self {
             code: StrView(ByteCodeOrScriptFunction::ScriptFunction(FunctionId {
                 module,
                 function,
@@ -395,8 +395,8 @@ pub enum ByteCodeOrScriptFunction {
 impl std::fmt::Display for ByteCodeOrScriptFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self {
-            ByteCodeOrScriptFunction::ByteCode(c) => write!(f, "0x{}", hex::encode(c)),
-            ByteCodeOrScriptFunction::ScriptFunction(FunctionId { module, function }) => {
+            Self::ByteCode(c) => write!(f, "0x{}", hex::encode(c)),
+            Self::ScriptFunction(FunctionId { module, function }) => {
                 write!(f, "{}::{}", module, function)
             }
         }
@@ -410,12 +410,12 @@ impl FromStr for ByteCodeOrScriptFunction {
         if splits.len() == 2 {
             let module_id = ModuleIdView::from_str(splits[1])?;
             let function = Identifier::new(splits[0])?;
-            Ok(ByteCodeOrScriptFunction::ScriptFunction(FunctionId {
+            Ok(Self::ScriptFunction(FunctionId {
                 module: module_id.0,
                 function,
             }))
         } else {
-            Ok(ByteCodeOrScriptFunction::ByteCode(hex::decode(
+            Ok(Self::ByteCode(hex::decode(
                 s.strip_prefix("0x").unwrap_or(s),
             )?))
         }
@@ -464,7 +464,7 @@ pub struct BlockHeaderView {
 
 impl From<BlockHeader> for BlockHeaderView {
     fn from(origin: BlockHeader) -> Self {
-        BlockHeaderView {
+        Self {
             block_hash: origin.id(),
             parent_hash: origin.parent_hash(),
             timestamp: origin.timestamp().into(),
@@ -489,7 +489,7 @@ impl From<BlockHeader> for BlockHeaderView {
 
 impl From<BlockHeaderView> for BlockHeader {
     fn from(header_view: BlockHeaderView) -> Self {
-        BlockHeader::new(
+        Self::new(
             header_view.parent_hash,
             header_view.timestamp.0,
             header_view.number.0,
@@ -553,7 +553,7 @@ impl TryFrom<RawUserTransaction> for RawUserTransactionView {
     type Error = anyhow::Error;
 
     fn try_from(origin: RawUserTransaction) -> Result<Self, Self::Error> {
-        Ok(RawUserTransactionView {
+        Ok(Self {
             sender: origin.sender(),
             sequence_number: origin.sequence_number().into(),
             max_gas_amount: origin.max_gas_amount().into(),
@@ -569,7 +569,7 @@ impl TryFrom<RawUserTransaction> for RawUserTransactionView {
 
 impl From<RawUserTransactionView> for RawUserTransaction {
     fn from(transaction_view: RawUserTransactionView) -> Self {
-        RawUserTransaction::new(
+        Self::new(
             transaction_view.sender,
             transaction_view.sequence_number.0,
             TransactionPayload::decode(transaction_view.payload.0.as_slice()).unwrap(),
@@ -995,7 +995,7 @@ impl TryFrom<BlockView> for Block {
             .collect();
         let transactions = block_view.body.try_into()?;
 
-        Ok(Block {
+        Ok(Self {
             header: block_header,
             body: BlockBody::new(transactions, Some(uncles)),
         })
@@ -1030,7 +1030,7 @@ pub struct TransactionInfoView {
 
 impl TransactionInfoView {
     pub fn new(txn_info: RichTransactionInfo) -> Self {
-        TransactionInfoView {
+        Self {
             block_hash: txn_info.block_id,
             block_number: txn_info.block_number.into(),
             transaction_hash: txn_info.transaction_hash,
@@ -1046,7 +1046,7 @@ impl TransactionInfoView {
 
 impl From<RichTransactionInfo> for TransactionInfoView {
     fn from(txn_info: RichTransactionInfo) -> Self {
-        TransactionInfoView::new(txn_info)
+        Self::new(txn_info)
     }
 }
 
@@ -1056,7 +1056,7 @@ impl TryFrom<TransactionInfoView> for RichTransactionInfo {
     fn try_from(view: TransactionInfoView) -> Result<Self, Self::Error> {
         let status: TransactionStatus = view.status.clone().into();
         match status {
-            TransactionStatus::Keep(kept_status) => Ok(RichTransactionInfo::new(
+            TransactionStatus::Keep(kept_status) => Ok(Self::new(
                 view.block_hash,
                 view.block_number.0,
                 TransactionInfo {
@@ -1119,9 +1119,9 @@ impl From<TransactionStatus> for TransactionStatusView {
 impl From<KeptVMStatus> for TransactionStatusView {
     fn from(origin: KeptVMStatus) -> Self {
         match origin {
-            KeptVMStatus::Executed => TransactionStatusView::Executed,
-            KeptVMStatus::OutOfGas => TransactionStatusView::OutOfGas,
-            KeptVMStatus::MoveAbort(l, c) => TransactionStatusView::MoveAbort {
+            KeptVMStatus::Executed => Self::Executed,
+            KeptVMStatus::OutOfGas => Self::OutOfGas,
+            KeptVMStatus::MoveAbort(l, c) => Self::MoveAbort {
                 location: l,
                 abort_code: c.into(),
             },
@@ -1129,12 +1129,12 @@ impl From<KeptVMStatus> for TransactionStatusView {
                 location,
                 function,
                 code_offset,
-            } => TransactionStatusView::ExecutionFailure {
+            } => Self::ExecutionFailure {
                 location,
                 function,
                 code_offset,
             },
-            KeptVMStatus::MiscellaneousError => TransactionStatusView::MiscellaneousError,
+            KeptVMStatus::MiscellaneousError => Self::MiscellaneousError,
         }
     }
 }
@@ -1151,20 +1151,20 @@ impl From<DiscardedVMStatus> for TransactionStatusView {
 impl From<TransactionStatusView> for TransactionStatus {
     fn from(value: TransactionStatusView) -> Self {
         match value {
-            TransactionStatusView::Executed => TransactionStatus::Keep(KeptVMStatus::Executed),
-            TransactionStatusView::OutOfGas => TransactionStatus::Keep(KeptVMStatus::OutOfGas),
+            TransactionStatusView::Executed => Self::Keep(KeptVMStatus::Executed),
+            TransactionStatusView::OutOfGas => Self::Keep(KeptVMStatus::OutOfGas),
             TransactionStatusView::MoveAbort {
                 location,
                 abort_code,
-            } => TransactionStatus::Keep(KeptVMStatus::MoveAbort(location, abort_code.0)),
+            } => Self::Keep(KeptVMStatus::MoveAbort(location, abort_code.0)),
             TransactionStatusView::MiscellaneousError => {
-                TransactionStatus::Keep(KeptVMStatus::MiscellaneousError)
+                Self::Keep(KeptVMStatus::MiscellaneousError)
             }
             TransactionStatusView::ExecutionFailure {
                 location,
                 function,
                 code_offset,
-            } => TransactionStatus::Keep(KeptVMStatus::ExecutionFailure {
+            } => Self::Keep(KeptVMStatus::ExecutionFailure {
                 location,
                 function,
                 code_offset,
@@ -1172,14 +1172,14 @@ impl From<TransactionStatusView> for TransactionStatus {
             TransactionStatusView::Discard {
                 status_code,
                 status_code_name: _,
-            } => TransactionStatus::Discard(
+            } => Self::Discard(
                 status_code
                     .0
                     .try_into()
                     .ok()
                     .unwrap_or(StatusCode::UNKNOWN_STATUS),
             ),
-            TransactionStatusView::Retry => TransactionStatus::Retry,
+            TransactionStatusView::Retry => Self::Retry,
         }
     }
 }
@@ -1215,7 +1215,7 @@ pub struct TransactionEventView {
 
 impl From<ContractEventInfo> for TransactionEventView {
     fn from(info: ContractEventInfo) -> Self {
-        TransactionEventView {
+        Self {
             block_hash: Some(info.block_hash),
             block_number: Some(info.block_number.into()),
             transaction_hash: Some(info.transaction_hash),
@@ -1229,9 +1229,10 @@ impl From<ContractEventInfo> for TransactionEventView {
         }
     }
 }
+
 impl From<ContractEvent> for TransactionEventView {
     fn from(event: ContractEvent) -> Self {
-        TransactionEventView {
+        Self {
             block_hash: None,
             block_number: None,
             transaction_hash: None,
@@ -1331,7 +1332,7 @@ impl From<(AccessPath, WriteOp)> for TransactionOutputAction {
             ),
         };
 
-        TransactionOutputAction {
+        Self {
             access_path,
             action,
             value,
@@ -1365,7 +1366,7 @@ impl From<(TableItem, WriteOp)> for TransactionOutputTableItemAction {
             WriteOp::Value(v) => (WriteOpView::Value, Some(StrView(v))),
         };
 
-        TransactionOutputTableItemAction {
+        Self {
             table_item: table_item.into(),
             action,
             value,
@@ -1494,7 +1495,7 @@ impl From<StateWithProofView> for StateWithProof {
             view.account_proof.into(),
             view.account_state_proof.into(),
         );
-        StateWithProof::new(state, proof)
+        Self::new(state, proof)
     }
 }
 
@@ -1545,7 +1546,7 @@ impl From<StateWithTableItemProofView> for StateWithTableItemProof {
             SparseMerkleProof::from(view.key_proof.1),
             view.key_proof.2,
         );
-        StateWithTableItemProof::new(state_proof, table_handle_proof, key_proof)
+        Self::new(state_proof, table_handle_proof, key_proof)
     }
 }
 
@@ -1590,7 +1591,7 @@ impl TryFrom<EventWithProofView> for EventWithProof {
     type Error = anyhow::Error;
 
     fn try_from(value: EventWithProofView) -> Result<Self, Self::Error> {
-        Ok(EventWithProof {
+        Ok(Self {
             event: ContractEvent::decode(value.event.0.as_slice())?,
             proof: value.proof.into(),
         })
@@ -1620,7 +1621,7 @@ impl TryFrom<TransactionInfoWithProofView> for TransactionInfoWithProof {
     type Error = anyhow::Error;
 
     fn try_from(view: TransactionInfoWithProofView) -> Result<Self, Self::Error> {
-        Ok(TransactionInfoWithProof {
+        Ok(Self {
             transaction_info: view.transaction_info.try_into()?,
             proof: view.proof.into(),
             event_proof: view.event_proof.map(TryInto::try_into).transpose()?,
@@ -1962,7 +1963,7 @@ impl AccumulatorInfoView {
 
 impl From<AccumulatorInfo> for AccumulatorInfoView {
     fn from(info: AccumulatorInfo) -> Self {
-        AccumulatorInfoView {
+        Self {
             accumulator_root: info.accumulator_root,
             frozen_subtree_roots: info.frozen_subtree_roots.clone(),
             num_leaves: info.num_leaves.into(),
@@ -1999,7 +2000,7 @@ impl BlockInfoView {
 
 impl From<BlockInfo> for BlockInfoView {
     fn from(block_info: BlockInfo) -> Self {
-        BlockInfoView {
+        Self {
             block_hash: block_info.block_id,
             total_difficulty: block_info.total_difficulty,
             txn_accumulator_info: block_info.txn_accumulator_info.into(),
@@ -2065,6 +2066,53 @@ impl From<TableInfoView> for TableInfo {
         Self {
             key_type: value.key_type.0,
             value_type: value.value_type.0,
+        }
+    }
+}
+
+#[derive(Eq, PartialEq, Deserialize, Serialize, Clone, Debug, JsonSchema)]
+pub struct ChainStatusView {
+    /// Chain head block's header.
+    pub head: BlockHeaderView,
+    /// Chain block info
+    pub info: BlockInfo,
+}
+
+impl From<ChainStatusView> for ChainStatus {
+    fn from(value: ChainStatusView) -> Self {
+        Self {
+            head: value.head.into(),
+            info: value.info,
+        }
+    }
+}
+
+impl From<ChainStatus> for ChainStatusView {
+    fn from(value: ChainStatus) -> Self {
+        Self {
+            head: value.head.into(),
+            info: value.info,
+        }
+    }
+}
+
+#[derive(Eq, PartialEq, Deserialize, Serialize, Clone, Debug, JsonSchema)]
+pub struct SyncStatusView {
+    pub chain_status: ChainStatusView,
+    pub state: SyncState,
+}
+
+impl From<SyncStatusView> for SyncStatus {
+    fn from(value: SyncStatusView) -> Self {
+        Self::new_with_state(value.chain_status.into(), value.state)
+    }
+}
+
+impl From<SyncStatus> for SyncStatusView {
+    fn from(value: SyncStatus) -> Self {
+        Self {
+            chain_status: value.chain_status().clone().into(),
+            state: value.sync_status().clone(),
         }
     }
 }

--- a/rpc/api/src/types/node_api_types.rs
+++ b/rpc/api/src/types/node_api_types.rs
@@ -14,11 +14,11 @@ pub struct ChainId {
 impl From<&ChainNetworkID> for ChainId {
     fn from(id: &ChainNetworkID) -> Self {
         match id {
-            ChainNetworkID::Builtin(t) => ChainId {
+            ChainNetworkID::Builtin(t) => Self {
                 name: t.chain_name(),
                 id: t.chain_id().id(),
             },
-            ChainNetworkID::Custom(t) => ChainId {
+            ChainNetworkID::Custom(t) => Self {
                 name: t.chain_name().to_string(),
                 id: t.chain_id().id(),
             },
@@ -37,9 +37,9 @@ impl FromStr for FactoryAction {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s.to_lowercase().as_str() {
-            "stop" => FactoryAction::Stop,
-            "start" => FactoryAction::Start,
-            _ => FactoryAction::Status, //default is status action
+            "stop" => Self::Stop,
+            "start" => Self::Start,
+            _ => Self::Status, //default is status action
         })
     }
 }

--- a/rpc/client/Cargo.toml
+++ b/rpc/client/Cargo.toml
@@ -51,6 +51,7 @@ starcoin-vm2-account-api = { workspace = true }
 starcoin-vm2-crypto = { workspace = true }
 starcoin-vm2-abi-types = { workspace = true }
 starcoin-vm2-state-api = { workspace = true }
+starcoin-dag = { workspace = true }
 
 [dev-dependencies]
 starcoin-config = { workspace = true }

--- a/rpc/client/src/chain_watcher.rs
+++ b/rpc/client/src/chain_watcher.rs
@@ -24,7 +24,7 @@ pub struct ThinHeadBlock {
 
 impl From<BlockView> for ThinHeadBlock {
     fn from(view: BlockView) -> Self {
-        ThinHeadBlock {
+        Self {
             header: view.header,
             txn_hashes: view.body.txn_hashes(),
         }

--- a/rpc/client/src/lib.rs
+++ b/rpc/client/src/lib.rs
@@ -36,7 +36,13 @@ use starcoin_rpc_api::state::{
 };
 use starcoin_rpc_api::types::pubsub::{EventFilter, EventFilterV2};
 use starcoin_rpc_api::types::{
-    AccountStateSetView, AnnotatedMoveStructView, BlockHeaderView, BlockInfoView, BlockView, ChainId, ChainInfoView, CodeView, ContractCall, DecodedMoveValue, DryRunOutputView, DryRunTransactionRequest, FactoryAction, FunctionIdView, ListCodeView, ListResourceView, MintedBlockView, ModuleIdView, MultiStateView, PeerInfoView, ResourceView, SignedMessageView, StateWithProofView, StateWithTableItemProofView, StrView, StructTagView, SyncStatusView, TransactionEventResponse, TransactionEventView, TransactionInfoView, TransactionInfoWithProofView, TransactionRequest, TransactionView
+    AccountStateSetView, AnnotatedMoveStructView, BlockHeaderView, BlockInfoView, BlockView,
+    ChainId, ChainInfoView, CodeView, ContractCall, DecodedMoveValue, DryRunOutputView,
+    DryRunTransactionRequest, FactoryAction, FunctionIdView, ListCodeView, ListResourceView,
+    MintedBlockView, ModuleIdView, MultiStateView, PeerInfoView, ResourceView, SignedMessageView,
+    StateWithProofView, StateWithTableItemProofView, StrView, StructTagView, SyncStatusView,
+    TransactionEventResponse, TransactionEventView, TransactionInfoView,
+    TransactionInfoWithProofView, TransactionRequest, TransactionView,
 };
 use starcoin_rpc_api::{
     account::AccountClient, chain::ChainClient, contract_api::ContractClient, debug::DebugClient,
@@ -843,7 +849,7 @@ impl RpcClient {
         self.call_rpc_blocking(|inner| inner.chain_client.get_block_info_by_number2(number))
             .map_err(map_err)
     }
-    
+
     pub fn chain_get_block_info_by_hash(
         &self,
         id: HashValue,

--- a/rpc/client/src/lib.rs
+++ b/rpc/client/src/lib.rs
@@ -36,13 +36,7 @@ use starcoin_rpc_api::state::{
 };
 use starcoin_rpc_api::types::pubsub::{EventFilter, EventFilterV2};
 use starcoin_rpc_api::types::{
-    AccountStateSetView, AnnotatedMoveStructView, BlockHeaderView, BlockInfoView, BlockView,
-    ChainId, ChainInfoView, CodeView, ContractCall, DecodedMoveValue, DryRunOutputView,
-    DryRunTransactionRequest, FactoryAction, FunctionIdView, ListCodeView, ListResourceView,
-    MintedBlockView, ModuleIdView, MultiStateView, PeerInfoView, ResourceView, SignedMessageView,
-    StateWithProofView, StateWithTableItemProofView, StrView, StructTagView,
-    TransactionEventResponse, TransactionEventView, TransactionInfoView,
-    TransactionInfoWithProofView, TransactionRequest, TransactionView,
+    AccountStateSetView, AnnotatedMoveStructView, BlockHeaderView, BlockInfoView, BlockView, ChainId, ChainInfoView, CodeView, ContractCall, DecodedMoveValue, DryRunOutputView, DryRunTransactionRequest, FactoryAction, FunctionIdView, ListCodeView, ListResourceView, MintedBlockView, ModuleIdView, MultiStateView, PeerInfoView, ResourceView, SignedMessageView, StateWithProofView, StateWithTableItemProofView, StrView, StructTagView, SyncStatusView, TransactionEventResponse, TransactionEventView, TransactionInfoView, TransactionInfoWithProofView, TransactionRequest, TransactionView
 };
 use starcoin_rpc_api::{
     account::AccountClient, chain::ChainClient, contract_api::ContractClient, debug::DebugClient,
@@ -58,7 +52,6 @@ use starcoin_types::account_address::AccountAddress;
 use starcoin_types::account_state::AccountState;
 use starcoin_types::block::BlockNumber;
 use starcoin_types::sign_message::SigningMessage;
-use starcoin_types::sync_status::SyncStatus;
 use starcoin_types::system_events::MintBlockEvent;
 use starcoin_types::transaction::{RawUserTransaction, SignedUserTransaction};
 use starcoin_vm2_rpc_api::block_info_view2::BlockInfoView2;
@@ -97,9 +90,9 @@ pub enum ConnSource {
 impl std::fmt::Debug for ConnSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ConnSource::Ipc(path) => write!(f, "Ipc({})", path.as_path().to_string_lossy()),
-            ConnSource::WebSocket(url) => write!(f, "WebSocket({})", url),
-            ConnSource::Local(_) => write!(f, "Local"),
+            Self::Ipc(path) => write!(f, "Ipc({})", path.as_path().to_string_lossy()),
+            Self::WebSocket(url) => write!(f, "WebSocket({})", url),
+            Self::Local(_) => write!(f, "Local"),
         }
     }
 }
@@ -315,8 +308,24 @@ impl RpcClient {
             .map_err(map_err)
     }
 
+    pub fn next_sequence_number_in_batch(
+        &self,
+        addresses: Vec<AccountAddress>,
+    ) -> anyhow::Result<Option<Vec<(AccountAddress, Option<u64>)>>> {
+        self.call_rpc_blocking(|inner| inner.txpool_client.next_sequence_number_in_batch(addresses))
+            .map_err(map_err)
+    }
+
     pub fn submit_transaction(&self, txn: SignedUserTransaction) -> anyhow::Result<HashValue> {
         self.call_rpc_blocking(|inner| inner.txpool_client.submit_transaction(txn))
+            .map_err(map_err)
+    }
+
+    pub fn submit_transactions(
+        &self,
+        txns: Vec<SignedUserTransaction>,
+    ) -> anyhow::Result<Vec<HashValue>> {
+        self.call_rpc_blocking(|inner| inner.txpool_client.submit_transactions(txns))
             .map_err(map_err)
     }
 
@@ -401,6 +410,14 @@ impl RpcClient {
             .map_err(map_err)
     }
 
+    pub fn account_sign_txn_in_batch(
+        &self,
+        raw_txns: Vec<RawUserTransaction>,
+    ) -> anyhow::Result<Vec<SignedUserTransaction>> {
+        self.call_rpc_blocking(|inner| inner.account_client.sign_txn_in_batch(raw_txns))
+            .map_err(map_err)
+    }
+
     pub fn account_sign_message(
         &self,
         signer: AccountAddress,
@@ -437,6 +454,19 @@ impl RpcClient {
             inner
                 .account_client
                 .unlock(address, password, Some(duration.as_secs() as u32))
+        })
+        .map_err(map_err)
+    }
+
+    pub fn account_unlock_in_batch(
+        &self,
+        batch: Vec<(AccountAddress, String)>,
+        duration: std::time::Duration,
+    ) -> anyhow::Result<Vec<AccountInfo>> {
+        self.call_rpc_blocking(|inner| {
+            inner
+                .account_client
+                .unlock_in_batch(batch, Some(duration.as_secs() as u32))
         })
         .map_err(map_err)
     }
@@ -813,6 +843,14 @@ impl RpcClient {
         self.call_rpc_blocking(|inner| inner.chain_client.get_block_info_by_number2(number))
             .map_err(map_err)
     }
+    
+    pub fn chain_get_block_info_by_hash(
+        &self,
+        id: HashValue,
+    ) -> anyhow::Result<Option<BlockInfoView>> {
+        self.call_rpc_blocking(|inner| inner.chain_client.get_block_info_by_hash(id))
+            .map_err(map_err)
+    }
 
     pub fn chain_get_blocks_by_number(
         &self,
@@ -1083,7 +1121,7 @@ impl RpcClient {
         result
     }
 
-    pub fn sync_status(&self) -> anyhow::Result<SyncStatus> {
+    pub fn sync_status(&self) -> anyhow::Result<SyncStatusView> {
         self.call_rpc_blocking(|inner| inner.sync_client.status())
             .map_err(map_err)
     }

--- a/rpc/client/src/pubsub_client.rs
+++ b/rpc/client/src/pubsub_client.rs
@@ -24,7 +24,7 @@ impl std::fmt::Debug for PubSubClient {
 
 impl From<RpcChannel> for PubSubClient {
     fn from(channel: RpcChannel) -> Self {
-        PubSubClient {
+        Self {
             client: channel.into(),
         }
     }

--- a/rpc/client/src/remote_state_reader.rs
+++ b/rpc/client/src/remote_state_reader.rs
@@ -28,9 +28,9 @@ impl FromStr for StateRootOption {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Ok(number) = s.parse::<u64>() {
-            Ok(StateRootOption::BlockNumber(number))
+            Ok(Self::BlockNumber(number))
         } else {
-            Ok(StateRootOption::BlockHash(HashValue::from_str(s)?))
+            Ok(Self::BlockHash(HashValue::from_str(s)?))
         }
     }
 }

--- a/rpc/middleware/src/lib.rs
+++ b/rpc/middleware/src/lib.rs
@@ -24,9 +24,9 @@ enum CallType {
 impl fmt::Display for CallType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let call_type = match self {
-            CallType::MethodCall => "method",
-            CallType::Notification => "notification",
-            CallType::Invalid => "invalid",
+            Self::MethodCall => "method",
+            Self::Notification => "notification",
+            Self::Invalid => "invalid",
         };
         write!(f, "{}", call_type)
     }
@@ -43,20 +43,20 @@ struct RpcCallRecord {
 impl RpcCallRecord {
     pub fn with_call(call: &Call) -> Self {
         match call {
-            Call::MethodCall(method_call) => RpcCallRecord::new(
+            Call::MethodCall(method_call) => Self::new(
                 id_to_string(&method_call.id),
                 Some(method_call.method.clone()),
                 CallType::MethodCall,
                 method_call.params.clone(),
             ),
-            Call::Notification(notification) => RpcCallRecord::new(
+            Call::Notification(notification) => Self::new(
                 "0".to_owned(),
                 Some(notification.method.clone()),
                 CallType::Notification,
                 notification.params.clone(),
             ),
             Call::Invalid { id } => {
-                RpcCallRecord::new(id_to_string(id), None, CallType::Invalid, Params::None)
+                Self::new(id_to_string(id), None, CallType::Invalid, Params::None)
             }
         }
     }

--- a/rpc/server/Cargo.toml
+++ b/rpc/server/Cargo.toml
@@ -77,9 +77,10 @@ starcoin-vm2-types = { workspace = true }
 starcoin-vm2-resource-viewer = { workspace = true }
 starcoin-vm2-vm-types = { workspace = true }
 
+starcoin-dag = { workspace = true }
+
 [dev-dependencies]
 starcoin-chain-mock = { workspace = true }
-starcoin-dag = { workspace = true }
 starcoin-executor = { workspace = true }
 starcoin-genesis = { workspace = true }
 starcoin-rpc-client = { workspace = true }

--- a/rpc/server/src/api_registry.rs
+++ b/rpc/server/src/api_registry.rs
@@ -17,7 +17,7 @@ pub struct ApiRegistry {
 }
 
 impl ApiRegistry {
-    pub fn new(api_quotas: ApiQuotaConfiguration, metrics: Option<RpcMetrics>) -> ApiRegistry {
+    pub fn new(api_quotas: ApiQuotaConfiguration, metrics: Option<RpcMetrics>) -> Self {
         Self {
             apis: Default::default(),
             quotas: api_quotas,

--- a/rpc/server/src/module/account_rpc.rs
+++ b/rpc/server/src/module/account_rpc.rs
@@ -161,6 +161,19 @@ where
         Box::pin(fut.boxed())
     }
 
+    fn sign_txn_in_batch(
+        &self,
+        raw_txn: Vec<RawUserTransaction>,
+    ) -> FutureResult<Vec<SignedUserTransaction>> {
+        let service = self.account.clone();
+        let fut = async move {
+            let result = service.sign_txn_in_batch(raw_txn).await?;
+            Ok(result)
+        }
+        .map_err(map_err);
+        Box::pin(fut.boxed())
+    }
+
     fn unlock(
         &self,
         address: AccountAddress,
@@ -173,6 +186,24 @@ where
                 .unlock_account(
                     address,
                     password,
+                    Duration::from_secs(duration.unwrap_or(u32::MAX) as u64),
+                )
+                .await
+        }
+        .map_err(map_err);
+        Box::pin(fut.boxed())
+    }
+
+    fn unlock_in_batch(
+        &self,
+        batch: Vec<(AccountAddress, String)>,
+        duration: Option<u32>,
+    ) -> FutureResult<Vec<AccountInfo>> {
+        let service = self.account.clone();
+        let fut = async move {
+            service
+                .unlock_account_in_batch(
+                    batch,
                     Duration::from_secs(duration.unwrap_or(u32::MAX) as u64),
                 )
                 .await

--- a/rpc/server/src/module/chain_rpc.rs
+++ b/rpc/server/src/module/chain_rpc.rs
@@ -78,7 +78,7 @@ where
 
 impl<S> ChainApi for ChainRpcImpl<S>
 where
-    S: ChainAsyncService,
+    S: ChainAsyncService
 {
     fn id(&self) -> jsonrpc_core::Result<ChainId> {
         Ok(self.config.net().id().into())
@@ -199,6 +199,18 @@ where
                 .get_block_info_by_number(number)
                 .await?
                 .map(Into::into);
+            Ok(result)
+        }
+        .map_err(map_err);
+
+        Box::pin(fut.boxed())
+    }
+    
+    fn get_block_info_by_hash(&self, id: HashValue) -> FutureResult<Option<BlockInfoView>> {
+        let service = self.service.clone();
+
+        let fut = async move {
+            let result = service.get_block_info_by_hash(&id).await?.map(Into::into);
             Ok(result)
         }
         .map_err(map_err);
@@ -701,7 +713,7 @@ where
 
         Box::pin(fut.boxed())
     }
-
+    
     fn get_transaction_proof2(
         &self,
         block_hash: HashValue,

--- a/rpc/server/src/module/chain_rpc.rs
+++ b/rpc/server/src/module/chain_rpc.rs
@@ -78,7 +78,7 @@ where
 
 impl<S> ChainApi for ChainRpcImpl<S>
 where
-    S: ChainAsyncService
+    S: ChainAsyncService,
 {
     fn id(&self) -> jsonrpc_core::Result<ChainId> {
         Ok(self.config.net().id().into())
@@ -205,7 +205,7 @@ where
 
         Box::pin(fut.boxed())
     }
-    
+
     fn get_block_info_by_hash(&self, id: HashValue) -> FutureResult<Option<BlockInfoView>> {
         let service = self.service.clone();
 
@@ -713,7 +713,7 @@ where
 
         Box::pin(fut.boxed())
     }
-    
+
     fn get_transaction_proof2(
         &self,
         block_hash: HashValue,

--- a/rpc/server/src/module/mod.rs
+++ b/rpc/server/src/module/mod.rs
@@ -249,7 +249,7 @@ impl From<TransactionError2> for RpcError {
                     ),
                 ),
             },
-            TransactionError2::ApiInterrupted(err_message) => (ErrorCode::InternalError, None),
+            TransactionError2::ApiInterrupted(_) => (ErrorCode::InternalError, None),
         };
         RpcError(jsonrpc_core::Error {
             code: err_code,

--- a/rpc/server/src/module/mod.rs
+++ b/rpc/server/src/module/mod.rs
@@ -120,36 +120,36 @@ impl From<TransactionError> for RpcError {
         let err_message = err.to_string();
         let (err_code, err_data) = match err {
             TransactionError::AlreadyImported
-                    | TransactionError::Old
-                    | TransactionError::InsufficientGasPrice { .. }
-                    | TransactionError::TooCheapToReplace { .. }
-                    | TransactionError::InsufficientGas { .. }
-                    | TransactionError::InsufficientBalance { .. }
-                    | TransactionError::GasLimitExceeded { .. }
-                    | TransactionError::SenderBanned
-                    | TransactionError::RecipientBanned
-                    | TransactionError::CodeBanned
-                    | TransactionError::InvalidChainId
-                    | TransactionError::InvalidSignature(..)
-                    | TransactionError::NotAllowed
-                    | TransactionError::TooBig => (ErrorCode::InvalidParams, None),
+            | TransactionError::Old
+            | TransactionError::InsufficientGasPrice { .. }
+            | TransactionError::TooCheapToReplace { .. }
+            | TransactionError::InsufficientGas { .. }
+            | TransactionError::InsufficientBalance { .. }
+            | TransactionError::GasLimitExceeded { .. }
+            | TransactionError::SenderBanned
+            | TransactionError::RecipientBanned
+            | TransactionError::CodeBanned
+            | TransactionError::InvalidChainId
+            | TransactionError::InvalidSignature(..)
+            | TransactionError::NotAllowed
+            | TransactionError::TooBig => (ErrorCode::InvalidParams, None),
             TransactionError::LimitReached(..) => (ErrorCode::ServerError(TXN_ERROR_BASE), None),
             TransactionError::CallErr(call_err) => match call_err {
-                        CallError::TransactionNotFound => (ErrorCode::InvalidParams, None),
-                        CallError::StatePruned | CallError::StateCorrupt => {
-                            (ErrorCode::ServerError(TXN_ERROR_BASE + 1), None)
-                        }
-                        CallError::ExecutionError(vm_status) => (
-                            ErrorCode::ServerError(TXN_ERROR_BASE + 2),
-                            Some(
-                                // translate to jsonrpc types
-                                serde_json::to_value(TransactionStatusView::from(TransactionStatus::from(
-                                    vm_status,
-                                )))
-                                .expect("vm status to json should be ok"),
-                            ),
-                        ),
-                    },
+                CallError::TransactionNotFound => (ErrorCode::InvalidParams, None),
+                CallError::StatePruned | CallError::StateCorrupt => {
+                    (ErrorCode::ServerError(TXN_ERROR_BASE + 1), None)
+                }
+                CallError::ExecutionError(vm_status) => (
+                    ErrorCode::ServerError(TXN_ERROR_BASE + 2),
+                    Some(
+                        // translate to jsonrpc types
+                        serde_json::to_value(TransactionStatusView::from(TransactionStatus::from(
+                            vm_status,
+                        )))
+                        .expect("vm status to json should be ok"),
+                    ),
+                ),
+            },
             TransactionError::ApiInterrupted(_) => (ErrorCode::InternalError, None),
         };
         Self(jsonrpc_core::Error {
@@ -219,36 +219,36 @@ impl From<TransactionError2> for RpcError {
         let err_message = err.to_string();
         let (err_code, err_data) = match err {
             TransactionError2::AlreadyImported
-                    | TransactionError2::Old
-                    | TransactionError2::InsufficientGasPrice { .. }
-                    | TransactionError2::TooCheapToReplace { .. }
-                    | TransactionError2::InsufficientGas { .. }
-                    | TransactionError2::InsufficientBalance { .. }
-                    | TransactionError2::GasLimitExceeded { .. }
-                    | TransactionError2::SenderBanned
-                    | TransactionError2::RecipientBanned
-                    | TransactionError2::CodeBanned
-                    | TransactionError2::InvalidChainId
-                    | TransactionError2::InvalidSignature(..)
-                    | TransactionError2::NotAllowed
-                    | TransactionError2::TooBig => (ErrorCode::InvalidParams, None),
+            | TransactionError2::Old
+            | TransactionError2::InsufficientGasPrice { .. }
+            | TransactionError2::TooCheapToReplace { .. }
+            | TransactionError2::InsufficientGas { .. }
+            | TransactionError2::InsufficientBalance { .. }
+            | TransactionError2::GasLimitExceeded { .. }
+            | TransactionError2::SenderBanned
+            | TransactionError2::RecipientBanned
+            | TransactionError2::CodeBanned
+            | TransactionError2::InvalidChainId
+            | TransactionError2::InvalidSignature(..)
+            | TransactionError2::NotAllowed
+            | TransactionError2::TooBig => (ErrorCode::InvalidParams, None),
             TransactionError2::LimitReached => (ErrorCode::ServerError(TXN_ERROR_BASE), None),
             TransactionError2::CallErr(call_err) => match call_err {
-                        CallError2::TransactionNotFound => (ErrorCode::InvalidParams, None),
-                        CallError2::StatePruned | CallError2::StateCorrupt => {
-                            (ErrorCode::ServerError(TXN_ERROR_BASE + 1), None)
-                        }
-                        CallError2::ExecutionError(vm_status) => (
-                            ErrorCode::ServerError(TXN_ERROR_BASE + 2),
-                            Some(
-                                // translate to jsonrpc types
-                                serde_json::to_value(TransactionStatusView2::from(
-                                    TransactionStatus2::from(vm_status),
-                                ))
-                                .expect("vm status to json should be ok"),
-                            ),
-                        ),
-                    },
+                CallError2::TransactionNotFound => (ErrorCode::InvalidParams, None),
+                CallError2::StatePruned | CallError2::StateCorrupt => {
+                    (ErrorCode::ServerError(TXN_ERROR_BASE + 1), None)
+                }
+                CallError2::ExecutionError(vm_status) => (
+                    ErrorCode::ServerError(TXN_ERROR_BASE + 2),
+                    Some(
+                        // translate to jsonrpc types
+                        serde_json::to_value(TransactionStatusView2::from(
+                            TransactionStatus2::from(vm_status),
+                        ))
+                        .expect("vm status to json should be ok"),
+                    ),
+                ),
+            },
             TransactionError2::ApiInterrupted(err_message) => (ErrorCode::InternalError, None),
         };
         RpcError(jsonrpc_core::Error {
@@ -263,7 +263,9 @@ impl From<MultiTransactionError> for RpcError {
         match err {
             MultiTransactionError::VM1(error) => error.into(),
             MultiTransactionError::VM2(error) => error.into(),
-            MultiTransactionError::ApiInterrupted(api_interrupted_error) => Error::from(api_interrupted_error).into(),
+            MultiTransactionError::ApiInterrupted(api_interrupted_error) => {
+                Error::from(api_interrupted_error).into()
+            }
         }
     }
 }

--- a/rpc/server/src/module/mod.rs
+++ b/rpc/server/src/module/mod.rs
@@ -120,36 +120,37 @@ impl From<TransactionError> for RpcError {
         let err_message = err.to_string();
         let (err_code, err_data) = match err {
             TransactionError::AlreadyImported
-            | TransactionError::Old
-            | TransactionError::InsufficientGasPrice { .. }
-            | TransactionError::TooCheapToReplace { .. }
-            | TransactionError::InsufficientGas { .. }
-            | TransactionError::InsufficientBalance { .. }
-            | TransactionError::GasLimitExceeded { .. }
-            | TransactionError::SenderBanned
-            | TransactionError::RecipientBanned
-            | TransactionError::CodeBanned
-            | TransactionError::InvalidChainId
-            | TransactionError::InvalidSignature(..)
-            | TransactionError::NotAllowed
-            | TransactionError::TooBig => (ErrorCode::InvalidParams, None),
+                    | TransactionError::Old
+                    | TransactionError::InsufficientGasPrice { .. }
+                    | TransactionError::TooCheapToReplace { .. }
+                    | TransactionError::InsufficientGas { .. }
+                    | TransactionError::InsufficientBalance { .. }
+                    | TransactionError::GasLimitExceeded { .. }
+                    | TransactionError::SenderBanned
+                    | TransactionError::RecipientBanned
+                    | TransactionError::CodeBanned
+                    | TransactionError::InvalidChainId
+                    | TransactionError::InvalidSignature(..)
+                    | TransactionError::NotAllowed
+                    | TransactionError::TooBig => (ErrorCode::InvalidParams, None),
             TransactionError::LimitReached(..) => (ErrorCode::ServerError(TXN_ERROR_BASE), None),
             TransactionError::CallErr(call_err) => match call_err {
-                CallError::TransactionNotFound => (ErrorCode::InvalidParams, None),
-                CallError::StatePruned | CallError::StateCorrupt => {
-                    (ErrorCode::ServerError(TXN_ERROR_BASE + 1), None)
-                }
-                CallError::ExecutionError(vm_status) => (
-                    ErrorCode::ServerError(TXN_ERROR_BASE + 2),
-                    Some(
-                        // translate to jsonrpc types
-                        serde_json::to_value(TransactionStatusView::from(TransactionStatus::from(
-                            vm_status,
-                        )))
-                        .expect("vm status to json should be ok"),
-                    ),
-                ),
-            },
+                        CallError::TransactionNotFound => (ErrorCode::InvalidParams, None),
+                        CallError::StatePruned | CallError::StateCorrupt => {
+                            (ErrorCode::ServerError(TXN_ERROR_BASE + 1), None)
+                        }
+                        CallError::ExecutionError(vm_status) => (
+                            ErrorCode::ServerError(TXN_ERROR_BASE + 2),
+                            Some(
+                                // translate to jsonrpc types
+                                serde_json::to_value(TransactionStatusView::from(TransactionStatus::from(
+                                    vm_status,
+                                )))
+                                .expect("vm status to json should be ok"),
+                            ),
+                        ),
+                    },
+            TransactionError::ApiInterrupted(_) => (ErrorCode::InternalError, None),
         };
         Self(jsonrpc_core::Error {
             code: err_code,
@@ -218,36 +219,37 @@ impl From<TransactionError2> for RpcError {
         let err_message = err.to_string();
         let (err_code, err_data) = match err {
             TransactionError2::AlreadyImported
-            | TransactionError2::Old
-            | TransactionError2::InsufficientGasPrice { .. }
-            | TransactionError2::TooCheapToReplace { .. }
-            | TransactionError2::InsufficientGas { .. }
-            | TransactionError2::InsufficientBalance { .. }
-            | TransactionError2::GasLimitExceeded { .. }
-            | TransactionError2::SenderBanned
-            | TransactionError2::RecipientBanned
-            | TransactionError2::CodeBanned
-            | TransactionError2::InvalidChainId
-            | TransactionError2::InvalidSignature(..)
-            | TransactionError2::NotAllowed
-            | TransactionError2::TooBig => (ErrorCode::InvalidParams, None),
+                    | TransactionError2::Old
+                    | TransactionError2::InsufficientGasPrice { .. }
+                    | TransactionError2::TooCheapToReplace { .. }
+                    | TransactionError2::InsufficientGas { .. }
+                    | TransactionError2::InsufficientBalance { .. }
+                    | TransactionError2::GasLimitExceeded { .. }
+                    | TransactionError2::SenderBanned
+                    | TransactionError2::RecipientBanned
+                    | TransactionError2::CodeBanned
+                    | TransactionError2::InvalidChainId
+                    | TransactionError2::InvalidSignature(..)
+                    | TransactionError2::NotAllowed
+                    | TransactionError2::TooBig => (ErrorCode::InvalidParams, None),
             TransactionError2::LimitReached => (ErrorCode::ServerError(TXN_ERROR_BASE), None),
             TransactionError2::CallErr(call_err) => match call_err {
-                CallError2::TransactionNotFound => (ErrorCode::InvalidParams, None),
-                CallError2::StatePruned | CallError2::StateCorrupt => {
-                    (ErrorCode::ServerError(TXN_ERROR_BASE + 1), None)
-                }
-                CallError2::ExecutionError(vm_status) => (
-                    ErrorCode::ServerError(TXN_ERROR_BASE + 2),
-                    Some(
-                        // translate to jsonrpc types
-                        serde_json::to_value(TransactionStatusView2::from(
-                            TransactionStatus2::from(vm_status),
-                        ))
-                        .expect("vm status to json should be ok"),
-                    ),
-                ),
-            },
+                        CallError2::TransactionNotFound => (ErrorCode::InvalidParams, None),
+                        CallError2::StatePruned | CallError2::StateCorrupt => {
+                            (ErrorCode::ServerError(TXN_ERROR_BASE + 1), None)
+                        }
+                        CallError2::ExecutionError(vm_status) => (
+                            ErrorCode::ServerError(TXN_ERROR_BASE + 2),
+                            Some(
+                                // translate to jsonrpc types
+                                serde_json::to_value(TransactionStatusView2::from(
+                                    TransactionStatus2::from(vm_status),
+                                ))
+                                .expect("vm status to json should be ok"),
+                            ),
+                        ),
+                    },
+            TransactionError2::ApiInterrupted(err_message) => (ErrorCode::InternalError, None),
         };
         RpcError(jsonrpc_core::Error {
             code: err_code,
@@ -261,6 +263,7 @@ impl From<MultiTransactionError> for RpcError {
         match err {
             MultiTransactionError::VM1(error) => error.into(),
             MultiTransactionError::VM2(error) => error.into(),
+            MultiTransactionError::ApiInterrupted(api_interrupted_error) => Error::from(api_interrupted_error).into(),
         }
     }
 }

--- a/rpc/server/src/module/mod.rs
+++ b/rpc/server/src/module/mod.rs
@@ -86,7 +86,7 @@ impl Into<jsonrpc_core::Error> for RpcError {
 
 impl From<anyhow::Error> for RpcError {
     fn from(e: Error) -> Self {
-        RpcError(jsonrpc_core::Error {
+        Self(jsonrpc_core::Error {
             code: jsonrpc_core::ErrorCode::InternalError,
             message: e.to_string(),
             data: None,
@@ -111,7 +111,7 @@ impl From<AccountError> for RpcError {
                 data: None,
             },
         };
-        RpcError(rpc_error)
+        Self(rpc_error)
     }
 }
 
@@ -151,7 +151,7 @@ impl From<TransactionError> for RpcError {
                 ),
             },
         };
-        RpcError(jsonrpc_core::Error {
+        Self(jsonrpc_core::Error {
             code: err_code,
             message: err_message,
             data: err_data,
@@ -161,7 +161,7 @@ impl From<TransactionError> for RpcError {
 
 impl From<hex::FromHexError> for RpcError {
     fn from(err: FromHexError) -> Self {
-        RpcError(jsonrpc_core::Error {
+        Self(jsonrpc_core::Error {
             code: ErrorCode::InvalidParams,
             message: err.to_string(),
             data: None,
@@ -170,7 +170,7 @@ impl From<hex::FromHexError> for RpcError {
 }
 impl From<bcs_ext::Error> for RpcError {
     fn from(err: bcs_ext::Error) -> Self {
-        RpcError(jsonrpc_core::Error {
+        Self(jsonrpc_core::Error {
             code: ErrorCode::InvalidParams,
             message: err.to_string(),
             data: None,
@@ -180,7 +180,7 @@ impl From<bcs_ext::Error> for RpcError {
 
 impl From<MailboxError> for RpcError {
     fn from(err: MailboxError) -> Self {
-        RpcError(jsonrpc_core::Error {
+        Self(jsonrpc_core::Error {
             code: ErrorCode::InternalError,
             message: err.to_string(),
             data: None,
@@ -190,7 +190,7 @@ impl From<MailboxError> for RpcError {
 
 impl From<VMStatus> for RpcError {
     fn from(vm_status: VMStatus) -> Self {
-        RpcError(jsonrpc_core::Error {
+        Self(jsonrpc_core::Error {
             code: ErrorCode::InvalidParams,
             message: vm_status.to_string(),
             data: Some(

--- a/rpc/server/src/module/pubsub/tests.rs
+++ b/rpc/server/src/module/pubsub/tests.rs
@@ -185,7 +185,7 @@ pub async fn test_subscribe_to_pending_transactions() -> Result<()> {
     };
     let txn_id = txn.id();
     txpool_service
-        .add_txns_multi_signed(vec![txn.into()], true, None)
+        .add_txns_multi_signed(vec![txn.into()], true, None)?
         .pop()
         .unwrap()
         .unwrap();

--- a/rpc/server/src/module/sync_manager_rpc.rs
+++ b/rpc/server/src/module/sync_manager_rpc.rs
@@ -6,10 +6,9 @@ use futures::future::TryFutureExt;
 use futures::FutureExt;
 use network_api::PeerStrategy;
 use network_p2p_types::peer_id::PeerId;
-use starcoin_rpc_api::sync_manager::SyncManagerApi;
 use starcoin_rpc_api::FutureResult;
+use starcoin_rpc_api::{sync_manager::SyncManagerApi, types::SyncStatusView};
 use starcoin_sync_api::{PeerScoreResponse, SyncAsyncService, SyncProgressReport};
-use starcoin_types::sync_status::SyncStatus;
 
 pub struct SyncManagerRpcImpl<S>
 where
@@ -31,11 +30,11 @@ impl<S> SyncManagerApi for SyncManagerRpcImpl<S>
 where
     S: SyncAsyncService,
 {
-    fn status(&self) -> FutureResult<SyncStatus> {
+    fn status(&self) -> FutureResult<SyncStatusView> {
         let service = self.service.clone();
         let fut = async move {
             let result = service.status().await?;
-            Ok(result)
+            Ok(result.into())
         }
         .map_err(map_err);
         Box::pin(fut.boxed())

--- a/rpc/server/src/module/txpool_rpc.rs
+++ b/rpc/server/src/module/txpool_rpc.rs
@@ -65,6 +65,21 @@ where
         self.submit_transaction_multi(MultiSignedUserTransaction::VM2(txn))
     }
 
+    fn submit_transactions(
+        &self,
+        txns: Vec<SignedUserTransaction>,
+    ) -> FutureResult<Vec<HashValue>> {
+        let txn_hashes = txns.iter().map(|txn| txn.id()).collect();
+        let result: Result<(), jsonrpc_core::Error> = self
+            .service
+            .add_txns(txns)
+            .pop()
+            .expect("txpool should return result")
+            .map_err(convert_to_rpc_error);
+
+        Box::pin(futures::future::ready(result.map(|_| txn_hashes)))
+    }
+
     fn submit_hex_transaction(&self, tx: String) -> FutureResult<HashValue> {
         let tx = tx.strip_prefix("0x").unwrap_or(tx.as_str());
         let result = hex::decode(tx)
@@ -168,6 +183,14 @@ where
 
     fn next_sequence_number(&self, address: AccountAddress) -> FutureResult<Option<u64>> {
         let result = self.service.next_sequence_number(address);
+        Box::pin(futures::future::ok(result))
+    }
+
+    fn next_sequence_number_in_batch(
+        &self,
+        addresses: Vec<AccountAddress>,
+    ) -> FutureResult<Option<Vec<(AccountAddress, Option<u64>)>>> {
+        let result = self.service.next_sequence_number_in_batch(addresses);
         Box::pin(futures::future::ok(result))
     }
 

--- a/rpc/server/src/module/txpool_rpc.rs
+++ b/rpc/server/src/module/txpool_rpc.rs
@@ -42,9 +42,15 @@ where
             Some("local-rpc".to_string())
         };
         let txn_hash = txn.id();
-        let result: Result<(), jsonrpc_core::Error> = self
-            .service
-            .add_txns_multi_signed(vec![txn], bypass_vm1_limit, local_peer_id)
+        let mut result =
+            match self
+                .service
+                .add_txns_multi_signed(vec![txn], bypass_vm1_limit, local_peer_id)
+            {
+                Ok(result) => result,
+                Err(e) => return Box::pin(futures::future::ready(Err(convert_to_rpc_error(e)))),
+            };
+        let result = result
             .pop()
             .expect("txpool should return result")
             .map_err(convert_to_rpc_error);
@@ -70,9 +76,13 @@ where
         txns: Vec<SignedUserTransaction>,
     ) -> FutureResult<Vec<HashValue>> {
         let txn_hashes = txns.iter().map(|txn| txn.id()).collect();
-        let result: Result<(), jsonrpc_core::Error> = self
-            .service
-            .add_txns(txns)
+        let mut result = match self.service.add_txns(txns) {
+            Ok(result) => result,
+            Err(e) => {
+                return Box::pin(futures::future::ready(Err(convert_to_rpc_error(e))));
+            }
+        };
+        let result = result
             .pop()
             .expect("txpool should return result")
             .map_err(convert_to_rpc_error);
@@ -87,8 +97,11 @@ where
             .and_then(|txn_bytes| SignedUserTransaction::decode(&txn_bytes).map_err(map_err))
             .and_then(|txn| {
                 let txn_hash = txn.id();
-                self.service
-                    .add_txns(vec![txn])
+                let mut result = match self.service.add_txns(vec![txn]) {
+                    Ok(result) => result,
+                    Err(e) => return Err(convert_to_rpc_error(e)),
+                };
+                result
                     .pop()
                     .expect("txpool should return result")
                     .map(|_| txn_hash)
@@ -104,8 +117,15 @@ where
             .and_then(|txn_bytes| SignedUserTransaction2::decode(&txn_bytes).map_err(map_err))
             .and_then(|txn| {
                 let txn_hash = txn.id();
-                self.service
-                    .add_txns_multi_signed(vec![MultiSignedUserTransaction::VM2(txn)], true, None)
+                let mut result = match self.service.add_txns_multi_signed(
+                    vec![MultiSignedUserTransaction::VM2(txn)],
+                    true,
+                    None,
+                ) {
+                    Ok(result) => result,
+                    Err(e) => return Err(convert_to_rpc_error(e)),
+                };
+                result
                     .pop()
                     .expect("txpool should return result")
                     .map(|_| txn_hash)

--- a/rpc/server/src/rate_limit_middleware.rs
+++ b/rpc/server/src/rate_limit_middleware.rs
@@ -19,7 +19,7 @@ impl From<ApiQuotaConfig> for QuotaWrapper {
             QuotaDuration::Minute => Quota::per_minute(c.max_burst),
             QuotaDuration::Hour => Quota::per_hour(c.max_burst),
         };
-        QuotaWrapper(q)
+        Self(q)
     }
 }
 

--- a/sync/src/announcement/mod.rs
+++ b/sync/src/announcement/mod.rs
@@ -118,7 +118,7 @@ mod tests {
     use std::time::Duration;
 
     #[stest::test]
-    fn test_get_txns_with_hash_from_pool() {
+    fn test_get_txns_with_hash_from_pool() -> Result<()> {
         let mut config_1 = NodeConfig::random_for_test();
         config_1.miner.disable_miner_client = Some(true);
         let config_1 = Arc::new(config_1);
@@ -149,11 +149,12 @@ mod tests {
         let txpool = service1.txpool();
         let txns = test_helper::txn::create_account(config_1.net(), 0, 1);
         txpool
-            .add_txns(txns.into_iter().map(|(_, txn)| txn).collect())
+            .add_txns(txns.into_iter().map(|(_, txn)| txn).collect())?
             .into_iter()
             .for_each(|r| r.unwrap());
 
         std::thread::sleep(Duration::from_secs(5));
         assert_eq!(service2.txpool().status().txn_count, 1);
+        Ok(())
     }
 }

--- a/sync/src/announcement/mod.rs
+++ b/sync/src/announcement/mod.rs
@@ -97,7 +97,9 @@ impl EventHandler<Self, PeerAnnouncementMessage> for AnnouncementService {
                             });
 
                             if !fresh_txns.is_empty() {
-                                txpool.add_txns_multi_signed(fresh_txns, true, None);
+                                if let Err(e) = txpool.add_txns_multi_signed(fresh_txns, true, None) {
+                                    error!("[sync] handle announcement msg error: {:?}, peer_id:{:?} ", e, peer_id);
+                                }
                             }
                         }
                     }

--- a/sync/src/txn_sync/mod.rs
+++ b/sync/src/txn_sync/mod.rs
@@ -106,8 +106,8 @@ impl Inner {
             .await?;
         let import_result =
             self.pool
-                .add_txns_multi_signed(txn_data, false, Some(peer_id.to_string()));
-        let succ_num = import_result.iter().filter(|r| r.is_ok()).count();
+                .add_txns_multi_signed(txn_data, false, Some(peer_id.to_string()))?;
+        let succ_num = import_result.into_iter().filter(|r| r.is_ok()).count();
         info!("succ to sync {} txn from peer {}", succ_num, peer_id);
         Ok(())
     }

--- a/sync/tests/txn_sync_test.rs
+++ b/sync/tests/txn_sync_test.rs
@@ -12,7 +12,7 @@ use test_helper::run_node_by_config;
 //TODO
 #[ignore]
 #[stest::test]
-fn test_txn_sync_actor() {
+fn test_txn_sync_actor() -> anyhow::Result<()> {
     let mut first_config = NodeConfig::random_for_test();
     first_config.miner.disable_miner_client = Some(false);
     let first_network_address = first_config.network.self_address();
@@ -25,7 +25,7 @@ fn test_txn_sync_actor() {
 
     // add txn to node1
     let user_txn = gen_user_txn(&first_config);
-    let import_result = txpool_1.add_txns(vec![user_txn.clone()]).pop();
+    let import_result = txpool_1.add_txns(vec![user_txn.clone()])?.pop();
     assert!(import_result.unwrap().is_ok());
 
     let mut second_config = NodeConfig::random_for_test();
@@ -43,12 +43,14 @@ fn test_txn_sync_actor() {
     std::thread::sleep(Duration::from_secs(2));
     let current_timestamp = second_config.net().time_service().now_secs();
     // check txn
-    let mut txns = txpool_2.get_pending_txns(None, Some(current_timestamp));
+    let mut txns = txpool_2.get_pending_txns(None, Some(current_timestamp))?;
     assert_eq!(txns.len(), 1);
     let txn = txns.pop().unwrap();
     assert_eq!(user_txn.id(), txn.id());
     second_node.stop().unwrap();
     first_node.stop().unwrap();
+
+    Ok(())
 }
 
 fn gen_user_txn(config: &NodeConfig) -> SignedUserTransaction {

--- a/testsuite/features/cmd.feature
+++ b/testsuite/features/cmd.feature
@@ -68,7 +68,7 @@ Feature: cmd integration test
     Then cmd: "account transfer -s 0x056d9bed868f8e8c74cf19109a2b375a -r 0x056d9bed868f8e8c74cf19109a2b375b -v 10000000 -b"
     Then cmd: "account unlock 0x056d9bed868f8e8c74cf19109a2b375a"
     # sign to file first
-    Then cmd: "account sign-multisig-txn -s 0x056d9bed868f8e8c74cf19109a2b375a --function 0x1::transfer_scripts::peer_to_peer_v2 -t 0x1::starcoin_coin::STC --arg 0x991c2f856a1e32985d9793b449c0f9d3 --arg 1000000u128 --output-dir /tmp"
+    Then cmd: "account sign-multisig-txn -s 0x056d9bed868f8e8c74cf19109a2b375a --function 0x1::transfer_scripts::peer_to_peer_v2 -t 0x1::starcoin_coin::STC --arg 0x991c2f856a1e32985d9793b449c0f9d3 --arg 1000000u128 --output-dir /tmp/integration_test"
     Then cmd: "account submit-txn {{$.account[-1].ok}} -b"
     Then stop
 

--- a/txpool/api/src/lib.rs
+++ b/txpool/api/src/lib.rs
@@ -10,11 +10,7 @@ use starcoin_types::multi_transaction::{
     MultiAccountAddress, MultiSignedUserTransaction, MultiTransactionError,
 };
 use starcoin_types::transaction::SignedUserTransaction;
-use starcoin_types::{
-    account_address::AccountAddress,
-    block::Block,
-    transaction,
-};
+use starcoin_types::{account_address::AccountAddress, block::Block, transaction};
 use starcoin_vm2_types::account_address::AccountAddress as AccountAddress2;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -96,17 +92,7 @@ pub trait TxPoolSyncService: Clone + Send + Sync + Unpin {
     fn next_sequence_number_in_batch(
         &self,
         addresses: Vec<AccountAddress>,
-        state_root1: HashValue,
-        state_root2: HashValue,
     ) -> Option<Vec<(AccountAddress, Option<u64>)>>;
-
-    /// alike next_sequence_number, it needs the pool client with the specific account state
-    fn next_sequence_number_with_state(
-        &self,
-        address: AccountAddress,
-        state_root1: HashValue,
-        state_root2: HashValue,
-    ) -> Option<u64>;
 
     /// subscribe
     fn subscribe_txns(&self) -> mpsc::UnboundedReceiver<TxnStatusFullEvent>;
@@ -132,21 +118,11 @@ pub trait TxPoolSyncService: Clone + Send + Sync + Unpin {
     /// or `None` if there are no pending transactions from that sender.
     fn next_sequence_number2(&self, address: AccountAddress2) -> Option<u64>;
 
-    /// Returns next valid sequence number for given sender (vm2 AccountAddress) with a specific header state.
-    fn next_sequence_number2_with_state(
-        &self,
-        address: AccountAddress2,
-        state_root1: HashValue,
-        state_root2: HashValue,
-    ) -> Option<u64>;
-
     /// For vm2, returns next valid sequence number for given sender
     /// or `None` if there are no pending transactions from that sender.
     fn next_sequence_number2_in_batch(
         &self,
         addresses: Vec<AccountAddress2>,
-        state_root1: HashValue,
-        state_root2: HashValue,
     ) -> Option<Vec<(AccountAddress2, Option<u64>)>>;
 }
 

--- a/txpool/api/src/lib.rs
+++ b/txpool/api/src/lib.rs
@@ -12,7 +12,7 @@ use starcoin_types::multi_transaction::{
 use starcoin_types::transaction::SignedUserTransaction;
 use starcoin_types::{
     account_address::AccountAddress,
-    block::{Block, BlockHeader},
+    block::Block,
     transaction,
 };
 use starcoin_vm2_types::account_address::AccountAddress as AccountAddress2;
@@ -35,10 +35,10 @@ pub trait TxPoolSyncService: Clone + Send + Sync + Unpin {
     fn add_txns(
         &self,
         txns: Vec<SignedUserTransaction>,
-    ) -> Vec<Result<(), transaction::TransactionError>> {
+    ) -> Result<Vec<Result<(), transaction::TransactionError>>> {
         let local_peer_id = Some("local-rpc".to_string());
         let multi_txns = txns.into_iter().map(|txn| txn.into()).collect();
-        let rets = self.add_txns_multi_signed(multi_txns, false, local_peer_id);
+        let rets = self.add_txns_multi_signed(multi_txns, false, local_peer_id)?;
         let mut results = vec![];
         for ret in rets {
             match ret {
@@ -49,7 +49,7 @@ pub trait TxPoolSyncService: Clone + Send + Sync + Unpin {
                 },
             }
         }
-        results
+        Ok(results)
     }
 
     fn add_txns_multi_signed(
@@ -57,7 +57,7 @@ pub trait TxPoolSyncService: Clone + Send + Sync + Unpin {
         txns: Vec<MultiSignedUserTransaction>,
         bypass_vm1_limit: bool,
         peer_id: Option<String>,
-    ) -> Vec<Result<(), MultiTransactionError>>;
+    ) -> Result<Vec<Result<(), MultiTransactionError>>>;
 
     /// Removes transaction from the pool.
     ///
@@ -76,25 +76,36 @@ pub trait TxPoolSyncService: Clone + Send + Sync + Unpin {
         &self,
         max_len: Option<u64>,
         now: Option<u64>,
-    ) -> Vec<MultiSignedUserTransaction>;
+    ) -> Result<Vec<MultiSignedUserTransaction>>;
 
-    /// Get all pending txns which is ok to be packaged to mining with a specific header state.
-    fn get_pending_with_header(
+    /// alike get_pending_txns, it needs the pool client with the specific account state
+    fn get_pending_with_state(
         &self,
         max_len: u64,
         current_timestamp_secs: Option<u64>,
-        header: &BlockHeader,
-    ) -> Vec<MultiSignedUserTransaction>;
+        state_root1: HashValue,
+        state_root2: HashValue,
+    ) -> Result<Vec<MultiSignedUserTransaction>>;
 
     /// Returns next valid sequence number for given sender
     /// or `None` if there are no pending transactions from that sender.
     fn next_sequence_number(&self, address: AccountAddress) -> Option<u64>;
 
-    /// Returns next valid sequence number for given sender with a specific header state.
-    fn next_sequence_number_with_header(
+    /// Returns next valid sequence number for given sender
+    /// or `None` if there are no pending transactions from that sender.
+    fn next_sequence_number_in_batch(
+        &self,
+        addresses: Vec<AccountAddress>,
+        state_root1: HashValue,
+        state_root2: HashValue,
+    ) -> Option<Vec<(AccountAddress, Option<u64>)>>;
+
+    /// alike next_sequence_number, it needs the pool client with the specific account state
+    fn next_sequence_number_with_state(
         &self,
         address: AccountAddress,
-        header: &BlockHeader,
+        state_root1: HashValue,
+        state_root2: HashValue,
     ) -> Option<u64>;
 
     /// subscribe
@@ -122,11 +133,21 @@ pub trait TxPoolSyncService: Clone + Send + Sync + Unpin {
     fn next_sequence_number2(&self, address: AccountAddress2) -> Option<u64>;
 
     /// Returns next valid sequence number for given sender (vm2 AccountAddress) with a specific header state.
-    fn next_sequence_number2_with_header(
+    fn next_sequence_number2_with_state(
         &self,
         address: AccountAddress2,
-        header: &BlockHeader,
+        state_root1: HashValue,
+        state_root2: HashValue,
     ) -> Option<u64>;
+
+    /// For vm2, returns next valid sequence number for given sender
+    /// or `None` if there are no pending transactions from that sender.
+    fn next_sequence_number2_in_batch(
+        &self,
+        addresses: Vec<AccountAddress2>,
+        state_root1: HashValue,
+        state_root2: HashValue,
+    ) -> Option<Vec<(AccountAddress2, Option<u64>)>>;
 }
 
 #[derive(Clone, Debug)]

--- a/txpool/mock-service/src/lib.rs
+++ b/txpool/mock-service/src/lib.rs
@@ -101,11 +101,12 @@ impl TxPoolSyncService for MockTxPoolService {
         unimplemented!()
     }
 
-    fn get_pending_with_header(
+    fn get_pending_with_state(
         &self,
         max_len: u64,
         _current_timestamp_secs: Option<u64>,
-        _header: &BlockHeader,
+        _state_root1: HashValue,
+        _state_root2: HashValue,
     ) -> Vec<MultiSignedUserTransaction> {
         self.pool
             .lock()
@@ -116,18 +117,10 @@ impl TxPoolSyncService for MockTxPoolService {
             .collect()
     }
 
-    fn next_sequence_number_with_header(
+    fn next_sequence_number_with_state(
         &self,
         _address: AccountAddress,
-        _header: &BlockHeader,
-    ) -> Option<u64> {
-        todo!()
-    }
-
-    fn next_sequence_number2_with_header(
-        &self,
-        _address: AccountAddress2,
-        _header: &BlockHeader,
+        _state_root: HashValue,
     ) -> Option<u64> {
         todo!()
     }
@@ -146,6 +139,45 @@ impl TxPoolSyncService for MockTxPoolService {
 
     fn next_sequence_number2(&self, _address: AccountAddress2) -> Option<u64> {
         unimplemented!("no need implemented for MockTxPoolService")
+    }
+    
+    fn get_pending_with_state(
+        &self,
+        max_len: u64,
+        current_timestamp_secs: Option<u64>,
+        state_root: HashValue,
+    ) -> Vec<MultiSignedUserTransaction> {
+        todo!()
+    }
+    
+    fn next_sequence_number_in_batch(
+        &self,
+        addresses: Vec<AccountAddress>,
+    ) -> Option<Vec<(AccountAddress, Option<u64>)>> {
+        todo!()
+    }
+    
+    fn next_sequence_number_with_state(
+        &self,
+        address: AccountAddress,
+        state_root: HashValue,
+    ) -> Option<u64> {
+        todo!()
+    }
+    
+    fn next_sequence_number2_with_state(
+        &self,
+        address: AccountAddress2,
+        state_root: HashValue,
+    ) -> Option<u64> {
+        todo!()
+    }
+    
+    fn next_sequence_number2_in_batch(
+        &self,
+        addresses: Vec<AccountAddress2>,
+    ) -> Option<Vec<(AccountAddress2, Option<u64>)>> {
+        todo!()
     }
 }
 

--- a/txpool/mock-service/src/lib.rs
+++ b/txpool/mock-service/src/lib.rs
@@ -8,10 +8,7 @@ use starcoin_txpool_api::{TxPoolStatus, TxPoolSyncService, TxnStatusFullEvent};
 use starcoin_types::multi_transaction::{
     MultiAccountAddress, MultiSignedUserTransaction, MultiTransactionError,
 };
-use starcoin_types::{
-    account_address::AccountAddress,
-    block::{Block, BlockHeader},
-};
+use starcoin_types::{account_address::AccountAddress, block::Block};
 use starcoin_vm2_types::account_address::AccountAddress as AccountAddress2;
 use std::{
     iter::Iterator,
@@ -41,12 +38,12 @@ impl TxPoolSyncService for MockTxPoolService {
         mut txns: Vec<MultiSignedUserTransaction>,
         _bypass_vm1_limit: bool,
         _peer_id: Option<String>,
-    ) -> Vec<Result<(), MultiTransactionError>> {
+    ) -> Result<Vec<Result<(), MultiTransactionError>>> {
         let len = txns.len();
         self.pool.lock().unwrap().append(&mut txns);
         let mut results = vec![];
         results.resize_with(len, || Ok(()));
-        results
+        Ok(results)
     }
 
     /// Removes transaction from the pool.
@@ -66,17 +63,17 @@ impl TxPoolSyncService for MockTxPoolService {
         &self,
         max_len: Option<u64>,
         _now: Option<u64>,
-    ) -> Vec<MultiSignedUserTransaction> {
+    ) -> Result<Vec<MultiSignedUserTransaction>> {
         match max_len {
-            Some(max) => self
+            Some(max) => Ok(self
                 .pool
                 .lock()
                 .unwrap()
                 .iter()
                 .take(max as usize)
                 .cloned()
-                .collect::<Vec<_>>(),
-            None => self.pool.lock().unwrap().clone(),
+                .collect::<Vec<_>>()),
+            None => Ok(self.pool.lock().unwrap().clone()),
         }
     }
 
@@ -107,22 +104,15 @@ impl TxPoolSyncService for MockTxPoolService {
         _current_timestamp_secs: Option<u64>,
         _state_root1: HashValue,
         _state_root2: HashValue,
-    ) -> Vec<MultiSignedUserTransaction> {
-        self.pool
+    ) -> Result<Vec<MultiSignedUserTransaction>> {
+        Ok(self
+            .pool
             .lock()
             .unwrap()
             .iter()
             .take(max_len as usize)
             .cloned()
-            .collect()
-    }
-
-    fn next_sequence_number_with_state(
-        &self,
-        _address: AccountAddress,
-        _state_root: HashValue,
-    ) -> Option<u64> {
-        todo!()
+            .collect())
     }
 
     fn find_txn(&self, _hash: &HashValue) -> Option<MultiSignedUserTransaction> {
@@ -140,44 +130,19 @@ impl TxPoolSyncService for MockTxPoolService {
     fn next_sequence_number2(&self, _address: AccountAddress2) -> Option<u64> {
         unimplemented!("no need implemented for MockTxPoolService")
     }
-    
-    fn get_pending_with_state(
-        &self,
-        max_len: u64,
-        current_timestamp_secs: Option<u64>,
-        state_root: HashValue,
-    ) -> Vec<MultiSignedUserTransaction> {
-        todo!()
-    }
-    
+
     fn next_sequence_number_in_batch(
         &self,
-        addresses: Vec<AccountAddress>,
+        _addresses: Vec<AccountAddress>,
     ) -> Option<Vec<(AccountAddress, Option<u64>)>> {
-        todo!()
+        unimplemented!()
     }
-    
-    fn next_sequence_number_with_state(
-        &self,
-        address: AccountAddress,
-        state_root: HashValue,
-    ) -> Option<u64> {
-        todo!()
-    }
-    
-    fn next_sequence_number2_with_state(
-        &self,
-        address: AccountAddress2,
-        state_root: HashValue,
-    ) -> Option<u64> {
-        todo!()
-    }
-    
+
     fn next_sequence_number2_in_batch(
         &self,
-        addresses: Vec<AccountAddress2>,
+        _addresses: Vec<AccountAddress2>,
     ) -> Option<Vec<(AccountAddress2, Option<u64>)>> {
-        todo!()
+        unimplemented!()
     }
 }
 
@@ -187,14 +152,16 @@ mod tests {
     use starcoin_types::transaction::SignedUserTransaction;
 
     #[stest::test]
-    async fn test_txpool() {
+    async fn test_txpool() -> Result<()> {
         let pool = MockTxPoolService::new();
 
-        pool.add_txns(vec![SignedUserTransaction::mock()])
+        pool.add_txns(vec![SignedUserTransaction::mock()])?
             .pop()
             .unwrap()
             .unwrap();
-        let txns = pool.get_pending_txns(None, None);
-        assert_eq!(1, txns.len())
+        let txns = pool.get_pending_txns(None, None)?;
+        assert_eq!(1, txns.len());
+
+        Ok(())
     }
 }

--- a/txpool/src/lib.rs
+++ b/txpool/src/lib.rs
@@ -85,7 +85,7 @@ impl TxPoolActorService {
         let current_timestamp = reader.get_timestamp()?.seconds();
         Ok(self
             .inner
-            .get_pending(max_len, current_timestamp)
+            .get_pending(max_len, current_timestamp)?
             .into_iter()
             .map(|t| t.signed().clone())
             .collect())
@@ -93,7 +93,7 @@ impl TxPoolActorService {
 }
 
 impl ServiceFactory<Self> for TxPoolActorService {
-    fn create(ctx: &mut ServiceContext<TxPoolActorService>) -> Result<TxPoolActorService> {
+    fn create(ctx: &mut ServiceContext<Self>) -> Result<Self> {
         let storage = ctx.get_shared::<Arc<Storage>>()?;
         let storage2 = ctx.get_shared::<Arc<Storage2>>()?;
         let node_config = ctx.get_shared::<Arc<NodeConfig>>()?;

--- a/txpool/src/pool.rs
+++ b/txpool/src/pool.rs
@@ -268,7 +268,7 @@ pub struct PendingSettings {
 impl PendingSettings {
     /// Get all transactions (no cap or len limit) prioritized.
     pub fn all_prioritized(block_number: u64, current_timestamp: u64) -> Self {
-        PendingSettings {
+        Self {
             block_number,
             current_timestamp,
             max_len: usize::MAX,

--- a/txpool/src/pool/local_transactions.rs
+++ b/txpool/src/pool/local_transactions.rs
@@ -44,7 +44,7 @@ pub enum Status {
 
 impl Status {
     fn is_pending(&self) -> bool {
-        matches!(self, Status::Pending(_))
+        matches!(self, Self::Pending(_))
     }
 }
 
@@ -76,7 +76,7 @@ impl Default for LocalTransactionsList {
 impl LocalTransactionsList {
     /// Create a new list of local transactions.
     pub fn new(max_old: usize) -> Self {
-        LocalTransactionsList {
+        Self {
             max_old,
             transactions: Default::default(),
             pending: 0,

--- a/txpool/src/pool/queue.rs
+++ b/txpool/src/pool/queue.rs
@@ -114,7 +114,7 @@ struct CachedPending {
 impl CachedPending {
     /// Creates new `CachedPending` without cached set.
     pub fn none() -> Self {
-        CachedPending {
+        Self {
             block_number: 0,
             current_timestamp: 0,
             has_local_pending: false,
@@ -177,7 +177,7 @@ struct RecentlyRejected {
 
 impl RecentlyRejected {
     fn new(limit: usize) -> Self {
-        RecentlyRejected {
+        Self {
             limit,
             inner: RwLock::new(HashMap::with_capacity(MIN_REJECTED_CACHE_SIZE)),
         }
@@ -538,11 +538,44 @@ impl TransactionQueue {
 
         let state_readiness = ready::State::new(client, stale_id);
 
-        let pool = self.pool.try_read()?;
+        let pool = match self.pool.try_read() {
+            Some(pool) => pool,
+            None => return None,
+        };
 
         pool.pending_from_sender(state_readiness, address)
             .last()
             .map(|tx| tx.signed().sequence_number().saturating_add(1))
+    }
+
+    /// Returns next valid sequence number for given sender
+    /// or `None` if there are no pending transactions from that sender.
+    pub fn next_sequence_number_in_batch<C: client::AccountSeqNumberClient>(
+        &self,
+        client: C,
+        addresses: Vec<MultiAccountAddress>,
+    ) -> Option<Vec<(MultiAccountAddress, Option<u64>)>> {
+        let pool = match self.pool.try_read() {
+            Some(pool) => pool,
+            None => return None,
+        };
+
+        Some(
+            addresses
+                .iter()
+                .map(|address| {
+                    // Also we ignore stale transactions in the queue.
+                    let stale_id = None;
+                    let state_readiness = ready::State::new(client.clone(), stale_id);
+                    (
+                        *address,
+                        pool.pending_from_sender(state_readiness, address)
+                            .last()
+                            .map(|tx| tx.signed().sequence_number().saturating_add(1)),
+                    )
+                })
+                .collect::<Vec<_>>(),
+        )
     }
 
     /// Retrieve a transaction from the pool.

--- a/txpool/src/pool/queue.rs
+++ b/txpool/src/pool/queue.rs
@@ -538,10 +538,7 @@ impl TransactionQueue {
 
         let state_readiness = ready::State::new(client, stale_id);
 
-        let pool = match self.pool.try_read() {
-            Some(pool) => pool,
-            None => return None,
-        };
+        let pool = self.pool.try_read()?;
 
         pool.pending_from_sender(state_readiness, address)
             .last()
@@ -555,10 +552,7 @@ impl TransactionQueue {
         client: C,
         addresses: Vec<MultiAccountAddress>,
     ) -> Option<Vec<(MultiAccountAddress, Option<u64>)>> {
-        let pool = match self.pool.try_read() {
-            Some(pool) => pool,
-            None => return None,
-        };
+        let pool = self.pool.try_read()?;
 
         Some(
             addresses

--- a/txpool/src/pool/ready.rs
+++ b/txpool/src/pool/ready.rs
@@ -31,7 +31,6 @@ use super::{client::AccountSeqNumberClient, SeqNumber, VerifiedTransaction};
 use crate::pending_transaction;
 use starcoin_types::multi_transaction::MultiAccountAddress;
 use tx_pool::{self, VerifiedTransaction as PoolVerifiedTransaction};
-
 /// Checks readiness of transactions by comparing the nonce to state nonce.
 #[derive(Debug)]
 pub struct State<C> {
@@ -44,7 +43,7 @@ pub struct State<C> {
 impl<C> State<C> {
     /// Create new State checker, given client interface.
     pub fn new(state: C, stale_id: Option<usize>) -> Self {
-        State {
+        Self {
             nonces: Default::default(),
             state,
             // disable the feature for now.
@@ -96,7 +95,7 @@ pub struct Expiration {
 impl Expiration {
     /// Create a new expiration checker given current UTC timestamp.
     pub fn new(now: u64) -> Self {
-        Expiration { now }
+        Self { now }
     }
 }
 
@@ -120,7 +119,7 @@ pub struct Condition {
 impl Condition {
     /// Create a new condition checker given current block number and UTC timestamp.
     pub fn new(block_number: u64, now: u64) -> Self {
-        Condition { block_number, now }
+        Self { block_number, now }
     }
 }
 
@@ -150,7 +149,7 @@ pub struct OptionalState<C> {
 
 impl<C> OptionalState<C> {
     pub fn new(state: C) -> Self {
-        OptionalState {
+        Self {
             nonces: Default::default(),
             state,
         }

--- a/txpool/src/pool/replace.rs
+++ b/txpool/src/pool/replace.rs
@@ -30,7 +30,7 @@ pub struct ReplaceByScoreAndReadiness<S, C> {
 impl<S, C> ReplaceByScoreAndReadiness<S, C> {
     /// Create a new `ReplaceByScoreAndReadiness`
     pub fn new(scoring: S, client: C) -> Self {
-        ReplaceByScoreAndReadiness { scoring, client }
+        Self { scoring, client }
     }
 }
 

--- a/txpool/src/pool/verifier.rs
+++ b/txpool/src/pool/verifier.rs
@@ -45,7 +45,7 @@ impl<C, S, V> Verifier<C, S, V> {
         id: Arc<AtomicUsize>,
         transaction_to_replace: Option<(S, Arc<V>)>,
     ) -> Self {
-        Verifier {
+        Self {
             client,
             options,
             id,

--- a/txpool/src/pool_client.rs
+++ b/txpool/src/pool_client.rs
@@ -1,6 +1,8 @@
 use crate::pool::{AccountSeqNumberClient, UnverifiedUserTransaction};
+use anyhow::format_err;
 use anyhow::Result;
 use parking_lot::RwLock;
+use starcoin_crypto::HashValue;
 use starcoin_executor::VMMetrics;
 use starcoin_state_api::AccountStateReader;
 use starcoin_statedb::ChainStateDB;
@@ -10,10 +12,8 @@ use starcoin_types::multi_transaction::{
     MultiAccountAddress, MultiSignatureCheckedTransaction, MultiSignedUserTransaction,
     MultiTransactionError,
 };
-use starcoin_types::{
-    block::BlockHeader,
-    transaction::{CallError, TransactionError},
-};
+use starcoin_types::transaction::CallError;
+use starcoin_types::transaction::TransactionError;
 use starcoin_vm2_state_api::AccountStateReader as AccountStateReader2;
 use starcoin_vm2_statedb::ChainStateDB as ChainStateDB2;
 use starcoin_vm2_vm_types::transaction::{
@@ -31,7 +31,7 @@ pub struct NonceCache {
 impl NonceCache {
     /// Create new cache with a limit of `limit` entries.
     pub fn new(limit: usize) -> Self {
-        NonceCache {
+        Self {
             nonces: Arc::new(RwLock::new(HashMap::with_capacity(limit / 2))),
             limit,
         }
@@ -141,7 +141,8 @@ impl AccountSeqNumberClient for CachedSeqNumberClient {
 
 #[derive(Clone)]
 pub struct PoolClient {
-    best_block_header: BlockHeader,
+    state_root1: HashValue,
+    state_root2: HashValue,
     nonce_client: CachedSeqNumberClient,
     vm_metrics: Option<VMMetrics>,
 }
@@ -154,19 +155,19 @@ impl std::fmt::Debug for PoolClient {
 
 impl PoolClient {
     pub fn new(
-        best_block_header: BlockHeader,
+        state_root1: HashValue,
+        state_root2: HashValue,
         storage: Arc<dyn Store>,
         storage2: Arc<dyn Store2>,
         cache: NonceCache,
         vm_metrics: Option<VMMetrics>,
     ) -> Self {
-        let state = storage.get_vm_multi_state(best_block_header.id()).unwrap();
-        let (state_root1, state_root2) = (state.state_root1(), state.state_root2());
         let statedb = ChainStateDB::new(storage.into_super_arc(), Some(state_root1));
         let statedb2 = ChainStateDB2::new(storage2.into_super_arc(), Some(state_root2));
         let nonce_client = CachedSeqNumberClient::new(statedb, statedb2, cache);
         Self {
-            best_block_header,
+            state_root1,
+            state_root2,
             nonce_client,
             vm_metrics,
         }

--- a/txpool/src/pool_client.rs
+++ b/txpool/src/pool_client.rs
@@ -1,5 +1,4 @@
 use crate::pool::{AccountSeqNumberClient, UnverifiedUserTransaction};
-use anyhow::format_err;
 use anyhow::Result;
 use parking_lot::RwLock;
 use starcoin_crypto::HashValue;

--- a/txpool/src/test.rs
+++ b/txpool/src/test.rs
@@ -68,11 +68,11 @@ impl AccountSeqNumberClient for MockNonceClient {
 async fn test_txn_expire() -> Result<()> {
     let (txpool_service, _storage, _, config, _, _) = test_helper::start_txpool().await;
     let txn = generate_txn(config, 0);
-    txpool_service.add_txns(vec![txn]).pop().unwrap()?;
-    let pendings = txpool_service.get_pending_txns(None, Some(0));
+    txpool_service.add_txns(vec![txn])?.pop().unwrap()?;
+    let pendings = txpool_service.get_pending_txns(None, Some(0))?;
     assert_eq!(pendings.len(), 1);
 
-    let pendings = txpool_service.get_pending_txns(None, Some(2));
+    let pendings = txpool_service.get_pending_txns(None, Some(2))?;
     assert_eq!(pendings.len(), 0);
 
     Ok(())
@@ -92,9 +92,9 @@ async fn test_tx_pool() -> Result<()> {
     );
     let txn = txn.as_signed_user_txn()?.clone();
     let txn_hash = txn.id();
-    let mut result = txpool_service.add_txns(vec![txn]);
+    let mut result = txpool_service.add_txns(vec![txn])?;
     assert!(result.pop().unwrap().is_ok());
-    let mut pending_txns = txpool_service.get_pending_txns(Some(10), Some(0));
+    let mut pending_txns = txpool_service.get_pending_txns(Some(10), Some(0))?;
     assert_eq!(pending_txns.pop().unwrap().id(), txn_hash);
 
     let next_sequence_number =
@@ -165,7 +165,7 @@ async fn test_pool_pending() -> Result<()> {
         .collect::<Vec<_>>();
 
     let _ = txpool_service.add_txns_multi_signed(txn_vec.clone(), true, None);
-    let pending = txpool_service.get_pending_txns(Some(pool_size), None);
+    let pending = txpool_service.get_pending_txns(Some(pool_size), None)?;
     assert!(!pending.is_empty());
 
     sleep(Duration::from_millis(200)).await;
@@ -313,7 +313,7 @@ async fn test_rollback() -> Result<()> {
     }
     pool.chain_new_block(vec![enacted_block], vec![retracted_block])
         .unwrap();
-    let txns = pool.get_pending_txns(Some(100), Some(start_timestamp + 60 * 10));
+    let txns = pool.get_pending_txns(Some(100), Some(start_timestamp + 60 * 10))?;
     assert_eq!(txns.len(), 0);
     Ok(())
 }
@@ -350,12 +350,12 @@ async fn test_vm1_txn_early_reject() -> Result<()> {
         .map(|i| generate_txn(config.clone(), i).into())
         .collect();
     let results =
-        txpool_service.add_txns_multi_signed(txns, false, Some("test_peer_1".to_string()));
+        txpool_service.add_txns_multi_signed(txns, false, Some("test_peer_1".to_string()))?;
 
     assert!(results.iter().take(100).all(|r| r.is_ok()));
     assert!(results.iter().skip(100).all(|r| r.is_err()));
 
-    let pendings = txpool_service.get_pending_txns(None, None);
+    let pendings = txpool_service.get_pending_txns(None, None)?;
 
     let vm1: Vec<_> = pendings.into_iter().filter(|txn| txn.is_v1()).collect();
 

--- a/txpool/src/tx_pool_service_impl.rs
+++ b/txpool/src/tx_pool_service_impl.rs
@@ -22,7 +22,8 @@ use starcoin_storage::Store;
 use starcoin_storage::Store2;
 use starcoin_txpool_api::{TxPoolStatus, TxPoolSyncService, TxnStatusFullEvent};
 use starcoin_types::multi_transaction::{
-    ApiInterruptedError, MultiAccountAddress, MultiSignatureCheckedTransaction, MultiSignedUserTransaction, MultiTransactionError
+    ApiInterruptedError, MultiAccountAddress, MultiSignatureCheckedTransaction,
+    MultiSignedUserTransaction, MultiTransactionError,
 };
 use starcoin_types::{
     account_address::AccountAddress,
@@ -30,8 +31,7 @@ use starcoin_types::{
 };
 use starcoin_vm2_statedb::ChainStateDB;
 use starcoin_vm2_types::account_address::AccountAddress as AccountAddress2;
-use core::error;
-use std::{clone, sync::Arc};
+use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub struct TxPoolService {
@@ -98,7 +98,8 @@ impl TxPoolService {
         tx: MultiSignedUserTransaction,
     ) -> Result<MultiSignatureCheckedTransaction, MultiTransactionError> {
         self.get_inner()
-            .get_pool_client().map_err(|e| MultiTransactionError::ApiInterrupted(ApiInterruptedError(e.to_string())))?
+            .get_pool_client()
+            .map_err(|e| MultiTransactionError::ApiInterrupted(ApiInterruptedError(e.to_string())))?
             .verify_transaction(tx.into())
     }
 }
@@ -156,7 +157,7 @@ impl TxPoolSyncService for TxPoolService {
             .get_pending(max_len.unwrap_or(u64::MAX), current_timestamp_secs)?;
         Ok(r.into_iter().map(|t| t.signed().clone()).collect())
     }
-    
+
     fn get_pending_with_state(
         &self,
         max_len: u64,
@@ -164,7 +165,7 @@ impl TxPoolSyncService for TxPoolService {
         state_root1: HashValue,
         state_root2: HashValue,
     ) -> Result<Vec<MultiSignedUserTransaction>> {
-       let _timer: Option<starcoin_metrics::HistogramTimer> =
+        let _timer: Option<starcoin_metrics::HistogramTimer> =
             self.inner.metrics.as_ref().map(|metrics| {
                 metrics
                     .txpool_service_time
@@ -196,14 +197,13 @@ impl TxPoolSyncService for TxPoolService {
                 .with_label_values(&["next_sequence_number"])
                 .start_timer()
         });
-        self.inner.next_sequence_number(MultiAccountAddress::VM1(address))
+        self.inner
+            .next_sequence_number(MultiAccountAddress::VM1(address))
     }
 
     fn next_sequence_number_in_batch(
         &self,
         addresses: Vec<AccountAddress>,
-        state_root1: HashValue,
-        state_root2: HashValue,
     ) -> Option<Vec<(AccountAddress, Option<u64>)>> {
         let _timer = self.inner.metrics.as_ref().map(|metrics| {
             metrics
@@ -211,28 +211,29 @@ impl TxPoolSyncService for TxPoolService {
                 .with_label_values(&["next_sequence_number"])
                 .start_timer()
         });
-        self.inner.next_sequence_number_in_batch(addresses.into_iter().map(MultiAccountAddress::VM1).collect(), state_root1, state_root2).map(|results| {
-            results.into_iter().map(|(address, seq)| (match address {
-                MultiAccountAddress::VM1(account_address) => account_address,
-                MultiAccountAddress::VM2(_account_address) => panic!("unexpected account address in next_sequence_number2_in_batch"),
-            }, seq)).collect()
-        })
-    }
-
-    fn next_sequence_number_with_state(
-        &self,
-        address: AccountAddress,
-        state_root1: HashValue,
-        state_root2: HashValue,
-    ) -> Option<u64> {
-        let _timer = self.inner.metrics.as_ref().map(|metrics| {
-            metrics
-                .txpool_service_time
-                .with_label_values(&["next_sequence_number_with_header"])
-                .start_timer()
-        });
         self.inner
-            .next_sequence_number_with_state(MultiAccountAddress::VM1(address), state_root1, state_root2)
+            .next_sequence_number_in_batch(
+                addresses
+                    .into_iter()
+                    .map(MultiAccountAddress::VM1)
+                    .collect(),
+            )
+            .map(|results| {
+                results
+                    .into_iter()
+                    .map(|(address, seq)| {
+                        (
+                            match address {
+                                MultiAccountAddress::VM1(account_address) => account_address,
+                                MultiAccountAddress::VM2(_account_address) => panic!(
+                                    "unexpected account address in next_sequence_number2_in_batch"
+                                ),
+                            },
+                            seq,
+                        )
+                    })
+                    .collect()
+            })
     }
 
     /// subscribe
@@ -298,30 +299,13 @@ impl TxPoolSyncService for TxPoolService {
                 .with_label_values(&["next_sequence_number2"])
                 .start_timer()
         });
-        self.inner.next_sequence_number(MultiAccountAddress::VM2(address))
+        self.inner
+            .next_sequence_number(MultiAccountAddress::VM2(address))
     }
 
-    fn next_sequence_number2_with_state(
-        &self,
-        address: AccountAddress2,
-        state_root1: HashValue,
-        state_root2: HashValue,
-    ) -> Option<u64> {
-        let _timer = self.inner.metrics.as_ref().map(|metrics| {
-            metrics
-                .txpool_service_time
-                .with_label_values(&["next_sequence_number2_with_header"])
-                .start_timer()
-        });
-        self.inner
-            .next_sequence_number_with_state(MultiAccountAddress::VM2(address), state_root1, state_root2)
-    }
-    
     fn next_sequence_number2_in_batch(
         &self,
         addresses: Vec<AccountAddress2>,
-        state_root1: HashValue,
-        state_root2: HashValue,
     ) -> Option<Vec<(AccountAddress2, Option<u64>)>> {
         let _timer = self.inner.metrics.as_ref().map(|metrics| {
             metrics
@@ -329,14 +313,30 @@ impl TxPoolSyncService for TxPoolService {
                 .with_label_values(&["next_sequence_number"])
                 .start_timer()
         });
-        self.inner.next_sequence_number_in_batch(addresses.into_iter().map(MultiAccountAddress::VM2).collect(), state_root1, state_root2).map(|results| {
-            results.into_iter().map(|(address, seq)| (match address {
-                MultiAccountAddress::VM1(_account_address) => panic!("unexpected account address in next_sequence_number2_in_batch"),
-                MultiAccountAddress::VM2(account_address) => account_address,
-            }, seq)).collect()
-        })
+        self.inner
+            .next_sequence_number_in_batch(
+                addresses
+                    .into_iter()
+                    .map(MultiAccountAddress::VM2)
+                    .collect(),
+            )
+            .map(|results| {
+                results
+                    .into_iter()
+                    .map(|(address, seq)| {
+                        (
+                            match address {
+                                MultiAccountAddress::VM1(_account_address) => panic!(
+                                    "unexpected account address in next_sequence_number2_in_batch"
+                                ),
+                                MultiAccountAddress::VM2(account_address) => account_address,
+                            },
+                            seq,
+                        )
+                    })
+                    .collect()
+            })
     }
-    
 }
 
 pub(crate) type TxnQueue = TransactionQueue;
@@ -384,7 +384,7 @@ impl Inner {
         ))
     }
 
-    pub(crate) fn cull(&self) -> Result<()>{
+    pub(crate) fn cull(&self) -> Result<()> {
         // NOTICE: as the new head block event is repeated with chain_new_block event,
         // we need to remove invalid txn here.
         // In fact, it would be better if caller can make it into one.
@@ -403,7 +403,8 @@ impl Inner {
         let txns = txns
             .into_iter()
             .map(|t| PoolTransaction::Unverified(UnverifiedUserTransaction::from(t)));
-        Ok(self.queue
+        Ok(self
+            .queue
             .import(self.get_pool_client()?, txns, bypass_vm1_limit, peer_id))
     }
     pub(crate) fn remove_txn(
@@ -430,7 +431,11 @@ impl Inner {
         // self.queue
         //     .inner_status(self.get_pool_client(), u64::MAX, current_timestamp_secs);
         // self.queue.pending(self.get_pool_client(), pending_settings)
-        Ok(self.get_pending_with_pool_client(max_len, current_timestamp_secs, self.get_pool_client()?))
+        Ok(self.get_pending_with_pool_client(
+            max_len,
+            current_timestamp_secs,
+            self.get_pool_client()?,
+        ))
     }
 
     pub fn get_pending_with_pool_client(
@@ -463,16 +468,26 @@ impl Inner {
                 return None;
             }
         };
-        self.queue
-            .next_sequence_number(client, &address)
+        self.queue.next_sequence_number(client, &address)
     }
 
     pub(crate) fn next_sequence_number_in_batch(
         &self,
         addresses: Vec<MultiAccountAddress>,
-        state_root1: HashValue,
-        state_root2: HashValue,
     ) -> Option<Vec<(MultiAccountAddress, Option<u64>)>> {
+        let (state_root1, state_root2) = match self
+            .storage
+            .get_vm_multi_state(self.chain_header.read().id())
+        {
+            Ok(multi_state) => (multi_state.state_root1(), multi_state.state_root2()),
+            Err(e) => {
+                error!(
+                    "failed to get vm multi state in next_sequence_number_in_batch: {}",
+                    e
+                );
+                return None;
+            }
+        };
         let pool_client = PoolClient::new(
             state_root1,
             state_root2,
@@ -488,9 +503,20 @@ impl Inner {
     pub(crate) fn next_sequence_number_with_state(
         &self,
         address: MultiAccountAddress,
-        state_root1: HashValue,
-        state_root2: HashValue,
     ) -> Option<u64> {
+        let (state_root1, state_root2) = match self
+            .storage
+            .get_vm_multi_state(self.chain_header.read().id())
+        {
+            Ok(multi_state) => (multi_state.state_root1(), multi_state.state_root2()),
+            Err(e) => {
+                error!(
+                    "failed to get vm multi state in next_sequence_number_in_batch: {}",
+                    e
+                );
+                return None;
+            }
+        };
         let pool_client = PoolClient::new(
             state_root1,
             state_root2,
@@ -499,8 +525,7 @@ impl Inner {
             NonceCache::new(0),
             self.vm_metrics.clone(),
         );
-        self.queue
-            .next_sequence_number(pool_client, &address)
+        self.queue.next_sequence_number(pool_client, &address)
     }
 
     pub(crate) fn subscribe_txns(&self) -> mpsc::UnboundedReceiver<TxnStatusFullEvent> {
@@ -559,7 +584,9 @@ impl Inner {
     }
 
     fn get_pool_client(&self) -> Result<PoolClient> {
-        let state = self.storage.get_vm_multi_state(self.chain_header.read().id())?;
+        let state = self
+            .storage
+            .get_vm_multi_state(self.chain_header.read().id())?;
         let (state_root1, state_root2) = (state.state_root1(), state.state_root2());
         Ok(PoolClient::new(
             state_root1,

--- a/txpool/src/tx_pool_service_impl.rs
+++ b/txpool/src/tx_pool_service_impl.rs
@@ -558,7 +558,10 @@ impl Inner {
         }
 
         // remove outdated txns.
-        self.cull();
+        if let Err(e) = self.cull() {
+            error!("failed to cull in chain_new_block: {}", e);
+            return;
+        }
 
         // import retracted txns.
         let txns = retracted

--- a/txpool/src/tx_pool_service_impl.rs
+++ b/txpool/src/tx_pool_service_impl.rs
@@ -500,34 +500,6 @@ impl Inner {
             .next_sequence_number_in_batch(pool_client, addresses)
     }
 
-    pub(crate) fn next_sequence_number_with_state(
-        &self,
-        address: MultiAccountAddress,
-    ) -> Option<u64> {
-        let (state_root1, state_root2) = match self
-            .storage
-            .get_vm_multi_state(self.chain_header.read().id())
-        {
-            Ok(multi_state) => (multi_state.state_root1(), multi_state.state_root2()),
-            Err(e) => {
-                error!(
-                    "failed to get vm multi state in next_sequence_number_in_batch: {}",
-                    e
-                );
-                return None;
-            }
-        };
-        let pool_client = PoolClient::new(
-            state_root1,
-            state_root2,
-            self.storage.clone(),
-            self.storage2.clone(),
-            NonceCache::new(0),
-            self.vm_metrics.clone(),
-        );
-        self.queue.next_sequence_number(pool_client, &address)
-    }
-
     pub(crate) fn subscribe_txns(&self) -> mpsc::UnboundedReceiver<TxnStatusFullEvent> {
         let (tx, rx) = mpsc::unbounded();
         self.queue.add_full_listener(tx);

--- a/txpool/src/tx_pool_service_impl.rs
+++ b/txpool/src/tx_pool_service_impl.rs
@@ -22,8 +22,7 @@ use starcoin_storage::Store;
 use starcoin_storage::Store2;
 use starcoin_txpool_api::{TxPoolStatus, TxPoolSyncService, TxnStatusFullEvent};
 use starcoin_types::multi_transaction::{
-    MultiAccountAddress, MultiSignatureCheckedTransaction, MultiSignedUserTransaction,
-    MultiTransactionError,
+    ApiInterruptedError, MultiAccountAddress, MultiSignatureCheckedTransaction, MultiSignedUserTransaction, MultiTransactionError
 };
 use starcoin_types::{
     account_address::AccountAddress,
@@ -31,7 +30,8 @@ use starcoin_types::{
 };
 use starcoin_vm2_statedb::ChainStateDB;
 use starcoin_vm2_types::account_address::AccountAddress as AccountAddress2;
-use std::sync::Arc;
+use core::error;
+use std::{clone, sync::Arc};
 
 #[derive(Clone, Debug)]
 pub struct TxPoolService {
@@ -98,7 +98,7 @@ impl TxPoolService {
         tx: MultiSignedUserTransaction,
     ) -> Result<MultiSignatureCheckedTransaction, MultiTransactionError> {
         self.get_inner()
-            .get_pool_client()
+            .get_pool_client().map_err(|e| MultiTransactionError::ApiInterrupted(ApiInterruptedError(e.to_string())))?
             .verify_transaction(tx.into())
     }
 }
@@ -109,7 +109,7 @@ impl TxPoolSyncService for TxPoolService {
         txns: Vec<MultiSignedUserTransaction>,
         bypass_vm1_limit: bool,
         peer_id: Option<String>,
-    ) -> Vec<Result<(), MultiTransactionError>> {
+    ) -> Result<Vec<Result<(), MultiTransactionError>>> {
         // _timer will observe_duration when it's dropped.
         // We don't need to call it explicitly.
         let _timer = self.inner.metrics.as_ref().map(|metrics| {
@@ -142,7 +142,7 @@ impl TxPoolSyncService for TxPoolService {
         &self,
         max_len: Option<u64>,
         current_timestamp_secs: Option<u64>,
-    ) -> Vec<MultiSignedUserTransaction> {
+    ) -> Result<Vec<MultiSignedUserTransaction>> {
         let _timer = self.inner.metrics.as_ref().map(|metrics| {
             metrics
                 .txpool_service_time
@@ -153,17 +153,18 @@ impl TxPoolSyncService for TxPoolService {
             .unwrap_or_else(|| self.inner.node_config.net().time_service().now_secs());
         let r = self
             .inner
-            .get_pending(max_len.unwrap_or(u64::MAX), current_timestamp_secs);
-        r.into_iter().map(|t| t.signed().clone()).collect()
+            .get_pending(max_len.unwrap_or(u64::MAX), current_timestamp_secs)?;
+        Ok(r.into_iter().map(|t| t.signed().clone()).collect())
     }
-
-    fn get_pending_with_header(
+    
+    fn get_pending_with_state(
         &self,
         max_len: u64,
         current_timestamp_secs: Option<u64>,
-        header: &BlockHeader,
-    ) -> Vec<MultiSignedUserTransaction> {
-        let _timer: Option<starcoin_metrics::HistogramTimer> =
+        state_root1: HashValue,
+        state_root2: HashValue,
+    ) -> Result<Vec<MultiSignedUserTransaction>> {
+       let _timer: Option<starcoin_metrics::HistogramTimer> =
             self.inner.metrics.as_ref().map(|metrics| {
                 metrics
                     .txpool_service_time
@@ -173,7 +174,8 @@ impl TxPoolSyncService for TxPoolService {
         let current_timestamp_secs = current_timestamp_secs
             .unwrap_or_else(|| self.inner.node_config.net().time_service().now_secs());
         let pool_client = PoolClient::new(
-            header.clone(),
+            state_root1,
+            state_root2,
             self.inner.storage.clone(),
             self.inner.storage2.clone(),
             NonceCache::new(0),
@@ -182,7 +184,7 @@ impl TxPoolSyncService for TxPoolService {
         let r =
             self.inner
                 .get_pending_with_pool_client(max_len, current_timestamp_secs, pool_client);
-        r.into_iter().map(|t| t.signed().clone()).collect()
+        Ok(r.into_iter().map(|t| t.signed().clone()).collect())
     }
 
     /// Returns next valid sequence number for given sender
@@ -194,13 +196,34 @@ impl TxPoolSyncService for TxPoolService {
                 .with_label_values(&["next_sequence_number"])
                 .start_timer()
         });
-        self.inner.next_sequence_number(address)
+        self.inner.next_sequence_number(MultiAccountAddress::VM1(address))
     }
 
-    fn next_sequence_number_with_header(
+    fn next_sequence_number_in_batch(
+        &self,
+        addresses: Vec<AccountAddress>,
+        state_root1: HashValue,
+        state_root2: HashValue,
+    ) -> Option<Vec<(AccountAddress, Option<u64>)>> {
+        let _timer = self.inner.metrics.as_ref().map(|metrics| {
+            metrics
+                .txpool_service_time
+                .with_label_values(&["next_sequence_number"])
+                .start_timer()
+        });
+        self.inner.next_sequence_number_in_batch(addresses.into_iter().map(MultiAccountAddress::VM1).collect(), state_root1, state_root2).map(|results| {
+            results.into_iter().map(|(address, seq)| (match address {
+                MultiAccountAddress::VM1(account_address) => account_address,
+                MultiAccountAddress::VM2(_account_address) => panic!("unexpected account address in next_sequence_number2_in_batch"),
+            }, seq)).collect()
+        })
+    }
+
+    fn next_sequence_number_with_state(
         &self,
         address: AccountAddress,
-        header: &BlockHeader,
+        state_root1: HashValue,
+        state_root2: HashValue,
     ) -> Option<u64> {
         let _timer = self.inner.metrics.as_ref().map(|metrics| {
             metrics
@@ -208,7 +231,8 @@ impl TxPoolSyncService for TxPoolService {
                 .with_label_values(&["next_sequence_number_with_header"])
                 .start_timer()
         });
-        self.inner.next_sequence_number_with_header(address, header)
+        self.inner
+            .next_sequence_number_with_state(MultiAccountAddress::VM1(address), state_root1, state_root2)
     }
 
     /// subscribe
@@ -274,13 +298,14 @@ impl TxPoolSyncService for TxPoolService {
                 .with_label_values(&["next_sequence_number2"])
                 .start_timer()
         });
-        self.inner.next_sequence_number2(address)
+        self.inner.next_sequence_number(MultiAccountAddress::VM2(address))
     }
 
-    fn next_sequence_number2_with_header(
+    fn next_sequence_number2_with_state(
         &self,
         address: AccountAddress2,
-        header: &BlockHeader,
+        state_root1: HashValue,
+        state_root2: HashValue,
     ) -> Option<u64> {
         let _timer = self.inner.metrics.as_ref().map(|metrics| {
             metrics
@@ -289,8 +314,29 @@ impl TxPoolSyncService for TxPoolService {
                 .start_timer()
         });
         self.inner
-            .next_sequence_number2_with_header(address, header)
+            .next_sequence_number_with_state(MultiAccountAddress::VM2(address), state_root1, state_root2)
     }
+    
+    fn next_sequence_number2_in_batch(
+        &self,
+        addresses: Vec<AccountAddress2>,
+        state_root1: HashValue,
+        state_root2: HashValue,
+    ) -> Option<Vec<(AccountAddress2, Option<u64>)>> {
+        let _timer = self.inner.metrics.as_ref().map(|metrics| {
+            metrics
+                .txpool_service_time
+                .with_label_values(&["next_sequence_number"])
+                .start_timer()
+        });
+        self.inner.next_sequence_number_in_batch(addresses.into_iter().map(MultiAccountAddress::VM2).collect(), state_root1, state_root2).map(|results| {
+            results.into_iter().map(|(address, seq)| (match address {
+                MultiAccountAddress::VM1(_account_address) => panic!("unexpected account address in next_sequence_number2_in_batch"),
+                MultiAccountAddress::VM2(account_address) => account_address,
+            }, seq)).collect()
+        })
+    }
+    
 }
 
 pub(crate) type TxnQueue = TransactionQueue;
@@ -338,13 +384,14 @@ impl Inner {
         ))
     }
 
-    pub(crate) fn cull(&self) {
+    pub(crate) fn cull(&self) -> Result<()>{
         // NOTICE: as the new head block event is repeated with chain_new_block event,
         // we need to remove invalid txn here.
         // In fact, it would be better if caller can make it into one.
         // In this situation, we don't need to reimport invalid txn on chain_new_block.
         let now_seconds = self.chain_header.read().timestamp() / 1000;
-        self.queue.cull(self.get_pool_client(), now_seconds)
+        self.queue.cull(self.get_pool_client()?, now_seconds);
+        Ok(())
     }
 
     pub(crate) fn import_txns(
@@ -352,12 +399,12 @@ impl Inner {
         txns: Vec<MultiSignedUserTransaction>,
         bypass_vm1_limit: bool,
         peer_id: Option<String>,
-    ) -> Vec<Result<(), MultiTransactionError>> {
+    ) -> Result<Vec<Result<(), MultiTransactionError>>> {
         let txns = txns
             .into_iter()
             .map(|t| PoolTransaction::Unverified(UnverifiedUserTransaction::from(t)));
-        self.queue
-            .import(self.get_pool_client(), txns, bypass_vm1_limit, peer_id)
+        Ok(self.queue
+            .import(self.get_pool_client()?, txns, bypass_vm1_limit, peer_id))
     }
     pub(crate) fn remove_txn(
         &self,
@@ -373,16 +420,17 @@ impl Inner {
         &self,
         max_len: u64,
         current_timestamp_secs: u64,
-    ) -> Vec<Arc<VerifiedTransaction>> {
-        let pending_settings = PendingSettings {
-            block_number: u64::MAX,
-            current_timestamp: current_timestamp_secs,
-            max_len: max_len as usize,
-            ordering: PendingOrdering::Priority,
-        };
-        self.queue
-            .inner_status(self.get_pool_client(), u64::MAX, current_timestamp_secs);
-        self.queue.pending(self.get_pool_client(), pending_settings)
+    ) -> Result<Vec<Arc<VerifiedTransaction>>> {
+        // let pending_settings = PendingSettings {
+        //     block_number: u64::MAX,
+        //     current_timestamp: current_timestamp_secs,
+        //     max_len: max_len as usize,
+        //     ordering: PendingOrdering::Priority,
+        // };
+        // self.queue
+        //     .inner_status(self.get_pool_client(), u64::MAX, current_timestamp_secs);
+        // self.queue.pending(self.get_pool_client(), pending_settings)
+        Ok(self.get_pending_with_pool_client(max_len, current_timestamp_secs, self.get_pool_client()?))
     }
 
     pub fn get_pending_with_pool_client(
@@ -407,25 +455,52 @@ impl Inner {
         self.queue.try_read()
     }
 
-    pub(crate) fn next_sequence_number(&self, address: AccountAddress) -> Option<u64> {
+    pub(crate) fn next_sequence_number(&self, address: MultiAccountAddress) -> Option<u64> {
+        let client = match self.get_pool_client() {
+            Ok(client) => client,
+            Err(e) => {
+                error!("failed to get pool client in next_sequence_number: {}", e);
+                return None;
+            }
+        };
         self.queue
-            .next_sequence_number(self.get_pool_client(), &MultiAccountAddress::VM1(address))
+            .next_sequence_number(client, &address)
     }
 
-    pub(crate) fn next_sequence_number_with_header(
+    pub(crate) fn next_sequence_number_in_batch(
         &self,
-        address: AccountAddress,
-        header: &BlockHeader,
-    ) -> Option<u64> {
+        addresses: Vec<MultiAccountAddress>,
+        state_root1: HashValue,
+        state_root2: HashValue,
+    ) -> Option<Vec<(MultiAccountAddress, Option<u64>)>> {
         let pool_client = PoolClient::new(
-            header.clone(),
+            state_root1,
+            state_root2,
             self.storage.clone(),
             self.storage2.clone(),
             NonceCache::new(0),
             self.vm_metrics.clone(),
         );
         self.queue
-            .next_sequence_number(pool_client, &MultiAccountAddress::VM1(address))
+            .next_sequence_number_in_batch(pool_client, addresses)
+    }
+
+    pub(crate) fn next_sequence_number_with_state(
+        &self,
+        address: MultiAccountAddress,
+        state_root1: HashValue,
+        state_root2: HashValue,
+    ) -> Option<u64> {
+        let pool_client = PoolClient::new(
+            state_root1,
+            state_root2,
+            self.storage.clone(),
+            self.storage2.clone(),
+            NonceCache::new(0),
+            self.vm_metrics.clone(),
+        );
+        self.queue
+            .next_sequence_number(pool_client, &address)
     }
 
     pub(crate) fn subscribe_txns(&self) -> mpsc::UnboundedReceiver<TxnStatusFullEvent> {
@@ -468,7 +543,14 @@ impl Inner {
                 txns.into_iter()
             })
             .map(|t| PoolTransaction::Retracted(UnverifiedUserTransaction::from(t)));
-        let results = self.queue.import(self.get_pool_client(), txns, true, None);
+        let client = match self.get_pool_client() {
+            Ok(client) => client,
+            Err(e) => {
+                error!("failed to get pool client in chain_new_block: {}", e);
+                return;
+            }
+        };
+        let results = self.queue.import(client, txns, true, None);
         for result in results {
             if let Err(err) = result {
                 debug!("retracted transaction fail: {}", err);
@@ -476,34 +558,16 @@ impl Inner {
         }
     }
 
-    fn get_pool_client(&self) -> PoolClient {
-        PoolClient::new(
-            self.chain_header.read().clone(),
+    fn get_pool_client(&self) -> Result<PoolClient> {
+        let state = self.storage.get_vm_multi_state(self.chain_header.read().id())?;
+        let (state_root1, state_root2) = (state.state_root1(), state.state_root2());
+        Ok(PoolClient::new(
+            state_root1,
+            state_root2,
             self.storage.clone(),
             self.storage2.clone(),
             self.sequence_number_cache.clone(),
             self.vm_metrics.clone(),
-        )
-    }
-
-    pub(crate) fn next_sequence_number2(&self, address: AccountAddress2) -> Option<u64> {
-        self.queue
-            .next_sequence_number(self.get_pool_client(), &MultiAccountAddress::VM2(address))
-    }
-
-    pub(crate) fn next_sequence_number2_with_header(
-        &self,
-        address: AccountAddress2,
-        header: &BlockHeader,
-    ) -> Option<u64> {
-        let pool_client = PoolClient::new(
-            header.clone(),
-            self.storage.clone(),
-            self.storage2.clone(),
-            NonceCache::new(0),
-            self.vm_metrics.clone(),
-        );
-        self.queue
-            .next_sequence_number(pool_client, &MultiAccountAddress::VM2(address))
+        ))
     }
 }

--- a/types/src/multi_transaction.rs
+++ b/types/src/multi_transaction.rs
@@ -195,9 +195,21 @@ impl From<MultiSignedUserTransaction> for Transaction {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+pub struct ApiInterruptedError(pub String);
+
+impl std::fmt::Display for ApiInterruptedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "API interrupted: {}", self.0)
+    }
+}
+
+impl std::error::Error for ApiInterruptedError {}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum MultiTransactionError {
     VM1(TransactionError),
     VM2(TransactionError2),
+    ApiInterrupted(ApiInterruptedError),
 }
 
 impl Display for MultiTransactionError {
@@ -205,6 +217,7 @@ impl Display for MultiTransactionError {
         match self {
             MultiTransactionError::VM1(e) => write!(f, "VM1 error: {}", e),
             MultiTransactionError::VM2(e) => write!(f, "VM2 error: {}", e),
+            MultiTransactionError::ApiInterrupted(msg) => write!(f, "API interrupted: {}", msg),
         }
     }
 }
@@ -226,6 +239,7 @@ impl std::error::Error for MultiTransactionError {
         match self {
             Self::VM1(e) => Some(e),
             Self::VM2(e) => Some(e),
+            Self::ApiInterrupted(msg) => Some(msg),
         }
     }
 }

--- a/types/src/sync_status.rs
+++ b/types/src/sync_status.rs
@@ -50,6 +50,13 @@ impl SyncStatus {
         }
     }
 
+    pub fn new_with_state(chain_status: ChainStatus, state: SyncState) -> Self {
+        Self {
+            chain_status,
+            state,
+        }
+    }
+
     pub fn sync_begin(&mut self, target: BlockIdAndNumber, total_difficulty: U256) {
         self.state = SyncState::Synchronizing {
             target,

--- a/vm/types/src/transaction/error.rs
+++ b/vm/types/src/transaction/error.rs
@@ -66,7 +66,7 @@ pub enum Error {
     /// Transaction too big
     TooBig,
     CallErr(CallError),
-    /// Api error, some technical error
+    /// API error, some technical error
     ApiInterrupted(String),
 }
 
@@ -104,7 +104,7 @@ impl fmt::Display for Error {
             }
             TooBig => "Transaction too big".into(),
             CallErr(call_err) => format!("Call txn err: {}.", call_err),
-            ApiInterrupted(msg) => format!("Api interupted for the reason: {}.", msg),
+            ApiInterrupted(msg) => format!("API interupted for the reason: {}.", msg),
         };
 
         f.write_fmt(format_args!("Transaction error ({})", msg))

--- a/vm/types/src/transaction/error.rs
+++ b/vm/types/src/transaction/error.rs
@@ -1,5 +1,5 @@
 use crate::vm_status::VMStatus;
-use std::{error, fmt};
+use std::{error, fmt::{self, format}};
 
 type Gas = u64;
 type GasPrice = u64;
@@ -66,6 +66,8 @@ pub enum Error {
     /// Transaction too big
     TooBig,
     CallErr(CallError),
+    /// Api error, some technical error
+    ApiInterrupted(String),
 }
 
 impl fmt::Display for Error {
@@ -75,34 +77,34 @@ impl fmt::Display for Error {
             AlreadyImported => "Already imported".into(),
             Old => "No longer valid".into(),
             TooCheapToReplace { prev, new } => format!(
-                "Gas price too low to replace, previous tx gas: {:?}, new tx gas: {:?}",
-                prev, new
-            ),
+                        "Gas price too low to replace, previous tx gas: {:?}, new tx gas: {:?}",
+                        prev, new
+                    ),
             LimitReached(e) => format!("Transaction limit reached, {e}"),
             InsufficientGasPrice { minimal, got } => {
-                format!("Insufficient gas price. Min={}, Given={}", minimal, got)
-            }
+                        format!("Insufficient gas price. Min={}, Given={}", minimal, got)
+                    }
             InsufficientGas { minimal, got } => {
-                format!("Insufficient gas. Min={}, Given={}", minimal, got)
-            }
+                        format!("Insufficient gas. Min={}, Given={}", minimal, got)
+                    }
             InsufficientBalance { balance, cost } => format!(
-                "Insufficient balance for transaction. Balance={}, Cost={}",
-                balance, cost
-            ),
+                        "Insufficient balance for transaction. Balance={}, Cost={}",
+                        balance, cost
+                    ),
             GasLimitExceeded { limit, got } => {
-                format!("Gas limit exceeded. Limit={}, Given={}", limit, got)
-            }
-            //            InvalidGasLimit(ref err) => format!("Invalid gas limit. {}", err),
+                        format!("Gas limit exceeded. Limit={}, Given={}", limit, got)
+                    }
             SenderBanned => "Sender is temporarily banned.".into(),
             RecipientBanned => "Recipient is temporarily banned.".into(),
             CodeBanned => "Contract code is temporarily banned.".into(),
             InvalidChainId => "Transaction of this chain ID is not allowed on this chain.".into(),
             InvalidSignature(ref err) => format!("Transaction has invalid signature: {}.", err),
             NotAllowed => {
-                "Sender does not have permissions to execute this type of transaction".into()
-            }
+                        "Sender does not have permissions to execute this type of transaction".into()
+                    }
             TooBig => "Transaction too big".into(),
             CallErr(call_err) => format!("Call txn err: {}.", call_err),
+            ApiInterrupted(msg) => format!("Api interupted for the reason: {}.", msg),
         };
 
         f.write_fmt(format_args!("Transaction error ({})", msg))

--- a/vm/types/src/transaction/error.rs
+++ b/vm/types/src/transaction/error.rs
@@ -1,5 +1,5 @@
 use crate::vm_status::VMStatus;
-use std::{error, fmt::{self, format}};
+use std::{error, fmt};
 
 type Gas = u64;
 type GasPrice = u64;
@@ -77,31 +77,31 @@ impl fmt::Display for Error {
             AlreadyImported => "Already imported".into(),
             Old => "No longer valid".into(),
             TooCheapToReplace { prev, new } => format!(
-                        "Gas price too low to replace, previous tx gas: {:?}, new tx gas: {:?}",
-                        prev, new
-                    ),
+                "Gas price too low to replace, previous tx gas: {:?}, new tx gas: {:?}",
+                prev, new
+            ),
             LimitReached(e) => format!("Transaction limit reached, {e}"),
             InsufficientGasPrice { minimal, got } => {
-                        format!("Insufficient gas price. Min={}, Given={}", minimal, got)
-                    }
+                format!("Insufficient gas price. Min={}, Given={}", minimal, got)
+            }
             InsufficientGas { minimal, got } => {
-                        format!("Insufficient gas. Min={}, Given={}", minimal, got)
-                    }
+                format!("Insufficient gas. Min={}, Given={}", minimal, got)
+            }
             InsufficientBalance { balance, cost } => format!(
-                        "Insufficient balance for transaction. Balance={}, Cost={}",
-                        balance, cost
-                    ),
+                "Insufficient balance for transaction. Balance={}, Cost={}",
+                balance, cost
+            ),
             GasLimitExceeded { limit, got } => {
-                        format!("Gas limit exceeded. Limit={}, Given={}", limit, got)
-                    }
+                format!("Gas limit exceeded. Limit={}, Given={}", limit, got)
+            }
             SenderBanned => "Sender is temporarily banned.".into(),
             RecipientBanned => "Recipient is temporarily banned.".into(),
             CodeBanned => "Contract code is temporarily banned.".into(),
             InvalidChainId => "Transaction of this chain ID is not allowed on this chain.".into(),
             InvalidSignature(ref err) => format!("Transaction has invalid signature: {}.", err),
             NotAllowed => {
-                        "Sender does not have permissions to execute this type of transaction".into()
-                    }
+                "Sender does not have permissions to execute this type of transaction".into()
+            }
             TooBig => "Transaction too big".into(),
             CallErr(call_err) => format!("Call txn err: {}.", call_err),
             ApiInterrupted(msg) => format!("Api interupted for the reason: {}.", msg),

--- a/vm2/starcoin-transactional-test-harness/src/fork_chain.rs
+++ b/vm2/starcoin-transactional-test-harness/src/fork_chain.rs
@@ -628,7 +628,7 @@ impl ChainApi for MockChainApi {
         Box::pin(fut.boxed().map_err(map_err))
     }
 
-    fn get_block_info_by_hash(&self, id: HashValue) -> FutureResult<Option<BlockInfoView>> {
+    fn get_block_info_by_hash(&self, _id: HashValue) -> FutureResult<Option<BlockInfoView>> {
         let fut = async move {
             bail!("not implemented.");
         };

--- a/vm2/starcoin-transactional-test-harness/src/fork_chain.rs
+++ b/vm2/starcoin-transactional-test-harness/src/fork_chain.rs
@@ -627,6 +627,13 @@ impl ChainApi for MockChainApi {
         };
         Box::pin(fut.boxed().map_err(map_err))
     }
+
+    fn get_block_info_by_hash(&self, id: HashValue) -> FutureResult<Option<BlockInfoView>> {
+        let fut = async move {
+            bail!("not implemented.");
+        };
+        Box::pin(fut.boxed().map_err(map_err))
+    }
 }
 
 fn try_decode_block_txns(state: &dyn StateView, block: &mut BlockView) -> anyhow::Result<()> {

--- a/vm2/vm-types/src/transaction/error.rs
+++ b/vm2/vm-types/src/transaction/error.rs
@@ -66,7 +66,7 @@ pub enum Error {
     /// Transaction too big
     TooBig,
     CallErr(CallError),
-    /// Api error, some technical error
+    /// API error, some technical error
     ApiInterrupted(String),
 }
 
@@ -105,7 +105,7 @@ impl fmt::Display for Error {
             }
             TooBig => "Transaction too big".into(),
             CallErr(call_err) => format!("Call txn err: {}.", call_err),
-            ApiInterrupted(msg) => format!("Api interupted for the reason: {}.", msg),
+            ApiInterrupted(msg) => format!("API interupted for the reason: {}.", msg),
         };
 
         f.write_fmt(format_args!("Transaction error ({})", msg))

--- a/vm2/vm-types/src/transaction/error.rs
+++ b/vm2/vm-types/src/transaction/error.rs
@@ -66,6 +66,8 @@ pub enum Error {
     /// Transaction too big
     TooBig,
     CallErr(CallError),
+    /// Api error, some technical error
+    ApiInterrupted(String),
 }
 
 impl fmt::Display for Error {
@@ -103,6 +105,7 @@ impl fmt::Display for Error {
             }
             TooBig => "Transaction too big".into(),
             CallErr(call_err) => format!("Call txn err: {}.", call_err),
+            ApiInterrupted(msg) => format!("Api interupted for the reason: {}.", msg),
         };
 
         f.write_fmt(format_args!("Transaction error ({})", msg))


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch account ops: unlock multiple accounts and sign multiple transactions in one call.
  * Tx pool: submit multiple transactions at once; query next-sequence numbers for many addresses.
  * Chain RPC: fetch block info by hash.

* **CLI**
  * Added transfer_account_size; batch-based submission and system-time-based expiration.

* **Improvements**
  * Enhanced error handling, logging, and pending-transaction retrieval.

* **Breaking Changes**
  * Sync status RPC and schema now use SyncStatusView.

* **Chores**
  * Docker image no longer includes a previously bundled binary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->