### PR TITLE
fix(miner): avoid template dispatch stalls in mining rpc

### DIFF
--- a/miner/src/create_block_template/mod.rs
+++ b/miner/src/create_block_template/mod.rs
@@ -47,7 +47,7 @@ impl ServiceRequest for BlockTemplateRequest {
     type Response = Result<BlockTemplateResponse>;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BlockTemplateResponse {
     pub parent: BlockHeader,
     pub template: BlockTemplate,

--- a/miner/src/lib.rs
+++ b/miner/src/lib.rs
@@ -19,6 +19,8 @@ mod create_block_template;
 pub mod generate_block_event_pacemaker;
 mod metrics;
 pub mod task;
+#[cfg(test)]
+mod tests;
 
 use crate::create_block_template::BlockTemplateResponse;
 pub use create_block_template::{BlockBuilderService, BlockTemplateRequest};

--- a/miner/src/lib.rs
+++ b/miner/src/lib.rs
@@ -4,7 +4,6 @@
 use crate::metrics::MinerMetrics;
 use crate::task::MintTask;
 use anyhow::Result;
-use futures::executor::block_on;
 use starcoin_config::NodeConfig;
 use starcoin_consensus::Consensus;
 use starcoin_logger::prelude::*;
@@ -21,6 +20,7 @@ pub mod generate_block_event_pacemaker;
 mod metrics;
 pub mod task;
 
+use crate::create_block_template::BlockTemplateResponse;
 pub use create_block_template::{BlockBuilderService, BlockTemplateRequest};
 use starcoin_crypto::HashValue;
 pub use starcoin_types::block::BlockHeaderExtra;
@@ -50,6 +50,8 @@ pub struct MinerService {
     current_task: Option<MintTask>,
     create_block_template_service: ServiceRef<BlockBuilderService>,
     client_subscribers_num: u32,
+    inflight_template_build: bool,
+    pending_template_event: Option<PendingGenerateBlockEvent>,
     metrics: Option<MinerMetrics>,
 }
 
@@ -90,10 +92,18 @@ impl ServiceHandler<Self, UpdateSubscriberNumRequest> for MinerService {
     fn handle(
         &mut self,
         req: UpdateSubscriberNumRequest,
-        _ctx: &mut ServiceContext<MinerService>,
+        ctx: &mut ServiceContext<MinerService>,
     ) -> Option<MintBlockEvent> {
+        let previous = self.client_subscribers_num;
         if let Some(num) = req.number {
             self.client_subscribers_num = num;
+            if previous == 0
+                && self.client_subscribers_num > 0
+                && self.current_task.is_none()
+                && !self.inflight_template_build
+            {
+                ctx.notify(GenerateBlockEvent::default());
+            }
         }
         self.current_task.as_ref().map(|task| MintBlockEvent {
             parent_hash: task.block_template.parent_hash,
@@ -119,6 +129,8 @@ impl ServiceFactory<MinerService> for MinerService {
             current_task: None,
             create_block_template_service,
             client_subscribers_num: 0,
+            inflight_template_build: false,
+            pending_template_event: None,
             metrics,
         })
     }
@@ -153,23 +165,90 @@ impl ServiceHandler<Self, SubmitSealRequest> for MinerService {
 // one hour
 const MAX_BLOCK_TIME_GAP: u64 = 3600 * 1000;
 
+#[derive(Clone, Copy, Debug, Default)]
+struct PendingGenerateBlockEvent {
+    break_current_task: bool,
+    skip_empty_block_check: bool,
+}
+
+impl PendingGenerateBlockEvent {
+    fn merge(&mut self, event: GenerateBlockEvent) {
+        self.break_current_task |= event.break_current_task;
+        self.skip_empty_block_check |= event.skip_empty_block_check;
+    }
+
+    fn into_event(self) -> GenerateBlockEvent {
+        GenerateBlockEvent::new(self.break_current_task, self.skip_empty_block_check)
+    }
+}
+
+impl From<GenerateBlockEvent> for PendingGenerateBlockEvent {
+    fn from(event: GenerateBlockEvent) -> Self {
+        Self {
+            break_current_task: event.break_current_task,
+            skip_empty_block_check: event.skip_empty_block_check,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct BlockTemplateBuilt {
+    request: PendingGenerateBlockEvent,
+    response: std::result::Result<BlockTemplateResponse, String>,
+}
+
 impl MinerService {
-    pub fn dispatch_task(
+    fn queue_template_build(&mut self, event: GenerateBlockEvent) {
+        match self.pending_template_event.as_mut() {
+            Some(pending) => pending.merge(event),
+            None => self.pending_template_event = Some(event.into()),
+        }
+    }
+
+    fn maybe_start_template_build(&mut self, ctx: &mut ServiceContext<MinerService>) {
+        if self.inflight_template_build {
+            return;
+        }
+
+        let request = match self.pending_template_event.take() {
+            Some(request) => request,
+            None => return,
+        };
+        self.inflight_template_build = true;
+
+        let create_block_template_service = self.create_block_template_service.clone();
+        let self_ref = ctx.self_ref();
+        ctx.spawn(async move {
+            let response = match create_block_template_service
+                .send(BlockTemplateRequest)
+                .await
+            {
+                Ok(Ok(response)) => Ok(response),
+                Ok(Err(err)) => Err(err.to_string()),
+                Err(err) => Err(err.to_string()),
+            };
+
+            if let Err(err) = self_ref.notify(BlockTemplateBuilt { request, response }) {
+                warn!(
+                    target: "miner",
+                    "failed to notify block template result: {:?}",
+                    err
+                );
+            }
+        });
+    }
+
+    fn handle_block_template_built(
         &mut self,
         ctx: &mut ServiceContext<MinerService>,
-        event: GenerateBlockEvent,
+        request: PendingGenerateBlockEvent,
+        response: BlockTemplateResponse,
     ) -> Result<()> {
-        //create block template should block_on for avoid mint same block template.
-        let response = block_on(async {
-            self.create_block_template_service
-                .send(BlockTemplateRequest)
-                .await?
-        })?;
         let parent = response.parent;
         let block_template = response.template;
         let block_time_gap = block_template.timestamp - parent.timestamp();
 
-        if !event.skip_empty_block_check
+        if !request.skip_empty_block_check
             && (block_template.body.transactions.is_empty()
             && self.config.miner.is_disable_mint_empty_block()
             //if block time gap > 3600, force create a empty block for fix https://github.com/starcoinorg/starcoin/issues/3036
@@ -180,16 +259,6 @@ impl MinerService {
         } else {
             self.dispatch_mint_block_event(ctx, block_template)
         }
-    }
-
-    pub fn dispatch_sleep_task(&mut self, ctx: &mut ServiceContext<MinerService>) -> Result<()> {
-        //create block template should block_on for avoid mint same block template.
-        let response = block_on(async {
-            self.create_block_template_service
-                .send(BlockTemplateRequest)
-                .await?
-        })?;
-        self.dispatch_mint_block_event(ctx, response.template)
     }
 
     fn dispatch_mint_block_event(
@@ -284,14 +353,42 @@ impl EventHandler<Self, GenerateBlockEvent> for MinerService {
             });
             return;
         }
-        if let Err(err) = self.dispatch_task(ctx, event) {
-            warn!(
-                "Failed to process generate block event:{}, delay to trigger a new event.",
-                err
-            );
-            ctx.run_later(Duration::from_secs(2), move |ctx| {
-                ctx.notify(GenerateBlockEvent::default());
-            });
+        self.queue_template_build(event);
+        self.maybe_start_template_build(ctx);
+    }
+}
+
+impl EventHandler<Self, BlockTemplateBuilt> for MinerService {
+    fn handle_event(&mut self, event: BlockTemplateBuilt, ctx: &mut ServiceContext<MinerService>) {
+        self.inflight_template_build = false;
+
+        match event.response {
+            Ok(response) => {
+                if let Err(err) = self.handle_block_template_built(ctx, event.request, response) {
+                    warn!(
+                        target: "miner",
+                        "Failed to process generated block template: {}, delay to trigger a new event.",
+                        err
+                    );
+                    let retry_event = event.request.into_event();
+                    ctx.run_later(Duration::from_secs(2), move |ctx| {
+                        ctx.notify(retry_event.clone());
+                    });
+                }
+            }
+            Err(err) => {
+                warn!(
+                    target: "miner",
+                    "Failed to build block template: {}, delay to trigger a new event.",
+                    err
+                );
+                let retry_event = event.request.into_event();
+                ctx.run_later(Duration::from_secs(2), move |ctx| {
+                    ctx.notify(retry_event.clone());
+                });
+            }
         }
+
+        self.maybe_start_template_build(ctx);
     }
 }

--- a/miner/src/tests.rs
+++ b/miner/src/tests.rs
@@ -1,0 +1,234 @@
+// Copyright (c) The Starcoin Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    create_block_template::BlockTemplateResponse, BlockBuilderService, BlockTemplateRequest,
+    GenerateBlockEvent, MinerService, UpdateSubscriberNumRequest,
+};
+use anyhow::Error;
+use starcoin_account_service::AccountService;
+use starcoin_config::NodeConfig;
+use starcoin_genesis::Genesis;
+use starcoin_service_registry::mocker::MockHandler;
+use starcoin_service_registry::{
+    RegistryAsyncService, RegistryService, ServiceContext, ServiceRef,
+};
+use starcoin_storage::{BlockStore, Storage};
+use starcoin_txpool::TxPoolService;
+use std::any::Any;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread::sleep as blocking_sleep;
+use std::time::Duration;
+use tokio::time::{sleep, timeout};
+
+#[derive(Clone)]
+struct SlowBlockBuilderMock {
+    response: BlockTemplateResponse,
+    delay: Duration,
+    calls: Arc<AtomicUsize>,
+}
+
+impl MockHandler<BlockBuilderService> for SlowBlockBuilderMock {
+    fn handle(
+        &mut self,
+        request: Box<dyn Any>,
+        _ctx: &mut ServiceContext<BlockBuilderService>,
+    ) -> Box<dyn Any> {
+        request
+            .downcast::<BlockTemplateRequest>()
+            .expect("unexpected block template request");
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        blocking_sleep(self.delay);
+        Box::new(Ok::<BlockTemplateResponse, Error>(self.response.clone()))
+    }
+}
+
+async fn prepare_template_response() -> (Arc<NodeConfig>, Arc<Storage>, BlockTemplateResponse) {
+    let mut config = NodeConfig::random_for_test();
+    config.miner.disable_miner_client = Some(true);
+    config.miner.disable_mint_empty_block = Some(false);
+    let node_config = Arc::new(config);
+
+    let (storage, _chain_info, genesis) =
+        Genesis::init_storage_for_test(node_config.net()).unwrap();
+    let chain_header = storage
+        .get_block_header_by_hash(genesis.block().id())
+        .unwrap()
+        .unwrap();
+    let txpool = TxPoolService::new(node_config.clone(), storage.clone(), chain_header, None);
+
+    let registry = RegistryService::launch();
+    registry.put_shared(node_config.clone()).await.unwrap();
+    registry.put_shared(storage.clone()).await.unwrap();
+    registry.put_shared(txpool).await.unwrap();
+    registry
+        .register_mocker(AccountService::mock().unwrap())
+        .await
+        .unwrap();
+
+    let block_builder = registry.register::<BlockBuilderService>().await.unwrap();
+    let response = block_builder
+        .send(BlockTemplateRequest)
+        .await
+        .unwrap()
+        .unwrap();
+    registry.shutdown_system().await.unwrap();
+
+    (node_config, storage, response)
+}
+
+async fn register_miner_with_mock_builder(
+    node_config: Arc<NodeConfig>,
+    storage: Arc<Storage>,
+    mocker: SlowBlockBuilderMock,
+) -> (ServiceRef<MinerService>, ServiceRef<RegistryService>) {
+    let startup_info = storage.get_startup_info().unwrap().unwrap();
+    let chain_header = storage
+        .get_block_header_by_hash(startup_info.main)
+        .unwrap()
+        .unwrap();
+    let txpool = TxPoolService::new(node_config.clone(), storage.clone(), chain_header, None);
+
+    let registry = RegistryService::launch();
+    registry.put_shared(node_config).await.unwrap();
+    registry.put_shared(storage).await.unwrap();
+    registry.put_shared(txpool).await.unwrap();
+    registry
+        .register_mocker(AccountService::mock().unwrap())
+        .await
+        .unwrap();
+    registry.register_mocker(mocker).await.unwrap();
+
+    let miner = registry.register::<MinerService>().await.unwrap();
+    (miner, registry)
+}
+
+#[stest::test]
+async fn test_generate_block_event_keeps_miner_service_responsive() {
+    let (node_config, storage, response) = prepare_template_response().await;
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mocker = SlowBlockBuilderMock {
+        response,
+        delay: Duration::from_secs(1),
+        calls: calls.clone(),
+    };
+    let (miner, registry) = register_miner_with_mock_builder(node_config, storage, mocker).await;
+
+    miner
+        .send(UpdateSubscriberNumRequest { number: Some(1) })
+        .await
+        .unwrap();
+    sleep(Duration::from_millis(50)).await;
+
+    for _ in 0..64 {
+        miner.notify(GenerateBlockEvent::new_break(true)).unwrap();
+    }
+
+    timeout(
+        Duration::from_millis(200),
+        miner.send(UpdateSubscriberNumRequest { number: None }),
+    )
+    .await
+    .expect("miner service should stay responsive while building")
+    .unwrap();
+
+    sleep(Duration::from_millis(200)).await;
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "only one block template build should be inflight"
+    );
+
+    sleep(Duration::from_millis(1200)).await;
+    assert!(
+        calls.load(Ordering::SeqCst) <= 2,
+        "refresh events should coalesce into a single pending rebuild"
+    );
+
+    registry.shutdown_system().await.unwrap();
+}
+
+#[stest::test]
+async fn test_subscriber_registration_triggers_first_job_build() {
+    let (node_config, storage, response) = prepare_template_response().await;
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mocker = SlowBlockBuilderMock {
+        response,
+        delay: Duration::from_millis(50),
+        calls: calls.clone(),
+    };
+    let (miner, registry) = register_miner_with_mock_builder(node_config, storage, mocker).await;
+
+    let initial = miner
+        .send(UpdateSubscriberNumRequest { number: Some(1) })
+        .await
+        .unwrap();
+    assert!(initial.is_none());
+
+    let minted = timeout(Duration::from_secs(2), async {
+        loop {
+            if let Some(event) = miner
+                .send(UpdateSubscriberNumRequest { number: None })
+                .await
+                .unwrap()
+            {
+                break event;
+            }
+            sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("first subscriber should trigger an initial mint job");
+
+    assert!(!minted.minting_blob.is_empty());
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    registry.shutdown_system().await.unwrap();
+}
+
+#[stest::test]
+async fn test_slow_block_template_build_still_dispatches_job() {
+    let (node_config, storage, response) = prepare_template_response().await;
+    let calls = Arc::new(AtomicUsize::new(0));
+    let mocker = SlowBlockBuilderMock {
+        response,
+        delay: Duration::from_secs(6),
+        calls: calls.clone(),
+    };
+    let (miner, registry) = register_miner_with_mock_builder(node_config, storage, mocker).await;
+
+    let initial = miner
+        .send(UpdateSubscriberNumRequest { number: Some(1) })
+        .await
+        .unwrap();
+    assert!(initial.is_none());
+
+    timeout(
+        Duration::from_millis(200),
+        miner.send(UpdateSubscriberNumRequest { number: None }),
+    )
+    .await
+    .expect("miner service should stay responsive while waiting for a slow template build")
+    .unwrap();
+
+    let minted = timeout(Duration::from_secs(8), async {
+        loop {
+            if let Some(event) = miner
+                .send(UpdateSubscriberNumRequest { number: None })
+                .await
+                .unwrap()
+            {
+                break event;
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("slow block template builds should still publish a mint job");
+
+    assert!(!minted.minting_blob.is_empty());
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    registry.shutdown_system().await.unwrap();
+}

--- a/rpc/server/src/module/pubsub.rs
+++ b/rpc/server/src/module/pubsub.rs
@@ -231,6 +231,12 @@ impl PubSubService {
         let id = self.subscriber_id.fetch_add(1, atomic::Ordering::SeqCst);
         SubscriptionId::Number(id)
     }
+
+    fn sync_mint_block_subscribers(&self) {
+        self.miner_service.do_send(UpdateSubscriberNumRequest {
+            number: Some(self.mint_block_subscribers.len() as u32),
+        });
+    }
 }
 
 type NewHeadNotification = Notification<ThinBlock>;
@@ -265,7 +271,9 @@ impl ActorEventHandler<Self, ContractEventNotification> for PubSubService {
 
 impl ActorEventHandler<Self, MintBlockEvent> for PubSubService {
     fn handle_event(&mut self, msg: MintBlockEvent, _ctx: &mut ServiceContext<PubSubService>) {
-        send_to_all(&mut self.mint_block_subscribers, msg);
+        if send_to_all(&mut self.mint_block_subscribers, msg) > 0 {
+            self.sync_mint_block_subscribers();
+        }
     }
 }
 
@@ -283,11 +291,13 @@ impl ServiceHandler<Self, SubscribeNewHeads> for PubSubService {
         let subscriber_id = self.next_id();
         self.new_header_subscribers
             .insert(subscriber_id.clone(), sender);
+        let service_ref = ctx.self_ref();
         ctx.spawn(run_subscription(
             receiver,
             subscriber_id,
             sink,
             NewHeadHandler,
+            Some(service_ref),
         ));
     }
 }
@@ -306,19 +316,19 @@ impl ServiceHandler<Self, SubscribeMintBlock> for PubSubService {
         let subscriber_id = self.next_id();
         self.mint_block_subscribers
             .insert(subscriber_id.clone(), sender.clone());
+        self.sync_mint_block_subscribers();
         let miner_service = self.miner_service.clone();
-        let subscribers_num = self.mint_block_subscribers.len() as u32;
+        let service_ref = ctx.self_ref();
         ctx.spawn(run_subscription(
             receiver,
             subscriber_id,
             subscriber,
             NewMintBlockHandler,
+            Some(service_ref),
         ));
         ctx.spawn(async move {
             match miner_service
-                .send(UpdateSubscriberNumRequest {
-                    number: Some(subscribers_num),
-                })
+                .send(UpdateSubscriberNumRequest { number: None })
                 .await
             {
                 Ok(Some(event)) => {
@@ -355,6 +365,7 @@ impl ServiceHandler<Self, SubscribeEvents> for PubSubService {
         let subscriber_id = self.next_id();
         self.new_event_subscribers
             .insert(subscriber_id.clone(), sender);
+        let service_ref = ctx.self_ref();
         ctx.spawn(run_subscription(
             receiver,
             subscriber_id,
@@ -364,6 +375,7 @@ impl ServiceHandler<Self, SubscribeEvents> for PubSubService {
                 filter,
                 decode,
             },
+            Some(service_ref),
         ));
     }
 }
@@ -384,12 +396,14 @@ impl ServiceHandler<Self, SubscribeNewPendingTxns> for PubSubService {
         let tasks = self.new_pending_txn_tasks.clone();
         let subscriber_id_clone = subscriber_id.clone();
         let receiver = self.txpool.subscribe_pending_txn();
+        let service_ref = ctx.self_ref();
         let (f, abort_handle) = futures::future::abortable(async move {
             run_subscription(
                 receiver,
                 subscriber_id_clone.clone(),
                 subscriber,
                 TxnEventHandler,
+                Some(service_ref),
             )
             .await;
             // remove self from task list.
@@ -417,10 +431,9 @@ impl ServiceHandler<Self, Unsubscribe> for PubSubService {
     fn handle(&mut self, msg: Unsubscribe, _ctx: &mut ServiceContext<Self>) {
         self.new_header_subscribers.remove(&msg.0);
         self.new_event_subscribers.remove(&msg.0);
-        self.mint_block_subscribers.remove(&msg.0);
-        self.miner_service.do_send(UpdateSubscriberNumRequest {
-            number: Some(self.mint_block_subscribers.len() as u32),
-        });
+        if self.mint_block_subscribers.remove(&msg.0).is_some() {
+            self.sync_mint_block_subscribers();
+        }
         if let Some(h) = self.new_pending_txn_tasks.write().remove(&msg.0) {
             h.abort();
         }
@@ -430,7 +443,7 @@ impl ServiceHandler<Self, Unsubscribe> for PubSubService {
 fn send_to_all<T: Clone>(
     subscriptions: &mut HashMap<SubscriptionId, mpsc::UnboundedSender<T>>,
     msg: T,
-) {
+) -> usize {
     let mut remove_outdated = vec![];
 
     for (id, ch) in subscriptions.iter() {
@@ -446,10 +459,13 @@ fn send_to_all<T: Clone>(
         }
     }
 
+    let removed = remove_outdated.len();
     // drop outdated subscribers.
     for id in remove_outdated {
         subscriptions.remove(&id);
     }
+
+    removed
 }
 
 async fn run_subscription<M, Handler>(
@@ -457,6 +473,7 @@ async fn run_subscription<M, Handler>(
     subscriber_id: SubscriptionId,
     subscriber: Subscriber<pubsub::Result>,
     event_handler: Handler,
+    cleanup_service: Option<ServiceRef<PubSubService>>,
 ) where
     M: Send + 'static,
     Handler: EventHandler<M> + Send + 'static,
@@ -473,6 +490,9 @@ async fn run_subscription<M, Handler>(
         if let Err(e) = forward {
             log::warn!(target: "rpc", "Unable to send notification: {}", e);
         }
+    }
+    if let Some(service) = cleanup_service {
+        service.do_send(Unsubscribe(subscriber_id));
     }
 }
 

--- a/rpc/server/src/module/pubsub/tests.rs
+++ b/rpc/server/src/module/pubsub/tests.rs
@@ -8,21 +8,29 @@ use jsonrpc_core::{futures, MetaIoHandler};
 use jsonrpc_pubsub::Session;
 use serde_json::Value;
 use starcoin_account_api::AccountInfo;
+use starcoin_account_service::AccountService;
 use starcoin_chain::BlockChain;
 use starcoin_chain::{ChainReader, ChainWriter};
 use starcoin_chain_notify::ChainNotifyHandlerService;
+use starcoin_config::NodeConfig;
 use starcoin_consensus::Consensus;
 use starcoin_crypto::{ed25519::Ed25519PrivateKey, Genesis, HashValue, PrivateKey};
+use starcoin_genesis::Genesis as ChainGenesis;
 use starcoin_logger::prelude::*;
+use starcoin_miner::{
+    BlockBuilderService, BlockHeaderExtra, MinerService, SubmitSealRequest,
+    UpdateSubscriberNumRequest,
+};
 use starcoin_rpc_api::metadata::Metadata;
 use starcoin_rpc_api::pubsub::StarcoinPubSub;
 use starcoin_service_registry::bus::{Bus, BusService};
-use starcoin_service_registry::RegistryAsyncService;
+use starcoin_service_registry::{RegistryAsyncService, RegistryService, ServiceRef};
 use starcoin_state_api::StateReaderExt;
 use starcoin_storage::BlockStore;
+use starcoin_txpool::TxPoolService;
 use starcoin_txpool_api::TxPoolSyncService;
-use starcoin_types::system_events::MintBlockEvent;
 use starcoin_types::system_events::NewHeadBlock;
+use starcoin_types::system_events::{GenerateBlockEvent, MintBlockEvent};
 use starcoin_types::{account_address, U256};
 use starcoin_vm_types::genesis_config::ConsensusStrategy;
 use std::sync::Arc;
@@ -128,6 +136,58 @@ pub async fn test_subscribe_to_events() -> Result<()> {
         }
     }
     Ok(())
+}
+
+async fn start_pubsub_registry_with_disabled_miner_client() -> Result<(
+    Arc<NodeConfig>,
+    ServiceRef<RegistryService>,
+    ServiceRef<BusService>,
+    ServiceRef<MinerService>,
+    ServiceRef<PubSubService>,
+)> {
+    let mut config = NodeConfig::random_for_test();
+    config.miner.disable_miner_client = Some(true);
+    config.miner.disable_mint_empty_block = Some(false);
+    let node_config = Arc::new(config);
+
+    let (storage, _chain_info, genesis) = ChainGenesis::init_storage_for_test(node_config.net())?;
+    let chain_header = storage
+        .get_block_header_by_hash(genesis.block().id())?
+        .unwrap();
+    let txpool = TxPoolService::new(node_config.clone(), storage.clone(), chain_header, None);
+
+    let registry = RegistryService::launch();
+    registry.put_shared(node_config.clone()).await?;
+    registry.put_shared(storage.clone()).await?;
+    let bus = registry.service_ref::<BusService>().await?;
+    registry.put_shared(bus.clone()).await?;
+    registry.put_shared(txpool).await?;
+    registry
+        .register_mocker(AccountService::mock().unwrap())
+        .await?;
+    registry.register::<BlockBuilderService>().await?;
+    let miner = registry.register::<MinerService>().await?;
+    let pubsub = registry
+        .register_by_factory::<PubSubService, PubSubServiceFactory>()
+        .await?;
+    Ok((node_config, registry, bus, miner, pubsub))
+}
+
+async fn wait_for_mint_job(miner: &ServiceRef<MinerService>) -> MintBlockEvent {
+    timeout(Duration::from_secs(2), async {
+        loop {
+            if let Some(event) = miner
+                .send(UpdateSubscriberNumRequest { number: None })
+                .await
+                .unwrap()
+            {
+                break event;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("mint job should become available")
 }
 
 #[stest::test]
@@ -238,5 +298,67 @@ pub async fn test_subscribe_to_mint_block() -> Result<()> {
     let response = r#"{"jsonrpc":"2.0","result":true,"id":1}"#;
     let resp = io.handle_request(request, metadata).await;
     assert_eq!(resp, Some(response.to_owned()));
+    Ok(())
+}
+
+#[stest::test]
+pub async fn test_mint_block_disconnect_resets_subscriber_count() -> Result<()> {
+    let (config, registry, bus, miner, service) =
+        start_pubsub_registry_with_disabled_miner_client().await?;
+    let pubsub = PubSubImpl::new(service).to_delegate();
+
+    let mut io = MetaIoHandler::default();
+    io.extend_with(pubsub);
+
+    let mut metadata = Metadata::default();
+    let (sender, receiver) = futures::channel::mpsc::unbounded();
+    metadata.session = Some(Arc::new(Session::new(sender)));
+
+    let request = r#"{"jsonrpc": "2.0", "method": "starcoin_subscribe", "params": [{"type_name":"newMintBlock"}], "id": 1}"#;
+    let response = r#"{"jsonrpc":"2.0","result":0,"id":1}"#;
+    let resp = io.handle_request(request, metadata).await;
+    assert_eq!(resp, Some(response.to_owned()));
+
+    let current_job = wait_for_mint_job(&miner).await;
+
+    drop(receiver);
+    bus.broadcast(MintBlockEvent::new(
+        HashValue::random(),
+        ConsensusStrategy::Dummy,
+        vec![0u8; 76],
+        U256::from(1024),
+        0,
+        None,
+    ))?;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let nonce = config
+        .net()
+        .genesis_config()
+        .consensus()
+        .solve_consensus_nonce(
+            &current_job.minting_blob,
+            current_job.difficulty,
+            config.net().time_service().as_ref(),
+        );
+    miner.try_send(SubmitSealRequest::new(
+        current_job.minting_blob,
+        nonce,
+        BlockHeaderExtra::new([0u8; 4]),
+    ))?;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    miner.notify(GenerateBlockEvent::default())?;
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let next_job = miner
+        .send(UpdateSubscriberNumRequest { number: None })
+        .await?;
+    assert!(
+        next_job.is_none(),
+        "disconnected mint subscribers should not keep miner service active"
+    );
+
+    registry.shutdown_system().await?;
     Ok(())
 }


### PR DESCRIPTION
## Summary

This fixes a miner-path stall where `GenerateBlockEvent` could pile up behind a blocking block-template request and leave `mining.get_job` unresponsive.

Changes:
- move block template building off the `MinerService` actor thread
- coalesce refresh events so only one template build can be in flight at a time
- trigger the first mint job build when the first miner subscriber connects
- clean up disconnected mint subscribers and sync the real subscriber count back to `MinerService`
- keep slow-but-valid block template builds usable instead of timing them out prematurely

## Tests

- `cargo test -p starcoin-miner --quiet`
- `cargo test -p starcoin-rpc-server pubsub --quiet`
- `cargo clippy -p starcoin-miner -p starcoin-rpc-server --all-targets -- -D warnings`
