### PR TITLE
Combine rand 0.10.1 + hashbrown 0.17.0 updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
  "cfg-if 1.0.4",
  "cipher 0.3.0",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug 0.3.1",
 ]
 
@@ -161,7 +161,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if 1.0.4",
  "cipher 0.4.4",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1667,7 +1667,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if 1.0.4",
  "cipher 0.4.4",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -1677,7 +1688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead 0.5.2",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher 0.4.4",
  "poly1305",
  "zeroize",
@@ -2221,6 +2232,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cpuid-bool"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2663,7 +2683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if 1.0.4",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto 0.2.9",
@@ -3987,8 +4007,8 @@ dependencies = [
  "parking_lot 0.12.5",
  "proptest",
  "proptest-derive 0.8.0",
+ "rand 0.10.1",
  "rand 0.7.3",
- "rand 0.9.2",
  "rand_core 0.6.4",
  "serde 1.0.228",
  "serde_bytes",
@@ -4300,6 +4320,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -5607,7 +5628,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -6327,7 +6348,7 @@ dependencies = [
  "log-mdc",
  "mock_instant",
  "parking_lot 0.12.5",
- "rand 0.9.2",
+ "rand 0.9.3",
  "serde 1.0.228",
  "serde-value",
  "serde_json",
@@ -8322,7 +8343,7 @@ dependencies = [
  "network-p2p-types",
  "network-types",
  "parking_lot 0.12.5",
- "rand 0.9.2",
+ "rand 0.10.1",
  "schemars",
  "serde 1.0.228",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
@@ -8359,7 +8380,7 @@ dependencies = [
  "parking_lot 0.12.5",
  "pin-project 0.4.30",
  "prometheus",
- "rand 0.9.2",
+ "rand 0.10.1",
  "sc-peerset",
  "serde 1.0.228",
  "serde_json",
@@ -8414,7 +8435,7 @@ dependencies = [
  "bytes 1.11.1",
  "derive_more 0.99.20",
  "libp2p",
- "rand 0.9.2",
+ "rand 0.10.1",
  "sc-peerset",
  "schemars",
  "serde 1.0.228",
@@ -9534,7 +9555,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug 0.3.1",
  "universal-hash 0.5.1",
 ]
@@ -9557,7 +9578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
  "cfg-if 1.0.4",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug 0.3.1",
  "universal-hash 0.4.1",
 ]
@@ -9569,7 +9590,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if 1.0.4",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug 0.3.1",
  "universal-hash 0.5.1",
 ]
@@ -9863,7 +9884,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.11.0",
  "num-traits 0.2.19",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha 0.9.0",
  "rand_xorshift 0.4.0",
  "regex-syntax",
@@ -10199,12 +10220,23 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -11203,7 +11235,7 @@ dependencies = [
  "futures 0.3.32",
  "libp2p",
  "log 0.4.29",
- "rand 0.9.2",
+ "rand 0.10.1",
  "serde_json",
  "sp-utils",
  "wasm-timer",
@@ -11252,7 +11284,7 @@ dependencies = [
  "ctrlc",
  "jpst",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rust-flatten-json",
  "rustyline",
  "rustyline-derive",
@@ -11641,7 +11673,7 @@ checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.4",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug 0.3.1",
 ]
@@ -11662,7 +11694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if 1.0.4",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -11680,7 +11712,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.4",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug 0.3.1",
 ]
@@ -11692,7 +11724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if 1.0.4",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -12122,8 +12154,8 @@ dependencies = [
  "futures 0.3.32",
  "hex",
  "parking_lot 0.12.5",
+ "rand 0.10.1",
  "rand 0.8.5",
- "rand 0.9.2",
  "rand_core 0.6.4",
  "serde 1.0.228",
  "serde_json",
@@ -12145,7 +12177,7 @@ dependencies = [
  "bcs-ext",
  "futures 0.3.32",
  "hex",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rand_core 0.6.4",
  "schemars",
  "serde 1.0.228",
@@ -12207,7 +12239,7 @@ dependencies = [
  "proptest",
  "proptest-derive 0.8.0",
  "quick_cache",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rand_core 0.6.4",
  "schemars",
  "serde 1.0.228",
@@ -12289,7 +12321,7 @@ dependencies = [
  "once_cell",
  "proptest",
  "proptest-derive 0.8.0",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rand_core 0.6.4",
  "serde_json",
  "sp-utils",
@@ -12338,7 +12370,7 @@ dependencies = [
  "bcs-ext",
  "futures 0.3.32",
  "network-api",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rand_core 0.6.4",
  "serde 1.0.228",
  "starcoin-accumulator",
@@ -12408,7 +12440,7 @@ version = "2.1.1"
 dependencies = [
  "anyhow",
  "futures 0.3.32",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rand_core 0.6.4",
  "serde 1.0.228",
  "starcoin-account-api",
@@ -12453,7 +12485,7 @@ dependencies = [
  "network-p2p-types",
  "network-types",
  "num_cpus",
- "rand 0.9.2",
+ "rand 0.10.1",
  "schemars",
  "scmd",
  "serde 1.0.228",
@@ -12529,7 +12561,7 @@ dependencies = [
  "num_enum",
  "once_cell",
  "parking_lot 0.12.5",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rand_core 0.6.4",
  "schemars",
  "serde 1.0.228",
@@ -12568,7 +12600,7 @@ dependencies = [
  "once_cell",
  "proptest",
  "proptest-derive 0.8.0",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rand_core 0.6.4",
  "rust-argon2 3.0.0",
  "serde 1.0.228",
@@ -12663,7 +12695,7 @@ dependencies = [
  "proptest",
  "proptest-derive 0.8.0",
  "quick_cache",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rand_core 0.6.4",
  "rocksdb",
  "rust-argon2 3.0.0",
@@ -12743,7 +12775,7 @@ dependencies = [
  "byteorder",
  "hmac 0.13.0",
  "pbkdf2",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rand_core 0.6.4",
  "sha2 0.10.9",
 ]
@@ -12852,8 +12884,8 @@ dependencies = [
  "clap 4.6.0",
  "itertools 0.10.5",
  "num_cpus",
+ "rand 0.10.1",
  "rand 0.8.5",
- "rand 0.9.2",
  "rayon",
  "starcoin-accumulator",
  "starcoin-cached-packages",
@@ -12954,7 +12986,7 @@ dependencies = [
  "num-traits 0.2.19",
  "once_cell",
  "quick_cache",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rand_core 0.5.1",
  "ripemd",
  "serde 1.0.228",
@@ -13151,7 +13183,7 @@ dependencies = [
  "once_cell",
  "proptest",
  "proptest-derive 0.8.0",
- "rand 0.9.2",
+ "rand 0.10.1",
  "serde 1.0.228",
  "starcoin-config",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
@@ -13215,7 +13247,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "parking_lot 0.12.5",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rayon",
  "serde 1.0.228",
  "sp-utils",
@@ -13279,7 +13311,7 @@ dependencies = [
  "hex",
  "libloading 0.7.4",
  "parking_lot 0.12.5",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rand_core 0.6.4",
  "rust-argon2 3.0.0",
  "serde 1.0.228",
@@ -13360,7 +13392,7 @@ dependencies = [
  "num",
  "once_cell",
  "pretty 0.12.5",
- "rand 0.9.2",
+ "rand 0.10.1",
  "serde 1.0.228",
  "serde_json",
  "shell-words",
@@ -13444,7 +13476,7 @@ dependencies = [
  "move-vm-runtime 0.1.0 (git+https://github.com/starcoinorg/move?rev=babf994a38cda17b84186c7992f92fb3554347f0)",
  "move-vm-types 0.1.0 (git+https://github.com/starcoinorg/move?rev=babf994a38cda17b84186c7992f92fb3554347f0)",
  "num_enum",
- "rand 0.9.2",
+ "rand 0.10.1",
  "ripemd160",
  "smallvec 1.15.1",
  "starcoin-crypto 1.10.0-rc.2 (git+https://github.com/starcoinorg/starcoin-crypto?rev=bc3ca2138cf66d646f14a0f673ae5d853743f50a)",
@@ -13474,7 +13506,7 @@ dependencies = [
  "parking_lot 0.12.5",
  "prometheus",
  "quick_cache",
- "rand 0.9.2",
+ "rand 0.10.1",
  "sc-peerset",
  "serde 1.0.228",
  "serde_json",
@@ -13683,7 +13715,7 @@ dependencies = [
  "once_cell",
  "proptest",
  "proptest-derive 0.8.0",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rayon",
  "starcoin-aggregator",
  "starcoin-infallible",
@@ -13824,7 +13856,7 @@ dependencies = [
  "futures 0.3.32",
  "jsonrpc-core",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.10.1",
  "serde_json",
  "starcoin-config",
  "starcoin-logger",
@@ -14075,7 +14107,7 @@ dependencies = [
  "proptest",
  "proptest-derive 0.8.0",
  "quick_cache",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rocksdb",
  "serde 1.0.228",
  "starcoin-accumulator",
@@ -14137,7 +14169,7 @@ dependencies = [
  "parking_lot 0.12.5",
  "pin-project 0.4.30",
  "pin-utils",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rayon",
  "serde 1.0.228",
  "sp-utils",
@@ -14305,7 +14337,7 @@ dependencies = [
  "ctrlc",
  "futures 0.3.32",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.10.1",
  "serde 1.0.228",
  "starcoin-account-api",
  "starcoin-config",
@@ -14341,8 +14373,8 @@ dependencies = [
  "parking_lot 0.12.5",
  "proptest",
  "proptest-derive 0.8.0",
+ "rand 0.10.1",
  "rand 0.8.5",
- "rand 0.9.2",
  "rand_core 0.6.4",
  "rayon",
  "serde 1.0.228",
@@ -14430,7 +14462,7 @@ dependencies = [
  "once_cell",
  "proptest",
  "proptest-derive 0.8.0",
- "rand 0.9.2",
+ "rand 0.10.1",
  "schemars",
  "serde 1.0.228",
  "serde_bytes",
@@ -14483,7 +14515,7 @@ dependencies = [
  "num_cpus",
  "num_enum",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rand_core 0.6.4",
  "rayon",
  "serde 1.0.228",
@@ -14519,7 +14551,7 @@ dependencies = [
  "claims",
  "move-core-types 0.0.4 (git+https://github.com/starcoinorg/move?rev=7d37ed75c76f34abd2ea71774dcf784408625887)",
  "move-vm-types 0.1.0 (git+https://github.com/starcoinorg/move?rev=7d37ed75c76f34abd2ea71774dcf784408625887)",
- "rand 0.9.2",
+ "rand 0.10.1",
  "serde 1.0.228",
  "starcoin-aggregator",
  "starcoin-gas-meter",
@@ -14556,7 +14588,7 @@ dependencies = [
  "once_cell",
  "proptest",
  "proptest-derive 0.8.0",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rustc-hash 2.1.2",
  "schemars",
  "serde 1.0.228",
@@ -14588,7 +14620,7 @@ dependencies = [
  "num_enum",
  "proptest",
  "proptest-derive 0.8.0",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rand_core 0.6.4",
  "schemars",
  "serde 1.0.228",
@@ -14618,7 +14650,7 @@ dependencies = [
  "num_cpus",
  "num_enum",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rand_core 0.6.4",
  "rayon",
  "serde 1.0.228",
@@ -14659,7 +14691,7 @@ dependencies = [
  "once_cell",
  "proptest",
  "proptest-derive 0.8.0",
- "rand 0.9.2",
+ "rand 0.10.1",
  "schemars",
  "serde 1.0.228",
  "serde_bytes",
@@ -14749,7 +14781,7 @@ dependencies = [
  "bcs-ext",
  "futures 0.3.32",
  "hex",
- "rand 0.9.2",
+ "rand 0.10.1",
  "rand_core 0.6.4",
  "schemars",
  "serde 1.0.228",
@@ -15604,7 +15636,7 @@ dependencies = [
  "network-api",
  "network-p2p-core",
  "network-p2p-types",
- "rand 0.9.2",
+ "rand 0.10.1",
  "serde 1.0.228",
  "serde_json",
  "starcoin-account-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4583,6 +4583,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -14573,7 +14579,7 @@ dependencies = [
  "bytes 1.11.1",
  "chrono",
  "forkable-jellyfish-merkle",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "hex",
  "log 0.4.29",
  "move-binary-format 0.0.3 (git+https://github.com/starcoinorg/move?rev=7d37ed75c76f34abd2ea71774dcf784408625887)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -340,7 +340,7 @@ rustc-hash = "2.1.2"
 git-version = "0.3.9"
 goldenfile = "1.8.0"
 governor = { version = "0.4.2", features = ["dashmap"] }
-hashbrown = "0.16.1"
+hashbrown = "0.17.0"
 heck = "0.5.0"
 hex = "0.4"
 hmac = "0.13.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -470,7 +470,7 @@ proptest-derive = "0.8.0"
 quote = "1.0.16"
 rand_0_7_3 = { package = "rand", version = "0.7.3" }
 rand_0_8 = { package = "rand", version = "0.8.5" }
-rand = "0.9.2"
+rand = "0.10.1"
 rand_core = { version = "0.6.3", default-features = false }
 rayon = "1.6.1"
 regex = "1.6.0"

--- a/vm/types/src/access_path.rs
+++ b/vm/types/src/access_path.rs
@@ -52,6 +52,7 @@ use proptest_derive::Arbitrary;
 use rand::distr::Distribution;
 use rand::seq::IndexedRandom;
 use rand::Rng;
+use rand::RngExt;
 use schemars::{self, JsonSchema};
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/vm/types/src/event.rs
+++ b/vm/types/src/event.rs
@@ -9,7 +9,7 @@ use anyhow::{ensure, Error, Result};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 #[cfg(any(test, feature = "fuzzing"))]
-use rand::Rng;
+use rand::RngExt;
 use schemars::{self, JsonSchema};
 use serde::{de, ser, Deserialize, Serialize};
 use std::str::FromStr;

--- a/vm/types/src/transaction/authenticator.rs
+++ b/vm/types/src/transaction/authenticator.rs
@@ -6,7 +6,7 @@ use crate::sign_message::SigningMessage;
 use anyhow::{ensure, Error, Result};
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
-use rand::Rng;
+use rand::RngExt;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use starcoin_crypto::ed25519::{


### PR DESCRIPTION
Combines #4844 and #4845 into a single dependency update.

Fixes rand 0.10 API usage errors found in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace dependencies to newer versions for improved compatibility and performance.
  * Adjusted internal code alignments with updated dependency APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->