### PR TITLE
feat(cli): show STC balances from primary stores

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "networks"]
 	path = networks
-	url = ../starcoin-networks.git
+	url = https://github.com/starcoinorg/starcoin-networks.git
 	branch = latest

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "networks"]
 	path = networks
-	url = https://github.com/starcoinorg/starcoin-networks.git
+	url = ../starcoin-networks.git
 	branch = latest

--- a/cmd/starcoin/src/account/show_cmd.rs
+++ b/cmd/starcoin/src/account/show_cmd.rs
@@ -9,10 +9,12 @@ use starcoin_rpc_client::StateRootOption;
 use starcoin_vm2_crypto::ValidCryptoMaterialStringExt;
 use starcoin_vm2_statedb::ChainStateReader;
 use starcoin_vm2_vm_types::{
-    account_address::AccountAddress, account_config::CoinStoreResource, state_view::StateReaderExt,
-    token::token_code::TokenCode,
+    account_address::AccountAddress,
+    account_config::CoinStoreResource,
+    state_view::StateReaderExt,
+    token::{stc::G_STC_TOKEN_CODE, token_code::TokenCode},
 };
-use std::collections::HashMap;
+use std::{collections::HashMap, convert::TryInto};
 
 /// Show a account info, only the accounts managed by the current node are supported
 #[derive(Debug, Parser, Default)]
@@ -72,7 +74,7 @@ impl CommandAction for ShowCommand {
             None,
         )?;
 
-        let balances: HashMap<TokenCode, u128> = resources
+        let mut balances: HashMap<TokenCode, u128> = resources
             .resources
             .into_iter()
             .filter_map(|(resource_type, resource)| {
@@ -87,6 +89,16 @@ impl CommandAction for ShowCommand {
                 }
             })
             .collect();
+
+        if let Ok(stc_struct_tag) = G_STC_TOKEN_CODE.clone().try_into() {
+            if let Ok(total_balance) =
+                chain_state_reader.get_balance_by_type(*account.address(), stc_struct_tag)
+            {
+                if total_balance > 0 || balances.contains_key(&G_STC_TOKEN_CODE) {
+                    balances.insert(G_STC_TOKEN_CODE.clone(), total_balance);
+                }
+            }
+        }
 
         let auth_key = account.public_key.authentication_key();
         Ok(AccountWithStateView {

--- a/testsuite/features/cmd.feature
+++ b/testsuite/features/cmd.feature
@@ -101,6 +101,7 @@ Feature: cmd integration test
     Then cmd: "state get-root"
     Then cmd: "dev get-coin"
     Then cmd: "account show"
+    Then assert: "{{$.account[-1].ok.balances.'0x1::starcoin_coin::STC'}} != 0"
     Then cmd: "state get-proof {{$.account[0].ok.account.address}}/1/0x1::account::Account"
     Then cmd: "state get-proof {{$.account[0].ok.account.address}}/1/0x1::account::Account --raw"
     Then cmd: "state get resource {{$.account[0].ok.account.address}} 0x1::account::Account"
@@ -321,4 +322,3 @@ Feature: cmd integration test
 #
 #    Examples:
 #      |  |
-

--- a/vm2/vm-types/src/state_view.rs
+++ b/vm2/vm-types/src/state_view.rs
@@ -97,19 +97,15 @@ pub trait StateReaderExt: StateView {
 
     /// Get balance by address and coin type
     fn get_balance_by_type(&self, address: AccountAddress, type_tag: StructTag) -> Result<u128> {
-        let rsrc_bytes = self
-            .get_state_value_bytes(&StateKey::resource(
-                &address,
-                &CoinStoreResource::struct_tag_for_token(type_tag.clone()),
-            )?)?
-            .ok_or_else(|| {
-                format_err!(
-                    "CoinStoreResource not exists at address:{} for type tag:{}",
-                    address,
-                    type_tag
-                )
-            })?;
-        let rsrc = bcs_ext::from_bytes::<CoinStoreResource>(&rsrc_bytes)?;
+        let coin_store_bytes = self.get_state_value_bytes(&StateKey::resource(
+            &address,
+            &CoinStoreResource::struct_tag_for_token(type_tag.clone()),
+        )?)?;
+
+        let mut total_balance: u128 = match coin_store_bytes {
+            Some(bytes) => bcs_ext::from_bytes::<CoinStoreResource>(&bytes)?.coin() as u128,
+            None => 0,
+        };
 
         // Read primary fungible store from user
         let primary_fungible_store_address =
@@ -124,17 +120,17 @@ pub trait StateReaderExt: StateView {
             &FungibleStoreResource::struct_tag(),
         )?;
 
-        if tag_bytes.is_some() {
-            let fungible_store = bcs_ext::from_bytes::<FungibleStoreResource>(&tag_bytes.unwrap())?;
-            Ok(rsrc.coin() as u128 + fungible_store.balance() as u128)
-        } else {
-            Ok(rsrc.coin() as u128)
+        if let Some(bytes) = tag_bytes {
+            let fungible_store = bcs_ext::from_bytes::<FungibleStoreResource>(&bytes)?;
+            total_balance += fungible_store.balance() as u128;
         }
+
+        Ok(total_balance)
     }
 
     fn get_resource_group_struct_tag_bytes(
         &self,
-        address: &AccountAddress,
+        _address: &AccountAddress,
         group_key: &StateKey,
         struct_tag: &StructTag,
     ) -> Result<Option<Bytes>> {
@@ -143,28 +139,17 @@ pub trait StateReaderExt: StateView {
             None => return Ok(None),
         };
 
-        let group_data_map =
-            bcs::from_bytes::<BTreeMap<StructTag, Bytes>>(&group_data).map_err(|e| {
-                PartialVMError::new(StatusCode::UNEXPECTED_DESERIALIZATION_ERROR).with_message(
-                    format!(
-                        "Failed to deserialize the resource group at {:? }: {:?}",
-                        group_key, e
-                    ),
-                )
-            })?;
+        let group_data_map: BTreeMap<StructTag, Bytes> = bcs::from_bytes::<
+            BTreeMap<StructTag, Bytes>,
+        >(&group_data)
+        .map_err(|e| {
+            PartialVMError::new(StatusCode::UNEXPECTED_DESERIALIZATION_ERROR).with_message(format!(
+                "Failed to deserialize the resource group at {:? }: {:?}",
+                group_key, e
+            ))
+        })?;
 
-        Ok(Some(
-            group_data_map
-                .get(struct_tag)
-                .ok_or_else(|| {
-                    format_err!(
-                        "Group struct tag not exists at address:{} for type tag:{}",
-                        address,
-                        struct_tag
-                    )
-                })?
-                .clone(),
-        ))
+        Ok(group_data_map.get(struct_tag).cloned())
     }
 
     fn get_epoch(&self) -> Result<Epoch> {


### PR DESCRIPTION
  - vm2/state_view now treats missing CoinStore as zero and adds balances from the primary_fungible_store resource group.
  - `account show` recomputes the STC entry using the combined balance so CLI/RPC users see rewards without deriving addresses manually.
  - testsuite cmd.feature asserts `account show` reports a non-zero STC balance after `dev get-coin`.
  - `.gitmodules` now points the `networks` submodule at the official GitHub repo for easier checkout.

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * STC token balance is now included in account balance information.

* **Bug Fixes**
  * Improved error handling for missing balance and resource data; system now gracefully handles absence instead of throwing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->