### PR TITLE
Fix: when minting a new block, the epilogue transaction will be added…

### DIFF
--- a/chain/open-block/src/lib.rs
+++ b/chain/open-block/src/lib.rs
@@ -326,7 +326,7 @@ impl OpenedBlock {
         Ok((txn_state_root, accumulator_root))
     }
 
-    pub fn included_user_txns2(&self) -> &Vec<SignedUserTransaction2> {
+    pub fn included_user_txns2(&self) -> &[SignedUserTransaction2] {
         &self.included_user_txns2
     }
 

--- a/chain/open-block/src/lib.rs
+++ b/chain/open-block/src/lib.rs
@@ -326,6 +326,10 @@ impl OpenedBlock {
         Ok((txn_state_root, accumulator_root))
     }
 
+    pub fn included_user_txns2(&self) -> &Vec<SignedUserTransaction2> {
+        &self.included_user_txns2
+    }
+
     /// Construct a block template for mining.
     pub fn finalize(self) -> Result<BlockTemplate> {
         let accumulator_root = self.txn_accumulator.root_hash();

--- a/miner/src/create_block_template/block_builder_service.rs
+++ b/miner/src/create_block_template/block_builder_service.rs
@@ -548,7 +548,6 @@ where
             }
 
             // Process VM2 transactions
-            let vm2_contains_user_transaction = !txns2.is_empty();
             let excluded_txns2 = match opened_block.push_txns2(txns2) {
                 Ok(excluded_txns) => excluded_txns,
                 Err(e) => {
@@ -566,7 +565,7 @@ where
                 excluded_txns2.untouched_txns.len()
             );
 
-            if vm2_contains_user_transaction {
+            if !opened_block.included_user_txns2().is_empty() {
                 match opened_block.finalize_block_epilogue() {
                     Ok(()) => {}
                     Err(e) => {


### PR DESCRIPTION
… if the included user tranaction length is large than 1.

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved block construction to reference the actual set of included transactions, making mining logic more accurate and consistent.
* **Bug Fix**
  * Fixed a gating issue so transaction presence is checked against the block’s recorded transactions, reducing mismatches during template creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->