### PR TITLE
Fix VM2 delayed-field serde gating

### DIFF
--- a/commons/parallel-executor/src/executor.rs
+++ b/commons/parallel-executor/src/executor.rs
@@ -40,11 +40,13 @@ static RAYON_EXEC_POOL: Lazy<rayon::ThreadPool> = Lazy::new(|| {
         .unwrap()
 });
 
+const ID_PREFIX_GRANULARITY: u32 = 1_000_000;
+
 fn gen_id_start_value(sequential: bool) -> u32 {
+    // Keep aptos semantics: random prefix in disjoint ranges for sequential vs parallel.
     let offset = if sequential { 0 } else { 1000 };
     let mut rng = rand::rng();
-    let base: u32 = rng.random_range((1 + offset)..(1000 + offset));
-    base.saturating_mul(1_000_000)
+    rng.random_range((1 + offset)..(1000 + offset)) * ID_PREFIX_GRANULARITY
 }
 
 struct DelayedFieldCommitCoordinator {
@@ -1242,6 +1244,33 @@ mod tests {
         executor
             .execute_transactions_parallel((), transactions)
             .expect("parallel execute");
+    }
+
+    #[test]
+    fn test_delayed_field_id_start_is_in_aptos_ranges_and_disjoint() {
+        let seq_start = gen_id_start_value(true);
+        let par_start = gen_id_start_value(false);
+        assert_eq!(seq_start % ID_PREFIX_GRANULARITY, 0);
+        assert_eq!(par_start % ID_PREFIX_GRANULARITY, 0);
+        assert!((1_000_000..1_000_000_000).contains(&seq_start));
+        assert!((1_001_000_000..2_000_000_000).contains(&par_start));
+        assert!(par_start > seq_start);
+
+        let exec_a: ParallelTransactionExecutor<TestTransaction, TestExecutor> =
+            ParallelTransactionExecutor::new(num_cpus::get().max(2), None);
+        let exec_b: ParallelTransactionExecutor<TestTransaction, TestExecutor> =
+            ParallelTransactionExecutor::new(num_cpus::get().max(2), None);
+
+        assert!((1_001_000_000..2_000_000_000).contains(&exec_a.delayed_field_id_start));
+        assert!((1_001_000_000..2_000_000_000).contains(&exec_b.delayed_field_id_start));
+        assert_eq!(
+            exec_a.delayed_field_id_counter.load(Ordering::SeqCst),
+            exec_a.delayed_field_id_start
+        );
+        assert_eq!(
+            exec_b.delayed_field_id_counter.load(Ordering::SeqCst),
+            exec_b.delayed_field_id_start
+        );
     }
 
     #[test]

--- a/vm2/vm-runtime/src/data_cache.rs
+++ b/vm2/vm-runtime/src/data_cache.rs
@@ -10,7 +10,7 @@ use move_binary_format::CompiledModule;
 use move_bytecode_utils::compiled_module_viewer::CompiledModuleView;
 use move_core_types::metadata::Metadata;
 use move_core_types::resolver::{resource_size, ModuleResolver, ResourceResolver};
-use move_core_types::value::MoveTypeLayout;
+use move_core_types::value::{MoveStructLayout, MoveTypeLayout};
 use move_table_extension::{TableHandle, TableResolver};
 use move_vm_types::delayed_values::delayed_field_id::{
     DelayedFieldID, ExtractUniqueIndex, ExtractWidth, TryFromMoveValue,
@@ -244,6 +244,25 @@ impl<S: StateView> TStateView for StateViewCache<'_, S> {
 }
 
 impl<'a, S: StateView> StorageAdapter<'a, S> {
+    fn layout_has_identifier_mappings(layout: &MoveTypeLayout) -> bool {
+        match layout {
+            MoveTypeLayout::Native(..) => true,
+            MoveTypeLayout::Vector(inner) => Self::layout_has_identifier_mappings(inner),
+            MoveTypeLayout::Struct(struct_layout) => match struct_layout {
+                MoveStructLayout::Runtime(fields) => {
+                    fields.iter().any(Self::layout_has_identifier_mappings)
+                }
+                MoveStructLayout::WithFields(fields) => fields
+                    .iter()
+                    .any(|field| Self::layout_has_identifier_mappings(&field.layout)),
+                MoveStructLayout::WithTypes { fields, .. } => fields
+                    .iter()
+                    .any(|field| Self::layout_has_identifier_mappings(&field.layout)),
+            },
+            _ => false,
+        }
+    }
+
     pub fn new(
         state_store: &'a S,
         deserializer_config: DeserializerConfig,
@@ -302,6 +321,9 @@ impl<'a, S: StateView> StorageAdapter<'a, S> {
         bytes: &Bytes,
         layout: &MoveTypeLayout,
     ) -> Result<HashSet<DelayedFieldID>, StateviewError> {
+        if !Self::layout_has_identifier_mappings(layout) {
+            return Ok(HashSet::new());
+        }
         let value = deserialize_and_allow_delayed_values(bytes, layout).ok_or_else(|| {
             StateviewError::Other("Failed to deserialize value for delayed field scan".to_string())
         })?;
@@ -430,6 +452,18 @@ impl<'a, S: StateView> StorageAdapter<'a, S> {
             state_value.clone().into_metadata(),
         );
         Ok((exchanged, mapping.delayed_ids.into_inner()))
+    }
+
+    fn maybe_exchange_state_value(
+        &self,
+        state_value: &StateValue,
+        layout: &MoveTypeLayout,
+    ) -> Result<(StateValue, HashSet<DelayedFieldID>, bool), StateviewError> {
+        if !Self::layout_has_identifier_mappings(layout) {
+            return Ok((state_value.clone(), HashSet::new(), false));
+        }
+        let (exchanged, delayed_ids) = self.exchange_state_value(state_value, layout)?;
+        Ok((exchanged, delayed_ids, true))
     }
 
     pub fn materialize_output(&self, mut output: VMOutput) -> Result<TransactionOutput, VMStatus> {
@@ -749,8 +783,8 @@ impl<S: StateView> ResourceResolver for StorageAdapter<'_, S> {
                         .unwrap_or_else(StateValueMetadata::none);
                     let group_size = self.resource_group_view.resource_group_size(&key)?.get();
                     let state_value = StateValue::new_with_metadata(raw_bytes.clone(), metadata);
-                    let (exchanged, ids) = self
-                        .exchange_state_value(&state_value, layout)
+                    let (exchanged, ids, _) = self
+                        .maybe_exchange_state_value(&state_value, layout)
                         .map_err(|e| {
                             PartialVMError::new(StatusCode::STORAGE_ERROR)
                                 .with_message(format!("{:?}", e))
@@ -813,8 +847,8 @@ impl<S: StateView> ResourceResolver for StorageAdapter<'_, S> {
                             PartialVMError::new(StatusCode::STORAGE_ERROR)
                                 .with_message("Cached base value missing bytes".to_string())
                         })?;
-                        let (exchanged, ids) = self
-                            .exchange_state_value(&state_value, layout)
+                        let (exchanged, ids, exchanged_flag) = self
+                            .maybe_exchange_state_value(&state_value, layout)
                             .map_err(|e| {
                                 PartialVMError::new(StatusCode::STORAGE_ERROR)
                                     .with_message(format!("{:?}", e))
@@ -823,7 +857,7 @@ impl<S: StateView> ResourceResolver for StorageAdapter<'_, S> {
                         self.delayed_field_cache.insert_base_value(
                             state_key.clone(),
                             WriteOp::from_state_value(Some(exchanged.clone())),
-                            true,
+                            exchanged_flag,
                         );
                         Some(exchanged.bytes().clone())
                     } else {
@@ -840,8 +874,8 @@ impl<S: StateView> ResourceResolver for StorageAdapter<'_, S> {
                     let Some(state_value) = state_value else {
                         return Ok((None, 0));
                     };
-                    let (exchanged, ids) = self
-                        .exchange_state_value(&state_value, layout)
+                    let (exchanged, ids, exchanged_flag) = self
+                        .maybe_exchange_state_value(&state_value, layout)
                         .map_err(|e| {
                             PartialVMError::new(StatusCode::STORAGE_ERROR)
                                 .with_message(format!("{:?}", e))
@@ -849,7 +883,7 @@ impl<S: StateView> ResourceResolver for StorageAdapter<'_, S> {
                     self.record_resource_read(&state_key, &exchanged, layout, ids);
                     let cached = self.delayed_field_cache.get_or_insert_base_value(
                         state_key.clone(),
-                        true,
+                        exchanged_flag,
                         || Ok(WriteOp::from_state_value(Some(exchanged.clone()))),
                     )?;
                     cached.bytes().cloned()
@@ -1071,8 +1105,15 @@ impl<S: StateView> IntoMoveResolver<S> for S {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
+    use move_core_types::value::IdentifierMappingKind;
     use starcoin_vm_runtime_types::resource_group_adapter::GroupSizeKind;
+    use starcoin_vm_types::state_store::in_memory_state_view::InMemoryStateView;
+    use std::collections::HashMap;
     //use starcoin_vm_types::on_chain_config::{Features, OnChainConfig};
+
+    fn has_identifier_mapping(layout: &MoveTypeLayout) -> bool {
+        StorageAdapter::<InMemoryStateView>::layout_has_identifier_mappings(layout)
+    }
 
     // Expose a method to create a storage adapter with a provided group size kind.
     #[allow(dead_code)]
@@ -1099,5 +1140,81 @@ pub(crate) mod tests {
         );
 
         state_view.as_move_resolver()
+    }
+
+    #[test]
+    fn layout_identifier_mapping_detection_handles_non_native_layout() {
+        let plain = MoveTypeLayout::Struct(MoveStructLayout::Runtime(vec![
+            MoveTypeLayout::U8,
+            MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U64)),
+        ]));
+        assert!(!has_identifier_mapping(&plain));
+    }
+
+    #[test]
+    fn layout_identifier_mapping_detection_handles_nested_native_layout() {
+        let nested =
+            MoveTypeLayout::Struct(MoveStructLayout::Runtime(vec![MoveTypeLayout::Struct(
+                MoveStructLayout::Runtime(vec![
+                    MoveTypeLayout::Native(
+                        IdentifierMappingKind::Aggregator,
+                        Box::new(MoveTypeLayout::U64),
+                    ),
+                    MoveTypeLayout::U64,
+                ]),
+            )]));
+        assert!(has_identifier_mapping(&nested));
+    }
+
+    #[test]
+    fn layout_identifier_mapping_detection_handles_snapshot_kind() {
+        let nested =
+            MoveTypeLayout::Struct(MoveStructLayout::Runtime(vec![MoveTypeLayout::Struct(
+                MoveStructLayout::Runtime(vec![
+                    MoveTypeLayout::Native(
+                        IdentifierMappingKind::Snapshot,
+                        Box::new(MoveTypeLayout::U64),
+                    ),
+                    MoveTypeLayout::U64,
+                ]),
+            )]));
+        assert!(has_identifier_mapping(&nested));
+    }
+
+    #[test]
+    fn delayed_ids_scan_skips_plain_layout_without_deserialize() {
+        let state_view = InMemoryStateView::new(HashMap::new());
+        let resolver = state_view.as_move_resolver();
+        let plain = MoveTypeLayout::Struct(MoveStructLayout::Runtime(vec![
+            MoveTypeLayout::U8,
+            MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U64)),
+        ]));
+
+        // invalid bytes for this layout, but scan should short-circuit and return empty ids.
+        let ids = resolver
+            .delayed_ids_from_bytes(&Bytes::from_static(b"not-bcs"), &plain)
+            .expect("non-native layout should not attempt delayed-id deserialize");
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn delayed_ids_scan_tries_native_layout_deserialize() {
+        let state_view = InMemoryStateView::new(HashMap::new());
+        let resolver = state_view.as_move_resolver();
+        let nested =
+            MoveTypeLayout::Struct(MoveStructLayout::Runtime(vec![MoveTypeLayout::Struct(
+                MoveStructLayout::Runtime(vec![
+                    MoveTypeLayout::Native(
+                        IdentifierMappingKind::Aggregator,
+                        Box::new(MoveTypeLayout::U64),
+                    ),
+                    MoveTypeLayout::U64,
+                ]),
+            )]));
+
+        // The same invalid bytes should error for native layout because serde path is taken.
+        assert!(resolver
+            .delayed_ids_from_bytes(&Bytes::from_static(b"not-bcs"), &nested)
+            .is_err());
     }
 }

--- a/vm2/vm-runtime/src/parallel_executor/storage_wrapper.rs
+++ b/vm2/vm-runtime/src/parallel_executor/storage_wrapper.rs
@@ -9,7 +9,7 @@ use move_core_types::account_address::AccountAddress;
 use move_core_types::language_storage::{ModuleId, StructTag};
 use move_core_types::metadata::Metadata;
 use move_core_types::resolver::{resource_size, ModuleResolver, ResourceResolver};
-use move_core_types::value::MoveTypeLayout;
+use move_core_types::value::{MoveStructLayout, MoveTypeLayout};
 use move_table_extension::{TableHandle, TableResolver};
 use move_vm_types::delayed_values::delayed_field_id::{
     DelayedFieldID, ExtractUniqueIndex, TryFromMoveValue,
@@ -178,6 +178,25 @@ pub(crate) struct VersionedView<'a, S: StateView> {
 }
 
 impl<'a, S: StateView> VersionedView<'a, S> {
+    fn layout_has_identifier_mappings(layout: &MoveTypeLayout) -> bool {
+        match layout {
+            MoveTypeLayout::Native(..) => true,
+            MoveTypeLayout::Vector(inner) => Self::layout_has_identifier_mappings(inner),
+            MoveTypeLayout::Struct(struct_layout) => match struct_layout {
+                MoveStructLayout::Runtime(fields) => {
+                    fields.iter().any(Self::layout_has_identifier_mappings)
+                }
+                MoveStructLayout::WithFields(fields) => fields
+                    .iter()
+                    .any(|field| Self::layout_has_identifier_mappings(&field.layout)),
+                MoveStructLayout::WithTypes { fields, .. } => fields
+                    .iter()
+                    .any(|field| Self::layout_has_identifier_mappings(&field.layout)),
+            },
+            _ => false,
+        }
+    }
+
     pub fn new(
         base_view: &'a S,
         hashmap_view: &'a MVHashMapView<'a, ParallelStateKey, ParallelStateValue>,
@@ -296,6 +315,9 @@ impl<'a, S: StateView> VersionedView<'a, S> {
         bytes: &Bytes,
         layout: &MoveTypeLayout,
     ) -> Result<HashSet<DelayedFieldID>, StateviewError> {
+        if !Self::layout_has_identifier_mappings(layout) {
+            return Ok(HashSet::new());
+        }
         let value = deserialize_and_allow_delayed_values(bytes, layout).ok_or_else(|| {
             StateviewError::Other("Failed to deserialize value for delayed field scan".to_string())
         })?;
@@ -371,6 +393,19 @@ impl<'a, S: StateView> VersionedView<'a, S> {
         Ok((exchanged, mapping.delayed_ids.into_inner()))
     }
 
+    fn maybe_exchange_state_value(
+        &self,
+        state_key: &StateKey,
+        state_value: &StateValue,
+        layout: &MoveTypeLayout,
+    ) -> Result<(StateValue, HashSet<DelayedFieldID>, bool), StateviewError> {
+        if !Self::layout_has_identifier_mappings(layout) {
+            return Ok((state_value.clone(), HashSet::new(), false));
+        }
+        let (exchanged, delayed_ids) = self.exchange_state_value(state_key, state_value, layout)?;
+        Ok((exchanged, delayed_ids, true))
+    }
+
     fn read_state_value_impl(
         &self,
         state_key: &StateKey,
@@ -389,12 +424,12 @@ impl<'a, S: StateView> VersionedView<'a, S> {
             let maybe_state_value = write.as_state_value();
             if let (Some(layout), Some(state_value)) = (maybe_layout, maybe_state_value.as_ref()) {
                 if !self.delayed_field_cache.is_base_value_exchanged(state_key) {
-                    let (exchanged, ids) =
-                        self.exchange_state_value(state_key, state_value, layout)?;
+                    let (exchanged, ids, exchanged_flag) =
+                        self.maybe_exchange_state_value(state_key, state_value, layout)?;
                     self.delayed_field_cache.insert_base_value(
                         state_key.clone(),
                         WriteOp::from_state_value(Some(exchanged.clone())),
-                        true,
+                        exchanged_flag,
                     );
                     self.record_resource_read(state_key, &exchanged, layout, ids);
                     return Ok(Some(exchanged));
@@ -409,10 +444,10 @@ impl<'a, S: StateView> VersionedView<'a, S> {
         if let (Some(layout), Some(state_value)) = (maybe_layout, maybe_state_value.as_ref()) {
             let exchanged = self.delayed_field_cache.get_or_insert_base_value(
                 state_key.clone(),
-                true,
+                Self::layout_has_identifier_mappings(layout),
                 || {
-                    let (value_with_ids, ids) =
-                        self.exchange_state_value(state_key, state_value, layout)?;
+                    let (value_with_ids, ids, _) =
+                        self.maybe_exchange_state_value(state_key, state_value, layout)?;
                     self.record_resource_read(state_key, &value_with_ids, layout, ids);
                     Ok(WriteOp::from_state_value(Some(value_with_ids)))
                 },
@@ -580,8 +615,8 @@ impl<S: StateView> TResourceGroupView for VersionedView<'_, S> {
                 || {
                     let state_value =
                         StateValue::new_with_metadata(raw_bytes.clone(), metadata.clone());
-                    let (value_with_ids, ids) =
-                        self.exchange_state_value(group_key, &state_value, layout)?;
+                    let (value_with_ids, ids, _) =
+                        self.maybe_exchange_state_value(group_key, &state_value, layout)?;
                     self.record_group_read(
                         group_key,
                         metadata,
@@ -1032,5 +1067,40 @@ impl<S: StateView> starcoin_aggregator::resolver::TDelayedFieldView for Versione
             }
         }
         Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::VersionedView;
+    use move_core_types::value::{IdentifierMappingKind, MoveStructLayout, MoveTypeLayout};
+    use starcoin_vm_types::state_store::in_memory_state_view::InMemoryStateView;
+
+    fn has_identifier_mapping(layout: &MoveTypeLayout) -> bool {
+        VersionedView::<InMemoryStateView>::layout_has_identifier_mappings(layout)
+    }
+
+    #[test]
+    fn layout_identifier_mapping_detection_handles_non_native_layout() {
+        let plain = MoveTypeLayout::Struct(MoveStructLayout::Runtime(vec![
+            MoveTypeLayout::Bool,
+            MoveTypeLayout::Vector(Box::new(MoveTypeLayout::U64)),
+        ]));
+        assert!(!has_identifier_mapping(&plain));
+    }
+
+    #[test]
+    fn layout_identifier_mapping_detection_handles_nested_native_layout() {
+        let nested =
+            MoveTypeLayout::Struct(MoveStructLayout::Runtime(vec![MoveTypeLayout::Struct(
+                MoveStructLayout::Runtime(vec![
+                    MoveTypeLayout::Native(
+                        IdentifierMappingKind::Aggregator,
+                        Box::new(MoveTypeLayout::U64),
+                    ),
+                    MoveTypeLayout::U64,
+                ]),
+            )]));
+        assert!(has_identifier_mapping(&nested));
     }
 }


### PR DESCRIPTION
- gate delayed exchange by recursive IdentifierMapping layout checks in vm2 data_cache and parallel storage_wrapper

- skip delayed serde for non-mapped layouts and preserve accurate exchanged flags in delayed-field cache

- restore Aptos-style randomized delayed field id start ranges for sequential/parallel execution

- add tests for layout detection, serde gating behavior, and delayed field id start range invariants

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized delayed field processing by skipping unnecessary operations when identifier mappings are not present.

* **Bug Fixes**
  * Enhanced transaction executor with improved ID generation and validated range verification to ensure correct sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->