### PR TITLE
Fix DAG selected parent block generation regression

### DIFF
--- a/.github/workflows/tps_benchmark.yml
+++ b/.github/workflows/tps_benchmark.yml
@@ -68,7 +68,7 @@ jobs:
     name: TPS Benchmark
     needs: choose-runner
     runs-on: ${{ fromJSON(needs.choose-runner.outputs.runs_on_json) }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       # ── 1. Checkout current branch ──
       - name: Checkout current branch

--- a/sync/src/block_connector/test_write_dag_block_chain.rs
+++ b/sync/src/block_connector/test_write_dag_block_chain.rs
@@ -49,31 +49,38 @@ pub fn new_dag_block(
     };
     let miner_address = *miner.address();
 
-    let block_chain = writeable_block_chain_service.get_main();
-    let tips = if block_chain.status().head().pruning_point() == HashValue::zero() {
-        let genesis_id = block_chain
+    let base_chain = writeable_block_chain_service.get_main();
+    let tips = if base_chain.status().head().pruning_point() == HashValue::zero() {
+        let genesis_id = base_chain
             .get_storage()
             .get_genesis()?
             .ok_or_else(|| format_err!("Genesis block is none"))?;
-        block_chain
+        base_chain
             .current_tips_hash(genesis_id)
             .expect("failed to get tips")
     } else {
-        block_chain
-            .current_tips_hash(block_chain.status().head().pruning_point())
+        base_chain
+            .current_tips_hash(base_chain.status().head().pruning_point())
             .expect("failed to get tips")
     };
-    let (block_template, _) = block_chain
-        .create_block_template(
-            miner_address,
-            None, // No specific parent header
-            Vec::new(),
-            None,       // uncles
-            None,       // block_gas_limit
-            Some(tips), // tips
-            HashValue::zero(),
-        )
-        .unwrap();
+    let ghostdata = base_chain.dag().ghostdata(&tips)?;
+    let block_chain = BlockChain::new(
+        net.time_service(),
+        ghostdata.selected_parent,
+        base_chain.get_storage(),
+        writeable_block_chain_service.get_storage2(),
+        None,
+        writeable_block_chain_service.get_dag(),
+    )?;
+    let (block_template, _) = block_chain.create_block_template(
+        miner_address,
+        None, // No specific parent header
+        Vec::new(),
+        None,       // uncles
+        None,       // block_gas_limit
+        Some(tips), // tips
+        HashValue::zero(),
+    )?;
     block_chain
         .consensus()
         .create_block(block_template, net.time_service().as_ref())


### PR DESCRIPTION
## Summary

- Build DAG test block templates from the ghostdata selected parent instead of the current main-chain head.
- Add deterministic regression coverage for the equal-difficulty fork case where the DAG selected parent differs from the current header.

## Root Cause

In an equal-difficulty fork, the current main-chain head can remain unchanged while ghostdata selects the fork tip as the block parent. Creating a template from the stale main-chain state can produce a block whose header parent and execution state roots disagree.

## Validation

- `cargo fmt --check`
- `git diff --check -- sync/src/block_connector/test_write_dag_block_chain.rs`
- `cargo nextest run -p starcoin-sync block_connector::test_write_dag_block_chain::test_dag_block_generation_uses_selected_parent_when_main_head_differs block_connector::test_write_dag_block_chain::test_equal_difficulty_branch_still_produce_block`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved DAG test utilities for deterministic block-template→block generation: explicitly resolve DAG parents, handle genesis/pruning scenarios, verify selected-parent behavior, and validate fork outcomes.
* **Chores**
  * Increased benchmark CI job timeout from 30 to 60 minutes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->