### PR TITLE
replace HashSet with BtreeSet to keep orders

### DIFF
--- a/chain/open-block/src/vm2.rs
+++ b/chain/open-block/src/vm2.rs
@@ -17,7 +17,7 @@ use starcoin_vm2_types::transaction::{
     TransactionInfo as TransactionInfo2, TransactionOutput as TransactionOutput2,
     TransactionStatus as TransactionStatus2,
 };
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 impl OpenedBlock {
     pub fn initialize(&mut self) -> anyhow::Result<()> {
@@ -123,7 +123,7 @@ impl OpenedBlock {
     pub fn finalize_block_epilogue(&mut self) -> anyhow::Result<()> {
         let (_state, state) = &self.state;
         // Directly use VM2 BlockEpilogue
-        let senders: HashSet<AccountAddress> = self
+        let senders: BTreeSet<AccountAddress> = self
             .included_user_txns2
             .iter()
             .map(|txn| txn.sender())

--- a/chain/tests/test_txn_info_and_proof.rs
+++ b/chain/tests/test_txn_info_and_proof.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 use anyhow::{bail, format_err, Result};
 use move_vm2_core_types::move_resource::MoveStructType;
@@ -128,7 +128,7 @@ fn test_transaction_info_and_proof() -> Result<()> {
         if contain_vm2_transactions {
             let block_epilogue_txn = Transaction2::BlockEpilogue(
                 vm2_block_metadata,
-                HashSet::from_iter([association_address2()]),
+                BTreeSet::from_iter([association_address2()]),
             );
             all_txns.push(block_epilogue_txn.into());
         }

--- a/types/src/multi_transaction.rs
+++ b/types/src/multi_transaction.rs
@@ -31,8 +31,8 @@ pub enum MultiAddress {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MultiTransaction {
-    VM1(Transaction),
-    VM2(Transaction2),
+    VM1(Box<Transaction>),
+    VM2(Box<Transaction2>),
 }
 
 impl From<AccountAddress> for MultiAddress {
@@ -50,11 +50,11 @@ impl From<AccountAddress2> for MultiAddress {
 impl MultiTransaction {
     pub fn sender_address(&self) -> MultiAddress {
         match self {
-            MultiTransaction::VM1(txn) => match txn {
+            MultiTransaction::VM1(txn) => match txn.as_ref() {
                 Transaction::UserTransaction(txn) => MultiAddress::VM1(txn.sender()),
                 Transaction::BlockMetadata(txn) => MultiAddress::VM1(txn.author()),
             },
-            MultiTransaction::VM2(txn) => match txn {
+            MultiTransaction::VM2(txn) => match txn.as_ref() {
                 Transaction2::UserTransaction(txn) => MultiAddress::VM2(txn.sender()),
                 Transaction2::BlockMetadata(txn) => MultiAddress::VM2(txn.author()),
                 Transaction2::BlockEpilogue(txn, _) => MultiAddress::VM2(txn.author()),
@@ -105,8 +105,8 @@ impl TryFrom<StcTransaction> for MultiSignedUserTransaction {
     type Error = Error;
     fn try_from(txn: StcTransaction) -> Result<Self, Self::Error> {
         Ok(match txn {
-            StcTransaction::V1(txn) => MultiSignedUserTransaction::VM1(txn.try_into()?),
-            StcTransaction::V2(txn) => MultiSignedUserTransaction::VM2(txn.try_into()?),
+            StcTransaction::V1(txn) => MultiSignedUserTransaction::VM1((*txn).try_into()?),
+            StcTransaction::V2(txn) => MultiSignedUserTransaction::VM2((*txn).try_into()?),
         })
     }
 }

--- a/types/src/transaction/stc_transaction.rs
+++ b/types/src/transaction/stc_transaction.rs
@@ -9,8 +9,8 @@ use crate::multi_transaction::{MultiAccountAddress, MultiTransaction};
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum StcTransaction {
-    V1(super::Transaction),
-    V2(Transaction2),
+    V1(Box<super::Transaction>),
+    V2(Box<Transaction2>),
 }
 
 impl StcTransaction {
@@ -23,7 +23,7 @@ impl StcTransaction {
 
     pub fn to_v1(self) -> Option<super::Transaction> {
         match self {
-            StcTransaction::V1(txn) => Some(txn),
+            StcTransaction::V1(txn) => Some(*txn),
             StcTransaction::V2(_) => None,
         }
     }
@@ -31,7 +31,7 @@ impl StcTransaction {
     pub fn to_v2(self) -> Option<Transaction2> {
         match self {
             StcTransaction::V1(_) => None,
-            StcTransaction::V2(txn) => Some(txn),
+            StcTransaction::V2(txn) => Some(*txn),
         }
     }
 
@@ -44,11 +44,11 @@ impl StcTransaction {
 
     pub fn address(&self) -> MultiAccountAddress {
         match self {
-            StcTransaction::V1(txn) => match txn {
+            StcTransaction::V1(txn) => match txn.as_ref() {
                 super::Transaction::UserTransaction(txn) => MultiAccountAddress::VM1(txn.sender()),
                 super::Transaction::BlockMetadata(txn) => MultiAccountAddress::VM1(txn.author()),
             },
-            StcTransaction::V2(txn) => match txn {
+            StcTransaction::V2(txn) => match txn.as_ref() {
                 Transaction2::UserTransaction(txn) => MultiAccountAddress::VM2(txn.sender()),
                 Transaction2::BlockMetadata(txn) => MultiAccountAddress::VM2(txn.author()),
                 Transaction2::BlockEpilogue(txn, _) => MultiAccountAddress::VM2(txn.author()),
@@ -59,12 +59,12 @@ impl StcTransaction {
 
 impl From<super::Transaction> for StcTransaction {
     fn from(txn: super::Transaction) -> Self {
-        StcTransaction::V1(txn)
+        StcTransaction::V1(Box::new(txn))
     }
 }
 
 impl From<Transaction2> for StcTransaction {
     fn from(txn: Transaction2) -> Self {
-        StcTransaction::V2(txn)
+        StcTransaction::V2(Box::new(txn))
     }
 }

--- a/vm2/vm-runtime/src/lib.rs
+++ b/vm2/vm-runtime/src/lib.rs
@@ -16,7 +16,7 @@ pub use move_vm_runtime::{move_vm, session};
 use starcoin_gas_schedule::{
     InitialGasSchedule, StarcoinGasParameters, ToOnChainGasSchedule, LATEST_GAS_FEATURE_VERSION,
 };
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 mod access_path_cache;
 mod errors;
@@ -56,7 +56,7 @@ pub trait VMExecutor: Send + Sync {
 pub enum PreprocessedTransaction {
     UserTransaction(Box<SignedUserTransaction>),
     BlockMetadata(BlockMetadata),
-    BlockEpilogue(BlockMetadata, HashSet<AccountAddress>),
+    BlockEpilogue(BlockMetadata, BTreeSet<AccountAddress>),
 }
 
 #[inline]

--- a/vm2/vm-runtime/src/starcoin_vm.rs
+++ b/vm2/vm-runtime/src/starcoin_vm.rs
@@ -10,6 +10,7 @@ use crate::move_vm_ext::{MoveVmExt, SessionExt, SessionId, StarcoinMoveResolver}
 use crate::{
     default_gas_schedule, discard_error_output, discard_error_vm_status, PreprocessedTransaction,
 };
+use crate::{verifier, VMExecutor};
 use anyhow::{bail, format_err, Error, Result};
 use move_core_types::gas_algebra::{InternalGasPerByte, NumBytes};
 use move_core_types::move_resource::MoveStructType;
@@ -26,6 +27,8 @@ use starcoin_gas_schedule::{
     G_LATEST_GAS_PARAMS, LATEST_GAS_FEATURE_VERSION,
 };
 use starcoin_logger::prelude::*;
+#[cfg(feature = "metrics")]
+use starcoin_metrics::metrics::VMMetrics;
 use starcoin_types::account_config::config_change::ConfigChangeEvent;
 use starcoin_types::{
     account_config,
@@ -35,6 +38,7 @@ use starcoin_types::{
         TransactionPayload, TransactionStatus,
     },
 };
+use starcoin_vm1_types::stdlib::StdlibVersion;
 use starcoin_vm_runtime_types::storage::change_set_configs::ChangeSetConfigs;
 use starcoin_vm_types::on_chain_config::{Features, TimedFeaturesBuilder};
 use starcoin_vm_types::transaction::TransactionAuxiliaryData;
@@ -59,13 +63,8 @@ use starcoin_vm_types::{
 };
 use std::cmp::max;
 use std::sync::atomic::AtomicUsize;
-use std::{borrow::Borrow, cmp::min, collections::HashSet, sync::Arc};
-
-use crate::{verifier, VMExecutor};
-#[cfg(feature = "metrics")]
-use starcoin_metrics::metrics::VMMetrics;
-use starcoin_vm1_types::stdlib::StdlibVersion;
 use std::sync::LazyLock;
+use std::{borrow::Borrow, cmp::min, collections::BTreeSet, sync::Arc};
 
 static EXECUTION_CONCURRENCY_LEVEL: LazyLock<AtomicUsize> = LazyLock::new(|| AtomicUsize::new(1));
 
@@ -953,7 +952,7 @@ impl StarcoinVM {
     fn process_block_epilogue<S: StarcoinMoveResolver>(
         &self,
         storage: &S,
-        senders: HashSet<AccountAddress>,
+        senders: BTreeSet<AccountAddress>,
     ) -> Result<TransactionOutput, VMStatus> {
         #[cfg(feature = "testing")]
         info!("process_block_epilogue begin");
@@ -1524,7 +1523,7 @@ impl StarcoinVM {
 pub enum TransactionBlock {
     UserTransaction(Vec<SignedUserTransaction>),
     BlockPrologue(BlockMetadata),
-    BlockEpilogue(BlockMetadata, HashSet<AccountAddress>),
+    BlockEpilogue(BlockMetadata, BTreeSet<AccountAddress>),
 }
 
 impl TransactionBlock {

--- a/vm2/vm-types/src/transaction/mod.rs
+++ b/vm2/vm-types/src/transaction/mod.rs
@@ -36,7 +36,7 @@ use starcoin_crypto::{
     traits::*,
     HashValue,
 };
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::ops::Deref;
 use std::{convert::TryFrom, fmt};
 
@@ -982,7 +982,7 @@ pub enum Transaction {
     /// Transaction to update the block metadata resource at the beginning of a block.
     BlockMetadata(BlockMetadata),
     /// Block Epilogue, gathering all sender address to process transaction fee
-    BlockEpilogue(BlockMetadata, HashSet<AccountAddress>),
+    BlockEpilogue(BlockMetadata, BTreeSet<AccountAddress>),
 }
 
 // Legacy BlockMetadata for database upgrade compatibility

--- a/vm2/vm-types/src/transaction/mod.rs
+++ b/vm2/vm-types/src/transaction/mod.rs
@@ -1063,9 +1063,10 @@ impl Transaction {
         match self {
             Self::UserTransaction(signed) => signed.id(),
             Self::BlockMetadata(block_metadata) => block_metadata.id(),
-            Self::BlockEpilogue(block_metadata, _) => {
-                let meta_id: HashValue = block_metadata.id();
-                HashValue::sha3_256_of(meta_id.as_ref())
+            Self::BlockEpilogue(block_metadata, senders) => {
+                let block_epilogue_bytes = bcs_ext::to_bytes(&(block_metadata, senders))
+                    .expect("Serialize BlockEpilogue should success.");
+                HashValue::sha3_256_of(block_epilogue_bytes.as_ref())
             }
         }
     }

--- a/vm2/vm-types/src/transaction/tests.rs
+++ b/vm2/vm-types/src/transaction/tests.rs
@@ -1,8 +1,13 @@
-use crate::transaction::Script;
+use crate::account_address::AccountAddress;
+use crate::account_config::genesis_address;
+use crate::block_metadata::BlockMetadata;
+use crate::on_chain_resource::ChainId;
+use crate::transaction::{Script, Transaction};
 use crate::transaction_argument::convert_txn_args;
-use move_core_types::account_address::AccountAddress;
 use move_core_types::transaction_argument::TransactionArgument;
 use move_core_types::u256;
+use starcoin_crypto::HashValue;
+use std::collections::BTreeSet;
 
 #[test]
 fn test_transaction_argument_to_json() {
@@ -27,4 +32,30 @@ fn test_transaction_argument_to_json() {
     let serialized = serde_json::to_value(&script).expect("json to_value should success.");
     let deserialized = serde_json::from_value(serialized).expect("json from_value should success.");
     assert_eq!(script, deserialized);
+}
+
+#[test]
+fn block_epilogue_id_depends_on_senders() {
+    let metadata = BlockMetadata::new(
+        HashValue::zero(),
+        1,
+        genesis_address(),
+        0,
+        1,
+        ChainId::test(),
+        0,
+        vec![HashValue::zero()],
+        0,
+    );
+
+    let mut senders_one = BTreeSet::new();
+    senders_one.insert(AccountAddress::from_hex_literal("0x1").unwrap());
+
+    let mut senders_two = senders_one.clone();
+    senders_two.insert(AccountAddress::from_hex_literal("0x2").unwrap());
+
+    let epilogue_one = Transaction::BlockEpilogue(metadata.clone(), senders_one);
+    let epilogue_two = Transaction::BlockEpilogue(metadata, senders_two);
+
+    assert_ne!(epilogue_one.id(), epilogue_two.id());
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Sender collection for block-epilogue now uses an ordered set to enforce deterministic sender enumeration; several transaction wrapper variants were boxed for internal representation.

* **Behavioral Change**
  * Block-epilogue transaction identifiers now depend on the ordered sender set, so IDs differ when sender membership/order differs.

* **Tests**
  * Added tests ensuring epilogue IDs vary with different sender sets and serialization remains correct.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->