### PR TITLE
fix block-txn-infos' order

### DIFF
--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -844,7 +844,7 @@ impl BlockChain {
         storage.save_block_transaction_ids(block_id, txn_id_vec)?;
         storage.save_block_txn_info_ids(
             block_id,
-            txn_info_ids.into_iter().chain(vm2_txn_info_ids).collect(),
+            vm2_txn_info_ids.into_iter().chain(txn_info_ids).collect(),
         )?;
         storage.commit_block(block.clone())?;
 
@@ -1597,10 +1597,10 @@ impl ChainReader for BlockChain {
                 MultiAccessPath::VM2(_) => {
                     let statedb2 = statedb2.fork_at(final_state_root_hash);
                     let state_key = final_access_path.to_state_key()?.ok_or_else(|| {
-                                format_err!(
+                        format_err!(
                                     "the transaction to be verified is vm version 2 but the access path is not"
                                 )
-                            })?;
+                    })?;
                     Some(MultiStateProof::VM2(statedb2.get_with_proof(&state_key)?))
                 }
             }
@@ -2536,7 +2536,7 @@ impl BlockChain {
         storage.save_block_transaction_ids(block_id, txn_id_vec)?;
         storage.save_block_txn_info_ids(
             block_id,
-            txn_info_ids.into_iter().chain(vm2_txn_info_ids).collect(),
+            vm2_txn_info_ids.into_iter().chain(txn_info_ids).collect(),
         )?;
 
         // Save table infos

--- a/chain/src/chain.rs
+++ b/chain/src/chain.rs
@@ -844,7 +844,10 @@ impl BlockChain {
         storage.save_block_transaction_ids(block_id, txn_id_vec)?;
         storage.save_block_txn_info_ids(
             block_id,
-            vm2_txn_info_ids.into_iter().chain(txn_info_ids).collect(),
+            std::iter::once(vm2_txn_info_ids[0])
+                .chain(txn_info_ids)
+                .chain(vm2_txn_info_ids.into_iter().skip(1))
+                .collect(),
         )?;
         storage.commit_block(block.clone())?;
 
@@ -2534,10 +2537,15 @@ impl BlockChain {
 
         // Save block's transaction ids and info ids
         storage.save_block_transaction_ids(block_id, txn_id_vec)?;
-        storage.save_block_txn_info_ids(
-            block_id,
-            vm2_txn_info_ids.into_iter().chain(txn_info_ids).collect(),
-        )?;
+        let ordered_ids = if txn_info_ids.is_empty() {
+            vm2_txn_info_ids
+        } else {
+            std::iter::once(vm2_txn_info_ids[0])
+                .chain(txn_info_ids)
+                .chain(vm2_txn_info_ids.into_iter().skip(1))
+                .collect()
+        };
+        storage.save_block_txn_info_ids(block_id, ordered_ids)?;
 
         // Save table infos
         storage.save_table_infos(txn_table_infos)?;

--- a/testsuite/features/cmd.feature
+++ b/testsuite/features/cmd.feature
@@ -16,7 +16,7 @@ Feature: cmd integration test
     Then cmd: "chain get-events {{$.chain[4].ok[0].transaction_hash}}"
     Then cmd: "chain get-txn-info-list -s 0 -c 5"
     Then cmd: "chain get-block-info {{$.chain[1].ok[0].number}}"
-    Then cmd: "chain get-txn-info --block-hash {{$.chain[1].ok[0].block_hash}} --idx 0 --vm1"
+    Then cmd: "chain get-txn-info --block-hash {{$.chain[1].ok[0].block_hash}} --idx 1 --vm1"
     Then cmd: "chain get-txn-proof --block-hash {{$.chain[1].ok[0].block_hash}} --transaction-global-index 0 --final-transaction-id {{$.chain[9].ok.transaction_info_id}} --final-transaction-info-index 1"
     Then cmd: "chain get-txn-proof --block-hash {{$.chain[1].ok[0].block_hash}} --transaction-global-index 0 --raw --final-transaction-id {{$.chain[9].ok.transaction_info_id}} --final-transaction-info-index 1"
     Then stop


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Changed ordering when saving transaction info so one VM's first transaction precedes the other VM's transactions; added a safety guard to handle empty transaction lists.

* **Tests**
  * Updated an integration test to expect the new ordering (command now retrieves the second transaction index for the affected block).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->